### PR TITLE
change break-all to break-words, sort Blogposts in search by date_added

### DIFF
--- a/next/backend/meili/fetchers/blogPostsFetcher.ts
+++ b/next/backend/meili/fetchers/blogPostsFetcher.ts
@@ -21,6 +21,10 @@ export const getBlogPostsSwrKey = (filters: BlogPostsFilters, locale: string) =>
   ['BlogPost', filters, locale] as Key
 
 export const blogPostsFetcher = (filters: BlogPostsFilters, locale: string) => async () => {
+  // Tmp fix:
+  // We sort first in meilisearch by publish date because date_added is not required and then in FE by date_added
+  // TODO make date_added required
+
   const data = await meiliClient
     .index('search_index')
     .search<SearchIndexWrapped<'blog-post', BlogPostMeili>>(filters.search, {
@@ -30,37 +34,46 @@ export const blogPostsFetcher = (filters: BlogPostsFilters, locale: string) => a
     })
     .then(unwrapFromSearchIndex('blog-post'))
 
-  const hits = data.hits.map((article) => {
-    return {
-      attributes: {
-        title: article.title,
-        slug: article.slug,
-        publishedAt: article.publishedAt,
-
-        coverImage: {
-          data: {
-            attributes: {
-              url: article.coverImage?.url,
+  const hits = data.hits
+    .map((article) => {
+      return {
+        attributes: {
+          title: article.title,
+          slug: article.slug,
+          publishedAt: article.publishedAt,
+          date_added: article.date_added,
+          coverImage: {
+            data: {
+              attributes: {
+                url: article.coverImage?.url,
+              },
             },
           },
-        },
-        tag: {
-          data: {
-            attributes: {
-              pageCategory: {
-                data: {
-                  attributes: {
-                    color: 'main', // hardcoded, api does not return this attribute
-                    shortTitle: article.tag?.title,
+          tag: {
+            data: {
+              attributes: {
+                pageCategory: {
+                  data: {
+                    attributes: {
+                      color: 'main', // hardcoded, api does not return this attribute
+                      shortTitle: article.tag?.title,
+                    },
                   },
                 },
               },
             },
           },
         },
-      },
-    } as BlogItem
-  })
+      } as BlogItem
+    })
+    .sort((a, b) => {
+      if (!a.attributes?.date_added || !b.attributes?.date_added) {
+        return 0
+      }
+      return (
+        new Date(b.attributes.date_added).getTime() - new Date(a.attributes.date_added).getTime()
+      )
+    })
 
   return { ...data, hits }
 }

--- a/next/components/atoms/HomepageMarkdown.tsx
+++ b/next/components/atoms/HomepageMarkdown.tsx
@@ -78,19 +78,25 @@ export const HomepageMarkdown = ({ className, content, numericalList }: Homepage
             {children}
           </h6>
         ),
-        p: ({ node, ...props }) => <div className="text-p1 mb-4 whitespace-pre-wrap last:mb-0" {...props} />,
+        p: ({ node, ...props }) => (
+          <div className="text-p1 mb-4 whitespace-pre-wrap last:mb-0" {...props} />
+        ),
         a: ({ href, children }) => (
           <UILink
             href={href ?? '#'}
-            className="break-all font-semibold text-font underline hover:text-category-600"
+            className="break-words font-semibold text-font underline hover:text-category-600"
             target={href?.startsWith('http') ? '_blank' : null}
           >
             {children[0]}
           </UILink>
         ),
-        img: ({ src, alt }) => <div className="flex justify-center">{src && <ContentImage src={src} alt={alt} />}</div>,
+        img: ({ src, alt }) => (
+          <div className="flex justify-center">{src && <ContentImage src={src} alt={alt} />}</div>
+        ),
         blockquote: ({ children }) => (
-          <div className="mb-5 border-l-4 border-category-600 pl-10 last:mb-0  lg:mb-10">{children}</div>
+          <div className="mb-5 border-l-4 border-category-600 pl-10 last:mb-0  lg:mb-10">
+            {children}
+          </div>
         ),
         table: ({ children }) => <table className="table-block w-full">{children}</table>,
         tr: ({ children }) => (
@@ -98,7 +104,9 @@ export const HomepageMarkdown = ({ className, content, numericalList }: Homepage
             {children}
           </tr>
         ),
-        tbody: ({ children }) => <tbody className="flex gap-5 md:table-row-group md:gap-0">{children}</tbody>,
+        tbody: ({ children }) => (
+          <tbody className="flex gap-5 md:table-row-group md:gap-0">{children}</tbody>
+        ),
         thead: () => <thead className="bg-transparent" />,
         td: ({ children }) => (
           <td className="first:rounded-l-lg last:rounded-r-lg">
@@ -114,7 +122,10 @@ export const HomepageMarkdown = ({ className, content, numericalList }: Homepage
               return (
                 isValidElement(e) && {
                   ...e,
-                  props: { ...e.props, children: e.props.children.filter((c: string) => c !== '\n') },
+                  props: {
+                    ...e.props,
+                    children: e.props.children.filter((c: string) => c !== '\n'),
+                  },
                 }
               )
             })
@@ -135,7 +146,7 @@ export const HomepageMarkdown = ({ className, content, numericalList }: Homepage
                 className={cx(
                   'h-4 w-4 shrink-0 bg-category-600 rounded-full mt-1 border-4 border-solid border-category-600',
                   { 'bg-category-600': level === 0 },
-                  { 'border-category-600 border-solid border-4': level !== 0 }
+                  { 'border-category-600 border-solid border-4': level !== 0 },
                 )}
               />
               <div className="text-p1 whitespace-pre-wrap">{children}</div>

--- a/next/components/forms/info-components/Tooltip.tsx
+++ b/next/components/forms/info-components/Tooltip.tsx
@@ -57,10 +57,14 @@ const Tooltip: FC<TooltipProps> = (props: TooltipProps) => {
   return (
     <div className={tooltipClassNames} style={positionStyle}>
       <div className={arrowClassNames}>
-        {arrow && ['top', 'bottom'].includes(arrow) && <TopArrowIcon className="p-0 m-0 border-0" />}
-        {arrow && ['left', 'right'].includes(arrow) && <LeftArrowIcon className="p-0 m-0 border-0"/>}
+        {arrow && ['top', 'bottom'].includes(arrow) && (
+          <TopArrowIcon className="p-0 m-0 border-0" />
+        )}
+        {arrow && ['left', 'right'].includes(arrow) && (
+          <LeftArrowIcon className="p-0 m-0 border-0" />
+        )}
       </div>
-      <div className="text-p2 m-0 border-0 flex flex-row justify-center min-w-[118px] max-w-xs break-all rounded bg-gray-700 py-3 px-4 text-white">
+      <div className="text-p2 m-0 border-0 flex flex-row justify-center min-w-[118px] max-w-xs break-words rounded bg-gray-700 py-3 px-4 text-white">
         <p className="w-fit">{text}</p>
       </div>
     </div>

--- a/next/components/forms/widget-components/RadioButton/Radio.tsx
+++ b/next/components/forms/widget-components/RadioButton/Radio.tsx
@@ -85,7 +85,7 @@ const Radio = ({
         {variant === 'card' ? (
           <div className="w-full flex flex-col items-start gap-4 p-0 ">
             <input id={rest.value} {...inputProps} ref={ref} className={inputStyle} />
-            <div className="text-p-md text-gray-700 font-normal not-italic break-all">
+            <div className="text-p-md text-gray-700 font-normal not-italic break-words">
               {rest.children}
               {tooltip && (
                 <div className="mt-8 relative flex flex-row">
@@ -114,7 +114,7 @@ const Radio = ({
           <div className={cx('flex items-center gap-4 w-full', {})}>
             <input id={rest.value} {...inputProps} ref={ref} className={inputStyle} />
             <div
-              className={cx('text-p-md flex font-normal not-italic text-gray-700 break-all', {})}
+              className={cx('text-p-md flex font-normal not-italic text-gray-700 break-words', {})}
             >
               {rest.children}
             </div>

--- a/next/components/ui/BlogSearchCard/BlogSearchCard.tsx
+++ b/next/components/ui/BlogSearchCard/BlogSearchCard.tsx
@@ -35,6 +35,7 @@ export interface BlogItem {
       }
     }
     publishedAt?: string
+    date_added?: string
     slug?: string
     tag?: {
       data?: {
@@ -69,12 +70,12 @@ export const BlogSearchCard = ({
 }: BlogSearchCardProps) => {
   const { Link: UILink } = useUIContext()
 
-  const { slug, tag, coverImage, title } = item.attributes
+  const { slug, tag, coverImage, title, publishedAt, date_added } = item.attributes
   const { shortTitle: tagTitle, color } = tag.data.attributes.pageCategory.data.attributes
 
-  const publishedAt = new Date(item.attributes.publishedAt)
   // TODO use formatter function, add locale
-  const date = publishedAt.toLocaleDateString('sk-SK')
+  console.log(item.attributes)
+  const date = new Date(date_added ?? publishedAt).toLocaleDateString('sk-SK')
   const tagColor = color ? `--color-${color}-100` : '--color-main-100'
 
   return (

--- a/next/components/ui/Contact/Contact.tsx
+++ b/next/components/ui/Contact/Contact.tsx
@@ -59,7 +59,7 @@ export const Contact = ({
             <div className={cx('flex flex-col h-full', { 'justify-center': !address })}>
               {description && (
                 <UIMarkdown
-                  className="text-p2 leading-[24px] md:text-p1 md:leading-[30px]"
+                  className="text-p2 md:text-p1 leading-[24px] md:leading-[30px]"
                   content={description}
                 />
               )}
@@ -100,23 +100,31 @@ interface ContactItemProps {
   linkVariant?: string
 }
 
-const ContactItem = ({ variant, value, label, href, linkVariant = 'primary' }: ContactItemProps) => {
+const ContactItem = ({
+  variant,
+  value,
+  label,
+  href,
+  linkVariant = 'primary',
+}: ContactItemProps) => {
   const { Markdown: UIMarkdown } = useUIContext()
 
   if (variant === 'address') {
-    return <UIMarkdown className="text-p2 leading-[24px] md:text-p1 md:leading-[30px]" content={value} />
+    return (
+      <UIMarkdown className="text-p2 md:text-p1 leading-[24px] md:leading-[30px]" content={value} />
+    )
   }
 
   const Icon = variant === 'phone' ? Phone : Email
 
   return (
-    <div className="relative flex h-full flex-col items-center justify-start pb-20 text-20 leading-[30px]">
+    <div className="text-20 relative flex h-full flex-col items-center justify-start pb-20 leading-[30px]">
       <Icon className="h-24 w-24" />
       {value.split(',').map((item, key) => {
         return (
           <div key={key} className="text-center">
             <span
-              className={cx('text-20-semibold w-full break-all text-center', {
+              className={cx('text-20-semibold w-full text-center', {
                 'mt-9': key === 0,
                 'whitespace-nowrap': variant === 'phone',
               })}
@@ -130,12 +138,12 @@ const ContactItem = ({ variant, value, label, href, linkVariant = 'primary' }: C
         <a
           href={href}
           className={cx(
-            'mt-8 px-6 py-3 text-20-medium border-2 rounded-lg shadow-sm whitespace-nowrap absolute bottom-0',
+            'text-20-medium mt-8 px-6 py-3 border-2 rounded-lg shadow-sm whitespace-nowrap absolute bottom-0',
             {
               'bg-category-600 border-category-600': linkVariant === 'primary',
               'bg-category-200 border-category-200 text-white': linkVariant === 'secondary',
               'text-black': linkVariant === 'primary',
-            }
+            },
           )}
         >
           {label}

--- a/next/components/ui/Institution/Institution.tsx
+++ b/next/components/ui/Institution/Institution.tsx
@@ -13,18 +13,32 @@ export interface InstitutionProps {
   urlLabel?: string
 }
 
-const InstitutionCard = ({ className, title, subtitle, content, children }: InstitutionCardProps) => {
+const InstitutionCard = ({
+  className,
+  title,
+  subtitle,
+  content,
+  children,
+}: InstitutionCardProps) => {
   const { Markdown: UIMarkdown } = useUIContext()
 
   return (
-    <div className={cx(className, 'px-8 py-8 bg-white border-2 border-[rgba(51,51,51,0.25)] rounded-lg h-full')}>
+    <div
+      className={cx(
+        className,
+        'px-8 py-8 bg-white border-2 border-[rgba(51,51,51,0.25)] rounded-lg h-full',
+      )}
+    >
       <div className="flex flex-col">
         <h4 className="text-20-semibold leading-[26px]">{title}</h4>
         {subtitle && <UIMarkdown className="fontSize-base text-16 mt-6" content={subtitle} />}
         {content && (
           <div className="row mt-6 flex w-full flex-row flex-wrap">
             {[...Array.from({ length: 3 })].map((_, ix) => (
-              <div key={ix} className="col-12 md:col-4 fontSize-base mb-2 break-all last:mb-0 md:mb-0">
+              <div
+                key={ix}
+                className="col-12 md:col-4 fontSize-base mb-2 break-words last:mb-0 md:mb-0"
+              >
                 {content[ix] && <UIMarkdown content={content[ix]} />}
               </div>
             ))}
@@ -61,7 +75,8 @@ export const Institution = ({ className, url, urlLabel, ...rest }: InstitutionPr
   )
 }
 
-interface InstitutionCardProps extends Pick<InstitutionProps, 'className' | 'title' | 'subtitle' | 'content'> {
+interface InstitutionCardProps
+  extends Pick<InstitutionProps, 'className' | 'title' | 'subtitle' | 'content'> {
   children?: React.ReactNode
 }
 

--- a/next/components/ui/Rent/Rent.tsx
+++ b/next/components/ui/Rent/Rent.tsx
@@ -29,7 +29,7 @@ export const Rent = ({ className, icon, title, desc, linkLabel }: RentProps) => 
     <div
       className={cx(
         className,
-        'flex flex-col text-center flex-1 items-center px-3 md:bg-transparent rent-shadow rounded-xl p-5 max-h-sm min-w-60 mr-4 md:mr-0 lg:min-w-0',
+        'rent-shadow max-h-sm min-w-60 flex flex-col text-center flex-1 items-center px-3 md:bg-transparent rounded-xl p-5 mr-4 md:mr-0 lg:min-w-0',
       )}
     >
       <div
@@ -45,7 +45,7 @@ export const Rent = ({ className, icon, title, desc, linkLabel }: RentProps) => 
       <div className="flex w-60 flex-col items-center text-center md:w-auto xl:w-[294px]">
         <h1 className="text-h4-normal mt-5 mb-7 h-16">{title}</h1>
 
-        <div className="line-clamp-3 w-full break-all text-center">
+        <div className="line-clamp-3 w-full break-words text-center">
           <ReactMarkdown skipHtml>{desc}</ReactMarkdown>
         </div>
         {isMore && (


### PR DESCRIPTION
- change `break-all` class to `break-words` - this should be quick fix for unwanted word breaks in the middle of words
- tmp fix sorting of blogposts in search results by date_added
- formatting