### PR TITLE
Fix menu overlays

### DIFF
--- a/next/components/atoms/CardGradient.tsx
+++ b/next/components/atoms/CardGradient.tsx
@@ -37,7 +37,9 @@ const CardGradient = ({ title, url, mainImage, className, description }: IProps)
             {title && (
               <p className="text-h5 p-6 pb-0 text-white lg:pb-6 lg:group-hover:pb-3">{title}</p>
             )}
-            {description && <p className="block lg:hidden lg:group-hover:block">{description}</p>}
+            {description && (
+              <div className="block lg:hidden lg:group-hover:block">{description}</div>
+            )}
           </div>
         </div>
       </div>

--- a/next/components/layouts/PageLayout.tsx
+++ b/next/components/layouts/PageLayout.tsx
@@ -1,7 +1,5 @@
-import { useNavMenuContext } from '@bratislava/ui-bratislava/../organisms/NavBar/NavMenu/navMenuContext'
-import cx from 'classnames'
+import CookieConsent from '@components/organisms/CookieConsent'
 import React, { PropsWithChildren } from 'react'
-import { twMerge } from 'tailwind-merge'
 
 import Footer from '../molecules/Footer'
 import NavBar from '../organisms/NavBar/NavBar'
@@ -11,25 +9,20 @@ type PageLayoutProps = {
 }
 
 const PageLayout = ({ className, children }: PropsWithChildren<PageLayoutProps>) => {
-  const { menuValue } = useNavMenuContext()
-
   return (
-    <div
-      className={twMerge(
-        className,
-        cx({
-          // If menu is open, disable pointer events on the whole page (pointer events on menu must be re-enabled)
-          'lg:pointer-events-none': menuValue !== '',
-        }),
-      )}
-    >
-      <header>
+    // Z-indices are set to create stacking contexts for easier z-index management.
+    <div className={className}>
+      <CookieConsent className="z-30" /* position: fixed */ />
+
+      <header className="relative z-30">
         <NavBar />
       </header>
 
-      <main>{children}</main>
+      <main className="relative z-0">{children}</main>
 
-      <Footer />
+      <footer className="relative z-0">
+        <Footer />
+      </footer>
     </div>
   )
 }

--- a/next/components/molecules/OrganizationalStructure/OrganizationalStructure.tsx
+++ b/next/components/molecules/OrganizationalStructure/OrganizationalStructure.tsx
@@ -1,32 +1,22 @@
-import { Divider } from '@bratislava/ui-bratislava/Divider/Divider'
 import { structureFetcher } from 'backend/utils/organisationalStructure'
 import { useTranslation } from 'next-i18next'
 import useSWR from 'swr'
 
 import { OrganizationalStructureTopLevelAccordion } from './OrganizationalStructureTopLevelAccordion'
 
