### PR TITLE
Change .env.development STRAPI_URL, docs update

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Each sub-project contains README which should get you up and running. More docum
 
 🗄️ `/strapi` Strapi CMS server for bratislava.sk
 
-📝 `/docs` (some) documentation files (in the process of being migrated to a separate docs site)
+📝 `/docs` contain the mapping between React and Strapi components - to be replaced by a styleguide in the future
 
 ---
 

--- a/next/.env.development
+++ b/next/.env.development
@@ -1,6 +1,6 @@
 # If you want to override you need to do it .env.development.local
 
-STRAPI_URL=http://localhost:1337
+STRAPI_URL=https://bratislava-strapi.bratislava.sk
 GINIS_URL=http://172.25.1.197/gordic/ginis/ws/Ude01/Ude.svc
 
 GINIS_USERNAME=<contact-PM-if-needed>

--- a/next/README.md
+++ b/next/README.md
@@ -12,7 +12,7 @@ To install dependencies run:
 yarn
 ```
 
-For CMS setup see `strapi` directory. You can also run the project against production strapi (TODO).
+For CMS setup see `strapi` directory. You can also run the project against production strapi - this is the default setup. If you want to run against local strapi, you need to set `NEXT_PUBLIC_STRAPI_URL` in `.env.development.local` file.
 
 ## Typescript Strict Mode
 

--- a/strapi/README.md
+++ b/strapi/README.md
@@ -13,9 +13,15 @@ cp .env.example .env.local
 
 You need postgres running locally (with correct credentials & databse available). The default setup is below, you can override any of the variables by passing them in you `.env.local` file. The easiest way to get a postgres db with the right credentials up&running is via `docker-compose.yml` file in the root fo this repo (check the root README).
 
+### Starting from empty database
+
+While not recommended in this project, if you want to start from a clean slate, read (TODO - writing in progress on the doc site).
+
 ### Seeding the database
 
 It's recommended that you don't start from an empty database, but instead seed with staging or production data. Ask in the internal Bratislava team or [follow the docs](https://bratislava.github.io/docs/recipes/load-strapi-db-in-local-dev). If you are an open-source contributor, note you do not need this setup for many of frontend-related changes. See the next.js project README.
+
+We may provide a db dump as part of the project in the future - for now please contact the BA Innovations Team if you need it.
 
 ### Meilisearch
 


### PR DESCRIPTION
Changes based on recent onboarding - should be better default. Will update the Strapi README again once newer version of docs site is published (may take another week).