### PR TITLE
BA-488: Create unused logic for intersection check

### DIFF
--- a/next/components/ui/VisibilityIntersection/VisibilityIntersectionWrapper.tsx
+++ b/next/components/ui/VisibilityIntersection/VisibilityIntersectionWrapper.tsx
@@ -1,0 +1,20 @@
+import { FC, ReactNode } from 'react'
+
+import { useIntersectionObserver } from './useIntersectionObserver'
+
+interface Props {
+  children: ReactNode
+
+  onHandleVisibility(): void
+}
+
+export const VisibilityIntersectionWrapper: FC<Props> = ({ children, onHandleVisibility }) => {
+  const { elementRef } = useIntersectionObserver({ threshold: 0.9 }, onHandleVisibility)
+
+  return (
+    <div>
+      <div ref={elementRef} />
+      {children}
+    </div>
+  )
+}

--- a/next/components/ui/VisibilityIntersection/useIntersectionObserver.ts
+++ b/next/components/ui/VisibilityIntersection/useIntersectionObserver.ts
@@ -1,0 +1,33 @@
+import { MutableRefObject, useEffect, useRef } from 'react'
+
+interface HookResult {
+  elementRef: MutableRefObject<HTMLDivElement | null>
+}
+
+export const useIntersectionObserver = (
+  observerOptions: IntersectionObserverInit,
+  onHandleIntersection: () => void,
+): HookResult => {
+  const elementRef = useRef<HTMLDivElement | null>(null)
+
+  const handleIntersection = (entries: IntersectionObserverEntry[]): void => {
+    if (entries[0].isIntersecting) {
+      onHandleIntersection()
+    }
+  }
+
+  const { disconnect, observe } = new IntersectionObserver(handleIntersection, observerOptions)
+
+  useEffect(() => {
+    if (!elementRef.current) {
+      return
+    }
+    observe(elementRef.current)
+  })
+
+  useEffect(() => disconnect)
+
+  return {
+    elementRef,
+  }
+}


### PR DESCRIPTION
This is a new component + hook w/ logic using `IntersectionObserver` API to make it easier when to show sticky navigation menu and when regular navigation.
It is unused currently, as this is a first of other PRs to refactor entire logic for showing navigation menu.