-export interface AdvancedAccordionProps {
+export interface OrganizationalStructureProps {
   title?: string | null
-  dividerStyle?: string
 }
 
 // TODO add search
-export const OrganizationalStructure = ({ title, dividerStyle }: AdvancedAccordionProps) => {
+export const OrganizationalStructure = ({ title }: OrganizationalStructureProps) => {
   const { data } = useSWR('organizationalStructure', structureFetcher)
   const { t } = useTranslation('common')
   return data ? (
     <div className="flex flex-col">
       <div className="text-h3 pb-4">{title}</div>
-      {data.groups.map((group, index) => (
+      {data.groups.map((group) => (
         <div key={group.id}>
-          {index > 0 && (
-            <Divider
-              className="py-6 lg:py-10"
-              dividerStyle={
-                dividerStyle && dividerStyle?.length > 1 ? dividerStyle : 'mesto_01_full_width'
-              }
-            />
-          )}
           <OrganizationalStructureTopLevelAccordion group={group} />
         </div>
       ))}

--- a/next/components/organisms/CookieConsent.tsx
+++ b/next/components/organisms/CookieConsent.tsx
@@ -1,17 +1,19 @@
-import Button from '@bratislava/ui-bratislava/Button/Button'
+import Button from '@components/forms/simple-components/Button'
+import MLink from '@components/forms/simple-components/MLink'
+import { getCategoryColorLocalStyle } from '@utils/colors'
 import { isProductionDeployment } from '@utils/utils'
 import { useCookieConsent } from 'backend/utils/cookies'
-import NextLink from 'next/link'
 import Script from 'next/script'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
+import { twMerge } from 'tailwind-merge'
 
-interface IProps {
-  pageColor?: string
+type CookieConsentProps = {
+  className?: string
 }
 
 // also takes care of loading all the consented 3rd parties - TODO consider better component name ?
-export const CookieConsent = ({ pageColor }: IProps) => {
+export const CookieConsent = ({ className }: CookieConsentProps) => {
   const { shouldShowBanner, setConsents, consents } = useCookieConsent()
   const { t } = useTranslation(['common'])
 
@@ -41,40 +43,35 @@ export const CookieConsent = ({ pageColor }: IProps) => {
       ) : null}
 
       {shouldShowBanner ? (
-        <div className="fixed inset-x-0 bottom-6 z-50 px-6">
+        <div
+          className={twMerge('fixed inset-x-0 bottom-6 px-6', className)}
+          style={getCategoryColorLocalStyle({ category: 'main' })}
+        >
           <div className="mx-auto max-w-[1110px] rounded-lg bg-white px-6 py-8 shadow md:px-10">
-            <h6 className="text-20-semibold mb-4"> {t('cookie_consent_modal_content_title')} </h6>
-            <p className="text-p2 mb-8">
-              {' '}
+            <h6 className="text-20-semibold mb-4">{t('cookie_consent_modal_content_title')}</h6>
+            <div className="text-p2 mb-8">
               {t('cookie_consent_body')}{' '}
-              <NextLink
+              <MLink
                 href={t('cookie_consent_privacy_policy_link')}
-                passHref
-                className="cursor-pointer font-semibold underline"
+                variant="navBarHeader"
+                className="font-semibold"
               >
-                {' '}
-                {t('cookie_consent_privacy_policy')}{' '}
-              </NextLink>
-            </p>
-            <div className="block sm:flex">
+                {t('cookie_consent_privacy_policy')}
+              </MLink>
+            </div>
+            <div className="flex flex-col gap-4 md:flex-row">
               <Button
-                className="text-16-medium mb-3 h-12 px-6 sm:my-0 sm:mr-6"
-                variant={
-                  pageColor === 'yellow' || pageColor === 'brown'
-                    ? 'tertiary-dark-text'
-                    : 'tertiary'
-                }
-                onClick={() => setConsents({ statistics: true })}
-              >
-                {t('cookie_consent_accept')}
-              </Button>
+                variant="category"
+                onPress={() => setConsents({ statistics: true })}
+                text={t('cookie_consent_accept')}
+                className="w-full md:w-fit"
+              />
               <Button
-                className="text-16-medium mt-0 h-12 px-6"
-                variant="secondary-dark-text"
-                onClick={() => setConsents({ statistics: false })}
-              >
-                {t('cookie_consent_reject')}
-              </Button>
+                variant="category-outline"
+                onPress={() => setConsents({ statistics: false })}
+                text={t('cookie_consent_reject')}
+                className="w-full md:w-fit"
+              />
             </div>
           </div>
         </div>

--- a/next/components/organisms/NavBar/MobileNavBar.tsx
+++ b/next/components/organisms/NavBar/MobileNavBar.tsx
@@ -4,6 +4,7 @@ import SearchIcon from '@assets/images/search-icon.svg'
 import { Brand } from '@bratislava/ui-bratislava'
 import Button from '@components/forms/simple-components/Button'
 import MLink from '@components/forms/simple-components/MLink'
+import { getCategoryColorLocalStyle } from '@utils/colors'
 import { getLanguageKey } from '@utils/utils'
 import cx from 'classnames'
 import FocusTrap from 'focus-trap-react'
@@ -22,7 +23,7 @@ interface MobileNavBarProps extends LanguageSelectProps {
   className?: string
 }
 
-export const MobileNavBar = ({ className, ...languageSelectProps }: MobileNavBarProps) => {
+const MobileNavBar = ({ className, ...languageSelectProps }: MobileNavBarProps) => {
   const { t } = useTranslation(['common'])
   const router = useRouter()
   const { isMobileMenuOpen, setMobileMenuOpen } = useNavMenuContext()
@@ -37,7 +38,7 @@ export const MobileNavBar = ({ className, ...languageSelectProps }: MobileNavBar
   return (
     <>
       <FocusTrap active={isMobileMenuOpen}>
-        <div>
+        <div style={getCategoryColorLocalStyle({ category: 'main' })}>
           <div
             className={cx(
               'fixed top-0 z-30 flex h-14 w-full items-center justify-between bg-white px-4 text-gray-700 shadow-md',
@@ -45,7 +46,7 @@ export const MobileNavBar = ({ className, ...languageSelectProps }: MobileNavBar
             )}
           >
             <div className="flex items-center">
-              <Brand url="/" className="-ml-4 py-3 px-4" />
+              <Brand url="/" className="-ml-4 px-4 py-3" />
             </div>
             <div className="flex items-center">
               {otherLanguage && (

--- a/next/components/organisms/NavBar/NavBar.tsx
+++ b/next/components/organisms/NavBar/NavBar.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'next-i18next'
 import * as React from 'react'
 
 import { usePageContext } from '../../layouts/PageContextProvider'
-import CookieConsent from '../CookieConsent'
 import MobileNavBar from './MobileNavBar'
 import NavBarHeader from './NavBarHeader/NavBarHeader'
 import NavMenu from './NavMenu/NavMenu'
@@ -25,8 +24,6 @@ const NavBar = () => {
 
   return (
     <>
-      <CookieConsent />
-
       <div className="fixed top-0 z-30 hidden w-full bg-white lg:block">
         <div className="w-full">
           {/* TODO mobile header, NavBarHeader (= new component) renders only on desktop */}
@@ -44,7 +41,6 @@ const NavBar = () => {
       </div>
       <div className="hidden h-[137px] lg:block" />
 
-      {/* TODO mobile header, BANavBar (= old component) renders only on mobile */}
       <MobileNavBar
         className="lg:hidden"
         onLanguageChange={handleLanguageChange}

--- a/next/components/organisms/NavBar/NavBarHeader/NavBarHeader.tsx
+++ b/next/components/organisms/NavBar/NavBarHeader/NavBarHeader.tsx
@@ -18,7 +18,7 @@ const Divider = ({ className }: { className?: string }) => {
   return <div aria-hidden className={`h-6 border-r ${className}`} />
 }
 
-export const NavBarHeader = ({ className, ...languageSelectProps }: NavBarProps) => {
+const NavBarHeader = ({ className, ...languageSelectProps }: NavBarProps) => {
   const { t, i18n } = useTranslation(['common'])
 
   const { general } = useGeneralContext()

--- a/next/components/organisms/NavBar/NavMenu/MobileNavMenu.tsx
+++ b/next/components/organisms/NavBar/NavMenu/MobileNavMenu.tsx
@@ -1,6 +1,7 @@
 import { Icon } from '@components/atoms/icon/Icon'
 import Button from '@components/forms/simple-components/Button'
 import MLink from '@components/forms/simple-components/MLink'
+import HorizontalDivider from '@components/organisms/NavBar/NavMenu/HorizontalDivider'
 import * as NavigationMenu from '@radix-ui/react-navigation-menu'
 import { useGeneralContext } from '@utils/generalContext'
 import { getCommonLinkProps } from '@utils/getCommonLinkProps'
@@ -11,7 +12,6 @@ import React, { useMemo } from 'react'
 import { useEventListener, useLockedBody, useWindowSize } from 'usehooks-ts'
 
 import { getParsedMenus } from './getParsedMenus'
-import HorizontalDivider from './HorizontalDivider'
 import MobileNavMenuItem from './MobileNavMenuItem'
 import { useNavMenuContext } from './navMenuContext'
 
@@ -23,6 +23,7 @@ const MobileNavMenu = () => {
   const { menu: generalMenu, general } = useGeneralContext()
   const { header } = general?.data?.attributes ?? {}
   const { links, accountLink } = header ?? {}
+  const linksOnMobile = links?.filter(isDefined).filter((link) => link.showOnMobile)
 
   const menus = useMemo(() => {
     return getParsedMenus(generalMenu, t('more'))
@@ -41,7 +42,7 @@ const MobileNavMenu = () => {
   return (
     <div
       className={cx(
-        'fixed top-14 left-0 z-[28] flex w-screen flex-col gap-4 overflow-y-scroll bg-white px-4 py-6 lg:hidden',
+        'fixed left-0 top-14 z-[28] flex w-screen flex-col gap-4 overflow-y-scroll bg-white px-4 py-6 lg:hidden',
         {
           'animate-fadeIn': isMobileMenuOpen,
           'animate-fadeOut': !isMobileMenuOpen,
@@ -60,48 +61,51 @@ const MobileNavMenu = () => {
             <MobileNavMenuItem key={index} menu={menu} />
           ))}
 
-          <HorizontalDivider />
-
-          {links
-            ?.filter(isDefined)
-            .filter((link) => link.showOnMobile)
-            .map((link) => {
-              // TODO better approach to links
-              const pageSlug = link.page?.data?.attributes?.slug
-              return (
-                <li className="relative flex items-center gap-2">
-                  <div aria-hidden>
-                    <Icon iconName={link.icon} />
-                  </div>
-                  <NavigationMenu.Link asChild onClick={() => setMobileMenuOpen(false)}>
-                    <MLink
-                      href={pageSlug ? `/${pageSlug}` : link.url ?? '#'}
-                      target={link.url ? '_blank' : undefined}
-                      variant="navBarHeader"
-                      stretched
-                    >
-                      {link.label}
-                    </MLink>
-                  </NavigationMenu.Link>
-                </li>
-              )
-            })}
-
           {accountLink && (
             <>
               <HorizontalDivider />
-              <li className="mt-2 flex justify-center">
+              <li className="my-1 flex justify-center md:justify-start">
                 <NavigationMenu.Link asChild onClick={() => setMobileMenuOpen(false)}>
-                  <Button size="sm" variant="negative" {...getCommonLinkProps(accountLink)} />
+                  <Button
+                    size="sm"
+                    variant="category"
+                    className="w-full md:w-fit"
+                    {...getCommonLinkProps(accountLink)}
+                  />
                 </NavigationMenu.Link>
               </li>
             </>
           )}
+
+          {linksOnMobile?.length && <HorizontalDivider />}
+
+          {linksOnMobile?.map((link, linkIndex) => {
+            // TODO better approach to links
+            const pageSlug = link.page?.data?.attributes?.slug
+            return (
+              // eslint-disable-next-line react/no-array-index-key
+              <li key={linkIndex} className="relative flex items-center gap-2">
+                <div aria-hidden>
+                  <Icon iconName={link.icon} />
+                </div>
+                <NavigationMenu.Link asChild onClick={() => setMobileMenuOpen(false)}>
+                  <MLink
+                    href={pageSlug ? `/${pageSlug}` : link.url ?? '#'}
+                    target={link.url ? '_blank' : undefined}
+                    variant="navBarHeader"
+                    stretched
+                  >
+                    {link.label}
+                  </MLink>
+                </NavigationMenu.Link>
+              </li>
+            )
+          })}
         </NavigationMenu.List>
 
         {/* Viewport represents popup div with links that appears under menu button */}
         <NavigationMenu.Viewport
-          className="fixed top-14 left-0 z-[29] w-screen overflow-y-scroll data-[state=open]:animate-enterFromRight data-[state=closed]:animate-exitToRight"
+          className="fixed left-0 top-14 z-[29] w-screen overflow-y-scroll data-[state=closed]:animate-exitToRight data-[state=open]:animate-enterFromRight"
           style={{ height: `calc(${height}px - 14*4px)` }}
         />
       </NavigationMenu.Root>

--- a/next/components/organisms/NavBar/NavMenu/NavMenu.tsx
+++ b/next/components/organisms/NavBar/NavMenu/NavMenu.tsx
@@ -29,14 +29,12 @@ const NavMenu = () => {
       value={menuValue}
       onValueChange={setMenuValue}
       aria-label={t('NavMenu.aria.navMenuLabel')}
-      // to re-enable pointer events when menu is open and whole page has pointer events disabled
-      className="pointer-events-auto"
     >
       <NavigationMenu.List className="relative z-30 shadow-md">
         <div className="m-auto grid w-full max-w-screen-lg grid-flow-col grid-cols-6">
-          {menus.map((menu, index) => (
+          {menus.map((menuItem, index) => (
             // eslint-disable-next-line react/no-array-index-key
-            <NavMenuItem key={index} menu={menu} />
+            <NavMenuItem key={index} menu={menuItem} />
           ))}
         </div>
       </NavigationMenu.List>
@@ -45,7 +43,7 @@ const NavMenu = () => {
       <NavigationMenu.Viewport
         // Together with onCLick in NavMenuContent, it closes the menu on click outside of container area
         onClick={() => setMenuValue('')}
-        className="absolute z-[29] w-full"
+        className="absolute z-[29] h-screen w-full"
       />
     </NavigationMenu.Root>
   )

--- a/next/components/organisms/NavBar/NavMenu/NavMenuContent.tsx
+++ b/next/components/organisms/NavBar/NavMenu/NavMenuContent.tsx
@@ -49,7 +49,7 @@ const NavMenuContent = ({ colCount, sections, colorStyle }: NavMenuContentProps)
       style={colorStyle}
     >
       <div className="relative z-[29] bg-category-200">
-        {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */}
+        {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions,jsx-a11y/no-noninteractive-element-interactions */}
         <ul
           className={cx('mx-auto grid w-full max-w-screen-lg gap-x-8 gap-y-6 px-4 py-8', {
             // Keeping for consistency with mestskakniznica.sk
@@ -86,7 +86,8 @@ const NavMenuContent = ({ colCount, sections, colorStyle }: NavMenuContentProps)
         </ul>
       </div>
       <Waves
-        className="relative z-[28] drop-shadow-xl"
+        // padding-bottom is needed for drop-shadow to render properly on Safari
+        className="relative z-[28] pb-20 drop-shadow-xl"
         wavePosition="bottom"
         waveColor="rgb(var(--color-category-200))"
       />

--- a/next/components/ui/WeddingForm/WeddingForm.tsx
+++ b/next/components/ui/WeddingForm/WeddingForm.tsx
@@ -1,8 +1,8 @@
+import Calendar from '@assets/images/calendar-form.svg'
 import { LocalDate } from '@js-joda/core'
 import { useTranslation } from 'next-i18next'
 import React from 'react'
 
-import Calendar from '@assets/images/calendar-form.svg'
 import { Button } from '../Button/Button'
 import { CheckBox } from '../CheckBox/CheckBox'
 import { Field } from '../Field/Field'
@@ -142,7 +142,7 @@ export const WeddingForm = () => {
                   name="date"
                   type="date"
                   min={LocalDate.now().toJSON()}
-                  className="h-12.5 text-20 w-full text-font focus:outline-none"
+                  className="text-20 h-12 w-full text-font focus:outline-none"
                   // hasError={!!errors?.email}
                   value={reservationFormValues?.date}
                   onChange={(e) => handleChange({ date: e.target.value })}
@@ -159,7 +159,7 @@ export const WeddingForm = () => {
               <TextArea
                 id="notes"
                 name="notes"
-                className="text-20 pt-5 pb-3.5"
+                className="text-20 pb-3.5 pt-5"
                 rows={11}
                 // hasError={!!errors?.email}
                 value={reservationFormValues?.notes}


### PR DESCRIPTION
- set `z-index` for parent elements to set stacking context
- improve cookie consent banner
- #784 remove dividers in organization structure
- move Account button to higher position in mobile menu 
- remove `pointer-events-...` in menu
  - click outside menu is solved by Viewport set to full screen an z-index under NavBarHeader (NavBarHeader and menu are still clickable while menu is open, but the rest of the body is not)
- fix minor bugs and eslint errors (part of #839)