### PR TITLE
Turn off Sentry

### DIFF
--- a/next/next.config.js
+++ b/next/next.config.js
@@ -2659,8 +2659,8 @@ const moduleExports = (phase, { defaultConfig }) => {
     ...nextConfig,
     // TODO enable sentry sourcemap uploading below once pipelines are used not just for testing, but also for deployment
     sentry: {
-      disableServerWebpackPlugin: process.env.CI === 'true' || process.env.SKIP_SENTRY === 'true',
-      disableClientWebpackPlugin: process.env.CI === 'true' || process.env.SKIP_SENTRY === 'true',
+      disableServerWebpackPlugin: true,
+      disableClientWebpackPlugin: true,
     },
     webpack(config) {
       config.module.rules.push({

--- a/next/sentry.client.config.js
+++ b/next/sentry.client.config.js
@@ -2,16 +2,17 @@
 // The config you add here will be used whenever a page is visited.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
-import * as Sentry from '@sentry/nextjs'
+// import * as Sentry from '@sentry/nextjs'
 
-const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN
+// const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN
 
-Sentry.init({
-  dsn: SENTRY_DSN || 'https://f49cbf10ffe648d1a74baeba759279a6@o701870.ingest.sentry.io/6467363',
-  // Adjust this value in production, or use tracesSampler for greater control
-  tracesSampleRate: 0.05,
-  // ...
-  // Note: if you want to override the automatic release value, do not set a
-  // `release` value here - use the environment variable `SENTRY_RELEASE`, so
-  // that it will also get attached to your source maps
-})
+// Sentry.init({
+//   enabled: false,
+//   dsn: SENTRY_DSN || 'https://f49cbf10ffe648d1a74baeba759279a6@o701870.ingest.sentry.io/6467363',
+//   // Adjust this value in production, or use tracesSampler for greater control
+//   tracesSampleRate: 0.05,
+//   // ...
+//   // Note: if you want to override the automatic release value, do not set a
+//   // `release` value here - use the environment variable `SENTRY_RELEASE`, so
+//   // that it will also get attached to your source maps
+// })

--- a/next/sentry.server.config.js
+++ b/next/sentry.server.config.js
@@ -2,16 +2,16 @@
 // The config you add here will be used whenever the server handles a request.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
-import * as Sentry from '@sentry/nextjs'
+// import * as Sentry from '@sentry/nextjs'
 
-const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN
+// const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN
 
-Sentry.init({
-  dsn: SENTRY_DSN || 'https://f49cbf10ffe648d1a74baeba759279a6@o701870.ingest.sentry.io/6467363',
-  // Adjust this value in production, or use tracesSampler for greater control
-  tracesSampleRate: 0.05,
-  // ...
-  // Note: if you want to override the automatic release value, do not set a
-  // `release` value here - use the environment variable `SENTRY_RELEASE`, so
-  // that it will also get attached to your source maps
-})
+// Sentry.init({
+//   dsn: SENTRY_DSN || 'https://f49cbf10ffe648d1a74baeba759279a6@o701870.ingest.sentry.io/6467363',
+//   // Adjust this value in production, or use tracesSampler for greater control
+//   tracesSampleRate: 0.05,
+//   // ...
+//   // Note: if you want to override the automatic release value, do not set a
+//   // `release` value here - use the environment variable `SENTRY_RELEASE`, so
+//   // that it will also get attached to your source maps
+// })


### PR DESCRIPTION
First like this, once we're set on switching to an alternative will remove completely.