### PR TITLE
Fix: Make cards on homepage clickable properly

### DIFF
--- a/next/components/ui/BANavBar/BANavBar.tsx
+++ b/next/components/ui/BANavBar/BANavBar.tsx
@@ -67,7 +67,7 @@ export const BANavBar = ({
             className="group"
             url="/"
             title={
-              <p className="text-font text-p2 group-hover:text-gray-600">
+              <p className="text-p2 text-font group-hover:text-gray-600">
                 {languageKey === 'en' && <span className="font-semibold">Bratislava </span>}
                 {t('capitalCity')}
                 {languageKey !== 'en' && <span className="font-semibold"> Bratislava</span>}
@@ -343,7 +343,7 @@ const LanguageSelect = ({
           <div className="flex h-auto min-h-[60px] w-full flex-col items-center rounded-lg bg-[#F8D7D4] pt-1 pb-3 shadow-[0_8px_24px_rgba(0,0,0,0.16)]">
             {dropDownOptions?.map((option) => (
               <div
-                className="text-p3 hover:text-p3-semibold text-font mt-3 h-6 w-6"
+                className="text-p3 hover:text-p3-semibold cursor-pointer text-font mt-3 h-6 w-6"
                 key={option.key}
                 onClick={handleChange}
               >

--- a/next/components/ui/BlogSearchCard/BlogSearchCard.tsx
+++ b/next/components/ui/BlogSearchCard/BlogSearchCard.tsx
@@ -61,7 +61,12 @@ export interface BlogSearchCardProps {
   item: BlogItem
 }
 
-export const BlogSearchCard = ({ className, imageClassName, fullCardSizeImage, item }: BlogSearchCardProps) => {
+export const BlogSearchCard = ({
+  className,
+  imageClassName,
+  fullCardSizeImage,
+  item,
+}: BlogSearchCardProps) => {
   const { Link: UILink } = useUIContext()
 
   const { slug, tag, coverImage, title } = item.attributes
@@ -78,7 +83,7 @@ export const BlogSearchCard = ({ className, imageClassName, fullCardSizeImage, i
           className,
           'w-full',
           { 'hidden lg:flex lg:flex-row': !fullCardSizeImage },
-          { hidden: fullCardSizeImage }
+          { hidden: fullCardSizeImage },
         )}
         hoverable
       >
@@ -100,12 +105,17 @@ export const BlogSearchCard = ({ className, imageClassName, fullCardSizeImage, i
           >
             {headline}
           </div>
-          <div className="line-clamp-2 text-20-semibold overflow-hidden text-ellipsis">{title} </div>
+          <div className="text-20-semibold line-clamp-2">{title} </div>
           <div>{date}</div>
         </div>
       </Panel>
       <Panel
-        className={cx('group', className, { 'flex lg:hidden': !fullCardSizeImage }, { flex: fullCardSizeImage })}
+        className={cx(
+          'group',
+          className,
+          { 'flex lg:hidden': !fullCardSizeImage },
+          { flex: fullCardSizeImage },
+        )}
         hoverable
       >
         <UILink href={`/blog/${slug}`}>
@@ -126,8 +136,11 @@ export const BlogSearchCard = ({ className, imageClassName, fullCardSizeImage, i
                 {headline}
               </div>
               <div className="flex">
-                <div className="line-clamp-2 text-20-semibold overflow-hidden text-white">{title}</div>
-                <VerticalCardButton className="invisible shrink-0 group-hover:lg:visible" size="medium">
+                <div className="text-20-semibold line-clamp-2 text-white">{title}</div>
+                <VerticalCardButton
+                  className="invisible shrink-0 group-hover:lg:visible"
+                  size="medium"
+                >
                   <ArrowRightShort className="scale-125" />
                 </VerticalCardButton>
               </div>

--- a/next/components/ui/DocumentCard/DocumentCard.tsx
+++ b/next/components/ui/DocumentCard/DocumentCard.tsx
@@ -1,8 +1,8 @@
 // @ts-strict-ignore
 import ArrowRight from '@assets/images/arrow-right.svg'
 import ChevronRight from '@assets/images/chevron-right-small.svg'
-import { useState } from 'react'
 import { getDocumentDetailURL, getDocumentFileURL } from 'backend/services/ginis'
+import { useState } from 'react'
 import useSWR from 'swr'
 
 import { Button } from '../Button/Button'
@@ -20,12 +20,19 @@ export interface DocumentCardProps {
   downloadButtonText: string
 }
 
-export const DocumentCard = ({ title, createdAt, id, content, className, viewButtonText }: DocumentCardProps) => {
+export const DocumentCard = ({
+  title,
+  createdAt,
+  id,
+  content,
+  className,
+  viewButtonText,
+}: DocumentCardProps) => {
   const [isOpen, setIsOpen] = useState(false)
 
   // if you need to develop this and can't connect to bratislava VPN, check out services/ginis.ts for mocks
   const { data } = useSWR(isOpen ? getDocumentDetailURL(id) : null, () =>
-    fetch(getDocumentDetailURL(id)).then((res) => res.json())
+    fetch(getDocumentDetailURL(id)).then((res) => res.json()),
   )
 
   const files: TFile[] =
@@ -52,8 +59,9 @@ export const DocumentCard = ({ title, createdAt, id, content, className, viewBut
       <Panel className={className}>
         <div className="flex w-full flex-col gap-y-5 px-5 py-6 lg:px-10 lg:py-8">
           <div className="text-20-semibold -mb-3">{title}</div>
-          <div className="flex flex-col gap-x-6 text-p3 text-font/75 lg:flex-row">
-            <div>{new Date(createdAt).toLocaleDateString()}</div>
+          <div className="text-p3 text-font/75 flex flex-col gap-x-6 lg:flex-row">
+            {/* TODO: Fix local date */}
+            <div>{new Date(createdAt).toLocaleDateString('sk')}</div>
 
             {/* <div>{`${fileExtension}; ${fileSize}`}</div> */}
           </div>

--- a/next/components/ui/DocumentListItem/DocumentListItem.tsx
+++ b/next/components/ui/DocumentListItem/DocumentListItem.tsx
@@ -32,9 +32,7 @@ export const DocumentListItem = ({
         </div>
         <div className="flex flex-[4] flex-col justify-start px-4 py-3 lg:px-8 lg:py-10 lg:pl-0">
           <div className="text-p3 lg:text-p2">{categoryName}</div>
-          <div className="text-truncate-2 text-p2-semibold lg:text-p1-semibold line-clamp-2">
-            {title}
-          </div>
+          <div className="text-p2-semibold lg:text-p1-semibold line-clamp-2">{title}</div>
           {moreDocuments.length > 0 ? (
             <div className="text-p1 lg:text-p2 pt-4">
               {t('documents')}:{' '}

--- a/next/components/ui/HorizontalCard/HorizontalCard.tsx
+++ b/next/components/ui/HorizontalCard/HorizontalCard.tsx
@@ -7,7 +7,13 @@ export interface HorizontalCardProps extends React.HTMLAttributes<HTMLDivElement
   imageSrc?: string
 }
 
-export const HorizontalCard = ({ accessory, className, children, imageSrc, ...rest }: HorizontalCardProps) => (
+export const HorizontalCard = ({
+  accessory,
+  className,
+  children,
+  imageSrc,
+  ...rest
+}: HorizontalCardProps) => (
   <div className={cx(className, 'relative')} {...rest}>
     <Panel className="flex h-full w-full flex-col lg:flex-row" hoverable>
       {imageSrc && (
@@ -27,12 +33,14 @@ export const HorizontalCard = ({ accessory, className, children, imageSrc, ...re
           />
         </>
       )}
-      <div className="flex-1 p-6 text-center lg:self-center lg:px-12 lg:py-8 lg:text-left text-p1">
+      <div className="text-p1 flex-1 p-6 text-center lg:self-center lg:px-12 lg:py-8 lg:text-left">
         {children}
       </div>
     </Panel>
     {accessory && (
-      <div className={cx('absolute bottom-0 left-1/2 transform translate-y-1/2 -translate-x-1/2')}>{accessory}</div>
+      <div className={cx('absolute bottom-0 left-1/2 transform translate-y-1/2 -translate-x-1/2')}>
+        {accessory}
+      </div>
     )}
   </div>
 )

--- a/next/components/ui/InBaCard/InBaCard.tsx
+++ b/next/components/ui/InBaCard/InBaCard.tsx
@@ -30,17 +30,19 @@ export const InBaCard = ({ className, images, title, content, link }: InBaCardPr
         {
           'pt-24 md:pt-0': !!frontImage,
         },
-        className
+        className,
       )}
     >
       {rearImage && (
         <Panel
           className={cx(
             'absolute w-24 top-0 transform rotate-12 translate-x-1/2 translate-y-[-57%]',
-            'md:w-40 md:top-auto md:right-0 md:translate-x-[15%] md:translate-y-0'
+            'md:w-40 md:top-auto md:right-0 md:translate-x-[15%] md:translate-y-0',
           )}
         >
-          <img src={rearImage} alt="inba" width="160" height="244" />
+          <UILink href={link}>
+            <img src={rearImage} alt="inba" width="160" height="244" />
+          </UILink>{' '}
         </Panel>
       )}
 
@@ -48,22 +50,27 @@ export const InBaCard = ({ className, images, title, content, link }: InBaCardPr
         <Panel
           className={cx(
             'absolute w-32 top-0 transform rotate-[-9deg] translate-x-[-30%] translate-y-[-57%]',
-            'md:w-52 md:top-auto md:right-0 md:translate-x-[-45%] md:translate-y-0'
+            'md:w-52 md:top-auto md:right-0 md:translate-x-[-45%] md:translate-y-0',
           )}
         >
-          <img src={frontImage} alt="inba" width="211" height="329" />
+          <UILink href={link}>
+            <img src={frontImage} alt="inba" width="211" height="329" />
+          </UILink>
         </Panel>
       )}
 
       <div
         className={cx(
           'flex flex-col items-center text-center gap-4 px-6 pt-3 pb-8',
-          'md:items-start md:text-left md:pr-96 md:pl-12 md:py-8'
+          'md:items-start md:text-left md:pr-96 md:pl-12 md:py-8',
         )}
       >
-        <h1 className="text-h4">{title}</h1>
+        <h2 className="text-h4">{title}</h2>
         <span className="text-p2">{content}</span>
-        <UILink className="group flex h-6 cursor-pointer items-center space-x-5 underline" href={link}>
+        <UILink
+          className="group flex h-6 cursor-pointer items-center space-x-5 hover:text-main-600 underline after:absolute after:inset-0"
+          href={link}
+        >
           <span className="text-p2-semibold">{t('readMore')}</span>
           <span className="group-hover:hidden">
             <ChevronRight />

--- a/next/components/ui/NewsCard/NewsCard.tsx
+++ b/next/components/ui/NewsCard/NewsCard.tsx
@@ -1,13 +1,13 @@
 // @ts-strict-ignore
 import { useUIContext } from '@bratislava/common-frontend-ui-context'
+import { Enum_Pagecategory_Color } from '@bratislava/strapi-sdk-homepage'
+import { getHoverColor } from '@bratislava/ui-bratislava/Sections/Posts/Posts'
 import { getNumericLocalDate } from '@utils/local-date'
 import { transformColorToCategory } from '@utils/page'
 import cx from 'classnames'
-import { RefObject, useEffect, useRef, useState } from 'react'
 
 import { ArrowRight, ChevronRight } from '../../../assets/images'
 import BratislavaPlaceholder from '../../../public/bratislava-placeholder.jpg'
-import { Button } from '../Button/Button'
 import { Tag } from '../Tag/Tag'
 import { VerticalCard } from '../VerticalCard/VerticalCard'
 
@@ -61,83 +61,50 @@ export const NewsCard = ({
   slug,
 }: NewsCardProps) => {
   const { Link: UILink } = useUIContext()
-  const [isHover, setHover] = useState(false)
-  const cardRef: RefObject<HTMLInputElement> = useRef()
-  const enterListner = () => setHover(true)
-  const exitListner = () => setHover(false)
-
-  useEffect(() => {
-    if (cardRef?.current) {
-      cardRef?.current.addEventListener('mouseenter', enterListner)
-      cardRef?.current.addEventListener('mouseleave', exitListner)
-    }
-    return () => {
-      cardRef?.current?.removeEventListener('mouseenter', enterListner)
-      cardRef?.current?.removeEventListener('mouseleave', exitListner)
-    }
-  }, [])
-
-  // TODO inject these from outside instead of useTranslation - react-i18n break the next app build
-  // const { t } = useTranslation('common');
-
-  useEffect(() => {
-    if (cardRef?.current) {
-      cardRef?.current.addEventListener('mouseenter', enterListner)
-      cardRef?.current.addEventListener('mouseleave', exitListner)
-    }
-    return () => {
-      cardRef?.current?.removeEventListener('mouseenter', enterListner)
-      cardRef?.current?.removeEventListener('mouseleave', exitListner)
-    }
-  }, [])
 
   return (
     <VerticalCard
       className={cx(className, 'min-w-66 leading-[1.3]')}
       imageSrc={coverImage?.data?.attributes?.url}
     >
-      <UILink href={`/blog/${slug}`}>
-        <div ref={cardRef} className="space-y-5">
-          {tag?.data?.attributes?.title && (
-            <Tag
-              title={tag?.data?.attributes?.title}
-              color={transformColorToCategory(tag?.data?.attributes?.pageCategory?.data?.attributes?.color)}
-            />
-          )}
-          <h3 className="news-small-content text-h4">{title}</h3>
-          {/* TODO this will rarely matter (only once we start showing previews of unpublished posts to admins), but below we should prefer createdAt before updatedAt */}
-          <span className="text-p4-medium">{getNumericLocalDate(date_added || publishedAt || updatedAt)}</span>
-          <p className="news-small-content text-p2">{excerpt}</p>
-          <div>
-            {slug && (
-              <Button
-                className="mt-5 h-6"
-                shape="none"
-                variant="muted"
-                onMouseEnter={enterListner}
-                onMouseLeave={exitListner}
-                icon={
-                  isHover ? (
-                    <ArrowRight color={`rgb(var(--color-${transformColorToCategory(tag?.data?.attributes?.pageCategory?.data?.attributes?.color)}-600))`} />
-                  ) : (
-                    <ChevronRight color="black" />
-                  )
-                }
-              >
-                <div
-                  className="relative font-semibold"
-                  style={{
-                    color: isHover ? `rgb(var(--color-${transformColorToCategory(tag?.data?.attributes?.pageCategory?.data?.attributes?.color)}-600))` : 'black',
-                  }}
-                >
-                  {readMoreText}
-                  <div className="absolute bottom-0 left-1/2 w-full -translate-x-1/2 border-b-2 border-current" />
-                </div>
-              </Button>
+      <div className="space-y-5">
+        {tag?.data?.attributes?.title && (
+          <Tag
+            title={tag?.data?.attributes?.title}
+            color={transformColorToCategory(
+              tag?.data?.attributes?.pageCategory?.data?.attributes?.color,
             )}
-          </div>
+          />
+        )}
+        <h3 className="text-h4 line-clamp-3">{title}</h3>
+        {/* TODO this will rarely matter (only once we start showing previews of unpublished posts to admins), but below we should prefer createdAt before updatedAt */}
+        <span className="text-p4-medium">
+          {getNumericLocalDate(date_added || publishedAt || updatedAt)}
+        </span>
+        <p className="text-p2 line-clamp-4">{excerpt}</p>
+        <div>
+          {slug && (
+            <UILink
+              className={cx(
+                'group mt-3 flex h-6 cursor-pointer items-center space-x-5 text-gray-700 hover:text-category-600 underline after:absolute after:inset-0',
+                getHoverColor(
+                  tag?.data?.attributes?.pageCategory?.data?.attributes
+                    ?.color as Enum_Pagecategory_Color,
+                ),
+              )}
+              href={`/blog/${slug}`}
+            >
+              <span className="text-p2-semibold">{readMoreText}</span>
+              <span className="group-hover:hidden">
+                <ChevronRight />
+              </span>
+              <span className="hidden group-hover:block">
+                <ArrowRight />
+              </span>
+            </UILink>
+          )}
         </div>
-      </UILink>
+      </div>
     </VerticalCard>
   )
 }

--- a/next/components/ui/PrimatorCard/PrimatorCard.tsx
+++ b/next/components/ui/PrimatorCard/PrimatorCard.tsx
@@ -1,7 +1,6 @@
 import { ArrowRight, ChevronRight } from '@assets/images'
 import { useUIContext } from '@bratislava/common-frontend-ui-context'
 import cx from 'classnames'
-import Link from 'next/dist/client/link'
 import { useTranslation } from 'next-i18next'
 
 import { Panel } from '../Panel/Panel'
@@ -14,51 +13,53 @@ export interface PrimatorCardProps {
   smImageAlign?: 'left' | 'right'
 }
 
-export const PrimatorCard = ({ className, title, imageSrc, href, smImageAlign = 'left' }: PrimatorCardProps) => {
+export const PrimatorCard = ({
+  className,
+  title,
+  imageSrc,
+  href,
+  smImageAlign = 'left',
+}: PrimatorCardProps) => {
   const { Link: UILink } = useUIContext()
   const { t } = useTranslation()
   const smRight = smImageAlign === 'right'
   return (
-    <Link href={href}>
-      <div className={cx('mt-24 lg:mt-28 w-full cursor-pointer',{
-                'mt-12 lg:mt-28': smRight,
-              }, className)}>
-        <Panel
-          className={cx(
-            'flex items-center justify-between lg:justify-start px-6 lg:px-11 h-24 lg:h-32 relative overflow-visible'
-          )}
-        >
-          <div>
-            <img
-              src={imageSrc}
-              alt={title}
-              className={cx('absolute bottom-0 h-40 lg:h-56', {
-                'right-5 lg:right-auto lg:left-11': smRight,
-              })}
-            />
-          </div>
-          <div
-            className={cx('ml-0 lg:ml-56', {
-              'absolute lg:relative left-6 lg:left-0': smRight,
-            })}
+    <div
+      className={cx(
+        'mt-24 lg:mt-28 w-full relative',
+        {
+          'mt-12 lg:mt-28': smRight,
+        },
+        className,
+      )}
+    >
+      <Panel
+        className={cx(
+          'flex items-center justify-between lg:justify-start px-6 lg:px-11 h-24 lg:h-32 relative overflow-visible',
+        )}
+      >
+        <div>
+          <UILink href={href}>
+            <img src={imageSrc} alt={title} className="absolute bottom-0 h-40 lg:h-56" />
+          </UILink>
+        </div>
+        <div className="ml-0 lg:ml-56 flex flex-col items-end lg:items-start">
+          <div className="text-h4-normal">{title}</div>
+          <UILink
+            className="group mt-1.5 flex h-6 items-center space-x-5 text-category-600 underline lg:mt-3 after:absolute after:inset-0"
+            href={href}
           >
-            <span className={cx(' text-h4-normal')}>{title}</span>
-            <UILink
-              className="group mt-1.5 flex h-6 cursor-pointer items-center space-x-5 text-category-600 underline lg:mt-3"
-              href={href}
-            >
-              <span className="text-p2-semibold">{t('readMore')}</span>
-              <span className="group-hover:hidden">
-                <ChevronRight />
-              </span>
-              <span className="hidden group-hover:block">
-                <ArrowRight />
-              </span>
-            </UILink>
-          </div>
-        </Panel>
-      </div>
-    </Link>
+            <span className="text-p2-semibold">{t('readMore')}</span>
+            <span className="group-hover:hidden">
+              <ChevronRight />
+            </span>
+            <span className="hidden group-hover:block">
+              <ArrowRight />
+            </span>
+          </UILink>
+        </div>
+      </Panel>
+    </div>
   )
 }
 

--- a/next/components/ui/Rent/Rent.tsx
+++ b/next/components/ui/Rent/Rent.tsx
@@ -45,7 +45,7 @@ export const Rent = ({ className, icon, title, desc, linkLabel }: RentProps) => 
       <div className="flex w-60 flex-col items-center text-center md:w-auto xl:w-[294px]">
         <h1 className="text-h4-normal mt-5 mb-7 h-16">{title}</h1>
 
-        <div className="news-small-content w-full break-all text-center">
+        <div className="line-clamp-3 w-full break-all text-center">
           <ReactMarkdown skipHtml>{desc}</ReactMarkdown>
         </div>
         {isMore && (

--- a/next/components/ui/Sections/BlogCards/BlogCards.tsx
+++ b/next/components/ui/Sections/BlogCards/BlogCards.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { ArrowRight, ChevronRight } from '@assets/images'
 import { useUIContext } from '@bratislava/common-frontend-ui-context'
 import cx from 'classnames'
@@ -6,7 +5,6 @@ import { useTranslation } from 'next-i18next'
 
 import { Carousel } from '../../Carousel/Carousel'
 import { HorizontalCard } from '../../HorizontalCard/HorizontalCard'
-import { HorizontalScrollWrapper } from '../../HorizontalScrollWrapper/HorizontalScrollWrapper'
 
 export interface BlogCardsProps {
   className?: string
@@ -23,71 +21,37 @@ export interface BlogCardsProps {
 export const BlogCards = ({ className, shiftIndex, posts = [] }: BlogCardsProps) => {
   const { Link: UILink } = useUIContext()
   const { t } = useTranslation()
+
   return (
     <div className={cx(className)}>
-      <div className="hidden lg:block">
+      <div>
         <Carousel
           shiftIndex={shiftIndex}
-          items={
-            posts != null
-              ? posts.map((blogCard, i) => (
-                  <div key={i} className="box-content flex py-16">
-                    <HorizontalCard
-                      className="min-h-[220px] w-[550px]"
-                      key={i}
-                      imageSrc={blogCard.imageSrc}
-                    >
-                      <p className="line-clamp-4 text-p2 lg:text-p1 overflow-hidden text-ellipsis">
-                        {blogCard.title}
-                      </p>
-                      <UILink
-                        className="group mt-3 flex h-6 cursor-pointer items-center space-x-5 text-category-600 underline"
-                        href={`${blogCard?.url}` || ''}
-                      >
-                        <span className="text-p2-semibold">{t('readMore')}</span>
-                        <span className="group-hover:hidden">
-                          <ChevronRight />
-                        </span>
-                        <span className="hidden group-hover:block">
-                          <ArrowRight />
-                        </span>
-                      </UILink>
-                    </HorizontalCard>
-                  </div>
-                ))
-              : []
-          }
+          className="flex"
+          items={posts.map((blogCard, index) => (
+            <HorizontalCard
+              className="min-h-[220px] h-full py-16"
+              key={index}
+              imageSrc={blogCard.imageSrc ?? ''}
+            >
+              <p className="text-p2 lg:text-p1 line-clamp-3 text-left">{blogCard.title}</p>
+              <UILink
+                className="group mt-3 flex h-6 cursor-pointer items-center space-x-5 text-gray-700 hover:text-category-600 underline after:absolute after:inset-0"
+                href={blogCard?.url || ''}
+                target={blogCard?.url?.startsWith('http') ? '_blank' : undefined}
+              >
+                <span className="text-p2-semibold">{t('readMore')}</span>
+                <span className="group-hover:hidden">
+                  <ChevronRight />
+                </span>
+                <span className="hidden group-hover:block">
+                  <ArrowRight />
+                </span>
+              </UILink>
+            </HorizontalCard>
+          ))}
         />
       </div>
-
-      <HorizontalScrollWrapper
-        className={cx(className, 'lg:hidden pt-10 pb-14 lg:pb-5 pl-8 gap-x-4 -mx-8 px-8 mb-0')}
-      >
-        {posts.map((blogCard, i) => (
-          <HorizontalCard
-            key={i}
-            imageSrc={blogCard.imageSrc}
-            className="w-full max-w-xs shrink-0"
-            // accessory={<VerticalCardButton />}
-          >
-            <p className="line-clamp-4 text-p2 lg:text-p1 overflow-hidden text-ellipsis text-left">
-              {blogCard.title}
-            </p>
-            <UILink
-              className="group mt-3 flex h-6 cursor-pointer items-center space-x-5 text-category-600 underline"
-              href={`${blogCard?.url}` || ''}
-            >
-              <span className="text-p2-semibold">{t('readMore')}</span>
-              <span className="group-hover:hidden">
-                <ChevronRight />
-              </span>
-              <span className="hidden group-hover:block">
-                <ArrowRight />
-              </span>
-            </UILink>
-          </HorizontalCard>
-        ))}
-      </HorizontalScrollWrapper>
     </div>
   )
 }

--- a/next/components/ui/Sections/Posts/Posts.tsx
+++ b/next/components/ui/Sections/Posts/Posts.tsx
@@ -50,7 +50,6 @@ export const getHoverColor = (color: Enum_Pagecategory_Color): string => {
       return 'hover:text-education-600'
     case Enum_Pagecategory_Color.Brown:
       return 'hover:text-culture-600'
-
     default:
       return 'hover:text-gray-600'
   }
@@ -126,7 +125,7 @@ export const Posts = ({
                     const card = newsCard.attributes
                     const tag = card.tag.data?.attributes
                     return (
-                      <div key={i}>
+                      <div key={i} className="relative">
                         {tag && (
                           <div className="mb-5">
                             <Tag
@@ -137,11 +136,10 @@ export const Posts = ({
                             />
                           </div>
                         )}
-                        <UILink href={`blog/${card.slug}`}>
+                        <UILink href={`/blog/${card.slug}`}>
                           <div
-                            // TODO hover:text-color (still don't work)
                             className={cx(
-                              `text-font mb-8 font-semibold underline`,
+                              `text-font mb-8 font-semibold underline after:absolute after:inset-0`,
                               getHoverColor(tag?.pageCategory.data.attributes.color),
                             )}
                           >
@@ -228,7 +226,7 @@ export const Posts = ({
                     const card = newsCard.attributes
                     const tag = card.tag.data?.attributes
                     return (
-                      <div key={i}>
+                      <div key={i} className="relative">
                         {card.tag && (
                           <div className="mb-5">
                             <Tag
@@ -239,11 +237,12 @@ export const Posts = ({
                             />
                           </div>
                         )}
-                        <UILink href={`blog/${card.slug}`}>
+                        <UILink href={`/blog/${card.slug}`}>
                           <div
-                            className={`hover:text-${transformColorToCategory(
-                              tag.pageCategory.data.attributes.color,
-                            )} mb-8 font-semibold underline`}
+                            className={cx(
+                              `text-font mb-8 font-semibold underline after:absolute after:inset-0`,
+                              getHoverColor(tag?.pageCategory.data.attributes.color),
+                            )}
                           >
                             {card.title}
                           </div>
@@ -271,21 +270,23 @@ export const Posts = ({
             </div>
           </HorizontalScrollWrapper>
           <div className="flex justify-center lg:hidden">
-            {/* TODO: change this button to custom button */}
-            <Button
-              variant="transparent"
-              className="text-20-medium mt-0 px-6 py-2 shadow-none"
-              icon={<ChevronRight />}
-              hoverIcon={<ArrowRight />}
-            >
-              {t('allNews')}
-            </Button>
+            <UILink href={t('rozkopavkyNews')}>
+              {/* TODO: change this button to custom button */}
+              <Button
+                variant="transparent"
+                className="text-20-medium mt-0 px-6 py-2 shadow-none"
+                icon={<ChevronRight />}
+                hoverIcon={<ArrowRight />}
+              >
+                {t('allNews')}
+              </Button>
+            </UILink>
           </div>
         </div>
       )}
       {activeTab > 2 && (
         <div className="text-h4-normal mt-14 items-end px-8 text-center">
-          {t('allInformationOnSite')}
+          {t('allInformationOnSite')}{' '}
           <UILink
             className="underline hover:text-gray-600"
             href="https://zverejnovanie.bratislava.sk"
@@ -293,7 +294,7 @@ export const Posts = ({
             <div className="lg:hidden">
               <br />
             </div>
-            <b> zverejnovanie.bratislava.sk</b>
+            <b>zverejnovanie.bratislava.sk</b>
           </UILink>
         </div>
       )}

--- a/next/components/ui/TopNineItem/TopNineItem.tsx
+++ b/next/components/ui/TopNineItem/TopNineItem.tsx
@@ -40,7 +40,10 @@ export const TopNineItem = ({ className, icon, title, href, linkTitle }: TopNine
   const { Link: UILink } = useUIContext()
   return (
     <div
-      className={cx('w-40 lg:w-full flex-shrink-0 flex flex-col font-medium text-font', className)}
+      className={cx(
+        'relative w-40 lg:w-full flex-shrink-0 flex flex-col font-medium text-font',
+        className,
+      )}
     >
       <div className="mb-6 lg:mb-3.5">
         <IconComponent className="h-20" />
@@ -49,7 +52,7 @@ export const TopNineItem = ({ className, icon, title, href, linkTitle }: TopNine
         {title}
       </div>
       <UILink
-        className="group mt-6 flex h-6 cursor-pointer items-center space-x-5 text-font underline"
+        className="group mt-6 flex h-6 cursor-pointer items-center space-x-5 text-font underline after:absolute after:inset-0"
         href={href}
       >
         <span className="text-p2-semibold">{linkTitle}</span>

--- a/next/package.json
+++ b/next/package.json
@@ -26,6 +26,7 @@
     "@rjsf/utils": "^5.0.0-beta.6",
     "@rjsf/validator-ajv8": "^5.0.0-beta.6",
     "@sentry/nextjs": "7.7.0",
+    "@tailwindcss/line-clamp": "^0.4.2",
     "@types/formidable": "^2.0.5",
     "@types/micro": "^7.3.7",
     "@types/minio": "^7.0.14",

--- a/next/pages/index.css
+++ b/next/pages/index.css
@@ -55,20 +55,6 @@
   .blog-card-image {
     clip-path: polygon(0 0, 100% 0, 75% 100%, 0 100%);
   }
-  .news-small-content {
-    overflow: hidden;
-    display: -webkit-box;
-    -webkit-line-clamp: 3;
-    -webkit-box-orient: vertical;
-    text-overflow: ellipsis;
-  }
-  .text-truncate-2 {
-    overflow: hidden;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    text-overflow: ellipsis;
-  }
   .modal-close-mobile-right {
     right: 45%;
   }
@@ -162,20 +148,6 @@
 
   .listitem .typography-regular {
     @apply text-p-sm lg:text-p-base;
-  }
-
-  .line-clamp-4 {
-    -webkit-line-clamp: 4;
-    line-clamp: 4;
-    -webkit-box-orient: vertical;
-    display: -webkit-box;
-  }
-
-  .line-clamp-2 {
-    -webkit-line-clamp: 2;
-    line-clamp: 2;
-    -webkit-box-orient: vertical;
-    display: -webkit-box;
   }
 
   .text-title-center h1,

--- a/next/tailwind.config.js
+++ b/next/tailwind.config.js
@@ -75,7 +75,7 @@ module.exports = {
         '"Noto Color Emoji"',
       ],
     },
-    
+
     fontSize: {
       'btn-base': ['16px', '24px'],
       'btn-lg': ['20px', '32px'],
@@ -236,7 +236,7 @@ module.exports = {
       },
     },
   },
-  plugins: [require('tailwind-scrollbar-hide')],
+  plugins: [require('tailwind-scrollbar-hide'), require('@tailwindcss/line-clamp')],
   corePlugins: {
     container: false,
   },

--- a/next/yarn.lock
+++ b/next/yarn.lock
@@ -4631,6 +4631,11 @@
   dependencies:
     tslib "^2.4.0"
 
+"@tailwindcss/line-clamp@^0.4.2":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/line-clamp/-/line-clamp-0.4.2.tgz#f353c5a8ab2c939c6267ac5b907f012e5ee130f9"
+  integrity sha512-HFzAQuqYCjyy/SX9sLGB1lroPzmcnWv1FHkIpmypte10hptf4oPUfucryMKovZh2u0uiS9U5Ty3GghWfEJGwVw==
+
 "@testing-library/dom@^8.11.1", "@testing-library/dom@^8.5.0":
   version "8.19.0"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.19.0.tgz#bd3f83c217ebac16694329e413d9ad5fdcfd785f"


### PR DESCRIPTION
Few accessibility and UX quick fixes:
- make all "cards" on homepage clickable properly
  - use `after:absolute after:inset-0` on links in card, and `relative` on card top div, so the link `::after` covers the whole card, therefore the whole card is clickable as a link
- remove cursor-pointer where it is redundant or deceptive
- add `@tailwindcss/line-clamp` plugin and remove custom line-clamp non-reliable css classes
- few more minor visual and UX fixes

I tried to touch as few chunks of code as possible :), just repaired what I aimed for.