### PR TITLE
Meilisearch bugfix

### DIFF
--- a/strapi/kubernetes/base/stateful-set-meilisearch.yml
+++ b/strapi/kubernetes/base/stateful-set-meilisearch.yml
@@ -11,6 +11,7 @@ spec:
       app: meilisearch
   replicas: 1
   serviceName: ${BUILD_REPOSITORY_NAME}-meilisearch
+  minReadySeconds: 60
   template:
     metadata:
       labels:


### PR DESCRIPTION
This PR adds more time for meilisearch to initialize and properly start. Therefore strapi isnot contacting meilisearch when not ready.