### PR TITLE
#809: add internationalisation to Tags

### DIFF
--- a/next/graphql/index.ts
+++ b/next/graphql/index.ts
@@ -1498,15 +1498,6 @@ export enum Enum_Pagecategory_Icon {
   ZpVystavba_03 = 'zp_vystavba_03',
 }
 
-export enum Enum_Pagecategory_Iconhover {
-  DopravaMapyColor_02 = 'doprava_mapy_color_02',
-  KulturaColor_06 = 'kultura_color_06',
-  MestoColor_01 = 'mesto_color_01',
-  SocialnaPomocColor_04 = 'socialna_pomoc_color_04',
-  VzdelavanieColor_05 = 'vzdelavanie_color_05',
-  ZpVystavbaColor_03 = 'zp_vystavba_color_03',
-}
-
 export enum Enum_Pagesubcategory_Icon {
   Aktivity_04 = 'aktivity_04',
   Byvanie_04 = 'byvanie_04',
@@ -2035,6 +2026,7 @@ export type Mutation = {
   createPageSubcategory?: Maybe<PageSubcategoryEntityResponse>
   createPageSubcategoryLocalization?: Maybe<PageSubcategoryEntityResponse>
   createTag?: Maybe<TagEntityResponse>
+  createTagLocalization?: Maybe<TagEntityResponse>
   createUploadFile?: Maybe<UploadFileEntityResponse>
   createUploadFolder?: Maybe<UploadFolderEntityResponse>
   /** Create a new role */
@@ -2165,6 +2157,13 @@ export type MutationCreatePageSubcategoryLocalizationArgs = {
 
 export type MutationCreateTagArgs = {
   data: TagInput
+  locale?: InputMaybe<Scalars['I18NLocaleCode']>
+}
+
+export type MutationCreateTagLocalizationArgs = {
+  data?: InputMaybe<TagInput>
+  id?: InputMaybe<Scalars['ID']>
+  locale?: InputMaybe<Scalars['I18NLocaleCode']>
 }
 
 export type MutationCreateUploadFileArgs = {
@@ -2225,6 +2224,7 @@ export type MutationDeletePageSubcategoryArgs = {
 
 export type MutationDeleteTagArgs = {
   id: Scalars['ID']
+  locale?: InputMaybe<Scalars['I18NLocaleCode']>
 }
 
 export type MutationDeleteUploadFileArgs = {
@@ -2332,6 +2332,7 @@ export type MutationUpdatePageSubcategoryArgs = {
 export type MutationUpdateTagArgs = {
   data: TagInput
   id: Scalars['ID']
+  locale?: InputMaybe<Scalars['I18NLocaleCode']>
 }
 
 export type MutationUpdateUploadFileArgs = {
@@ -2412,7 +2413,6 @@ export type PageLocalizationsArgs = {
 export type PageRelatedContentsArgs = {
   filters?: InputMaybe<TagFiltersInput>
   pagination?: InputMaybe<PaginationArg>
-  publicationState?: InputMaybe<PublicationState>
   sort?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
 }
 
@@ -2421,11 +2421,9 @@ export type PageCategory = {
   color?: Maybe<Enum_Pagecategory_Color>
   createdAt?: Maybe<Scalars['DateTime']>
   icon?: Maybe<Enum_Pagecategory_Icon>
-  iconHover?: Maybe<Enum_Pagecategory_Iconhover>
   locale?: Maybe<Scalars['String']>
   localizations?: Maybe<PageCategoryRelationResponseCollection>
   pages?: Maybe<PageRelationResponseCollection>
-  priority?: Maybe<Scalars['Int']>
   publishedAt?: Maybe<Scalars['DateTime']>
   shortTitle?: Maybe<Scalars['String']>
   subcategories?: Maybe<PageSubcategoryRelationResponseCollection>
@@ -2476,14 +2474,12 @@ export type PageCategoryFiltersInput = {
   color?: InputMaybe<StringFilterInput>
   createdAt?: InputMaybe<DateTimeFilterInput>
   icon?: InputMaybe<StringFilterInput>
-  iconHover?: InputMaybe<StringFilterInput>
   id?: InputMaybe<IdFilterInput>
   locale?: InputMaybe<StringFilterInput>
   localizations?: InputMaybe<PageCategoryFiltersInput>
   not?: InputMaybe<PageCategoryFiltersInput>
   or?: InputMaybe<Array<InputMaybe<PageCategoryFiltersInput>>>
   pages?: InputMaybe<PageFiltersInput>
-  priority?: InputMaybe<IntFilterInput>
   publishedAt?: InputMaybe<DateTimeFilterInput>
   shortTitle?: InputMaybe<StringFilterInput>
   subcategories?: InputMaybe<PageSubcategoryFiltersInput>
@@ -2494,9 +2490,7 @@ export type PageCategoryFiltersInput = {
 export type PageCategoryInput = {
   color?: InputMaybe<Enum_Pagecategory_Color>
   icon?: InputMaybe<Enum_Pagecategory_Icon>
-  iconHover?: InputMaybe<Enum_Pagecategory_Iconhover>
   pages?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>
-  priority?: InputMaybe<Scalars['Int']>
   publishedAt?: InputMaybe<Scalars['DateTime']>
   shortTitle?: InputMaybe<Scalars['String']>
   subcategories?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>
@@ -2611,7 +2605,6 @@ export type PageSubcategory = {
   localizations?: Maybe<PageSubcategoryRelationResponseCollection>
   moreLink?: Maybe<ComponentBlocksPageLink>
   pages?: Maybe<Array<Maybe<ComponentBlocksPageLink>>>
-  priority?: Maybe<Scalars['Int']>
   publishedAt?: Maybe<Scalars['DateTime']>
   title?: Maybe<Scalars['String']>
   updatedAt?: Maybe<Scalars['DateTime']>
@@ -2658,7 +2651,6 @@ export type PageSubcategoryFiltersInput = {
   not?: InputMaybe<PageSubcategoryFiltersInput>
   or?: InputMaybe<Array<InputMaybe<PageSubcategoryFiltersInput>>>
   pages?: InputMaybe<ComponentBlocksPageLinkFiltersInput>
-  priority?: InputMaybe<IntFilterInput>
   publishedAt?: InputMaybe<DateTimeFilterInput>
   title?: InputMaybe<StringFilterInput>
   updatedAt?: InputMaybe<DateTimeFilterInput>
@@ -2668,7 +2660,6 @@ export type PageSubcategoryInput = {
   icon?: InputMaybe<Enum_Pagesubcategory_Icon>
   moreLink?: InputMaybe<ComponentBlocksPageLinkInput>
   pages?: InputMaybe<Array<InputMaybe<ComponentBlocksPageLinkInput>>>
-  priority?: InputMaybe<Scalars['Int']>
   publishedAt?: InputMaybe<Scalars['DateTime']>
   title?: InputMaybe<Scalars['String']>
 }
@@ -2811,12 +2802,13 @@ export type QueryPagesArgs = {
 
 export type QueryTagArgs = {
   id?: InputMaybe<Scalars['ID']>
+  locale?: InputMaybe<Scalars['I18NLocaleCode']>
 }
 
 export type QueryTagsArgs = {
   filters?: InputMaybe<TagFiltersInput>
+  locale?: InputMaybe<Scalars['I18NLocaleCode']>
   pagination?: InputMaybe<PaginationArg>
-  publicationState?: InputMaybe<PublicationState>
   sort?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
 }
 
@@ -2902,18 +2894,17 @@ export type StringFilterInput = {
 
 export type Tag = {
   __typename?: 'Tag'
-  blogPosts?: Maybe<BlogPostRelationResponseCollection>
   createdAt?: Maybe<Scalars['DateTime']>
+  locale?: Maybe<Scalars['String']>
+  localizations?: Maybe<TagRelationResponseCollection>
   pageCategory?: Maybe<PageCategoryEntityResponse>
-  publishedAt?: Maybe<Scalars['DateTime']>
   title?: Maybe<Scalars['String']>
   updatedAt?: Maybe<Scalars['DateTime']>
 }
 
-export type TagBlogPostsArgs = {
-  filters?: InputMaybe<BlogPostFiltersInput>
+export type TagLocalizationsArgs = {
+  filters?: InputMaybe<TagFiltersInput>
   pagination?: InputMaybe<PaginationArg>
-  publicationState?: InputMaybe<PublicationState>
   sort?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
 }
 
@@ -2936,21 +2927,19 @@ export type TagEntityResponseCollection = {
 
 export type TagFiltersInput = {
   and?: InputMaybe<Array<InputMaybe<TagFiltersInput>>>
-  blogPosts?: InputMaybe<BlogPostFiltersInput>
   createdAt?: InputMaybe<DateTimeFilterInput>
   id?: InputMaybe<IdFilterInput>
+  locale?: InputMaybe<StringFilterInput>
+  localizations?: InputMaybe<TagFiltersInput>
   not?: InputMaybe<TagFiltersInput>
   or?: InputMaybe<Array<InputMaybe<TagFiltersInput>>>
   pageCategory?: InputMaybe<PageCategoryFiltersInput>
-  publishedAt?: InputMaybe<DateTimeFilterInput>
   title?: InputMaybe<StringFilterInput>
   updatedAt?: InputMaybe<DateTimeFilterInput>
 }
 
 export type TagInput = {
-  blogPosts?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>
   pageCategory?: InputMaybe<Scalars['ID']>
-  publishedAt?: InputMaybe<Scalars['DateTime']>
   title?: InputMaybe<Scalars['String']>
 }
 
@@ -3834,7 +3823,6 @@ export type LatestBlogsWithTagsQuery = {
             attributes?: {
               __typename?: 'Tag'
               title?: string | null
-              publishedAt?: any | null
               pageCategory?: {
                 __typename?: 'PageCategoryEntityResponse'
                 data?: {
@@ -3879,7 +3867,6 @@ export type LatestBlogPostEntityFragment = {
         attributes?: {
           __typename?: 'Tag'
           title?: string | null
-          publishedAt?: any | null
           pageCategory?: {
             __typename?: 'PageCategoryEntityResponse'
             data?: {
@@ -4909,7 +4896,6 @@ export type HomepageEntityFragment = {
               attributes?: {
                 __typename?: 'Tag'
                 title?: string | null
-                publishedAt?: any | null
                 pageCategory?: {
                   __typename?: 'PageCategoryEntityResponse'
                   data?: {
@@ -4954,7 +4940,6 @@ export type HomepageEntityFragment = {
               attributes?: {
                 __typename?: 'Tag'
                 title?: string | null
-                publishedAt?: any | null
                 pageCategory?: {
                   __typename?: 'PageCategoryEntityResponse'
                   data?: {
@@ -5135,7 +5120,6 @@ export type HomepageQuery = {
                   attributes?: {
                     __typename?: 'Tag'
                     title?: string | null
-                    publishedAt?: any | null
                     pageCategory?: {
                       __typename?: 'PageCategoryEntityResponse'
                       data?: {
@@ -5180,7 +5164,6 @@ export type HomepageQuery = {
                   attributes?: {
                     __typename?: 'Tag'
                     title?: string | null
-                    publishedAt?: any | null
                     pageCategory?: {
                       __typename?: 'PageCategoryEntityResponse'
                       data?: {
@@ -9475,7 +9458,6 @@ export const LatestBlogPostEntityFragmentDoc = gql`
         data {
           attributes {
             title
-            publishedAt
             pageCategory {
               data {
                 attributes {

--- a/next/graphql/queries/BlogPosts.graphql
+++ b/next/graphql/queries/BlogPosts.graphql
@@ -69,7 +69,6 @@ fragment LatestBlogPostEntity on BlogPostEntity {
       data {
         attributes {
           title
-          publishedAt
           pageCategory {
             data {
               attributes {

--- a/strapi/schema.graphql
+++ b/strapi/schema.graphql
@@ -1914,15 +1914,6 @@ enum ENUM_PAGECATEGORY_ICON {
   zp_vystavba_03
 }
 
-enum ENUM_PAGECATEGORY_ICONHOVER {
-  doprava_mapy_color_02
-  kultura_color_06
-  mesto_color_01
-  socialna_pomoc_color_04
-  vzdelavanie_color_05
-  zp_vystavba_color_03
-}
-
 enum ENUM_PAGESUBCATEGORY_ICON {
   aktivity_04
   byvanie_04
@@ -2416,7 +2407,8 @@ type Mutation {
   createPageLocalization(data: PageInput, id: ID, locale: I18NLocaleCode): PageEntityResponse
   createPageSubcategory(data: PageSubcategoryInput!, locale: I18NLocaleCode): PageSubcategoryEntityResponse
   createPageSubcategoryLocalization(data: PageSubcategoryInput, id: ID, locale: I18NLocaleCode): PageSubcategoryEntityResponse
-  createTag(data: TagInput!): TagEntityResponse
+  createTag(data: TagInput!, locale: I18NLocaleCode): TagEntityResponse
+  createTagLocalization(data: TagInput, id: ID, locale: I18NLocaleCode): TagEntityResponse
   createUploadFile(data: UploadFileInput!): UploadFileEntityResponse
   createUploadFolder(data: UploadFolderInput!): UploadFolderEntityResponse
 
@@ -2434,7 +2426,7 @@ type Mutation {
   deletePage(id: ID!, locale: I18NLocaleCode): PageEntityResponse
   deletePageCategory(id: ID!, locale: I18NLocaleCode): PageCategoryEntityResponse
   deletePageSubcategory(id: ID!, locale: I18NLocaleCode): PageSubcategoryEntityResponse
-  deleteTag(id: ID!): TagEntityResponse
+  deleteTag(id: ID!, locale: I18NLocaleCode): TagEntityResponse
   deleteUploadFile(id: ID!): UploadFileEntityResponse
   deleteUploadFolder(id: ID!): UploadFolderEntityResponse
 
@@ -2470,7 +2462,7 @@ type Mutation {
   updatePage(data: PageInput!, id: ID!, locale: I18NLocaleCode): PageEntityResponse
   updatePageCategory(data: PageCategoryInput!, id: ID!, locale: I18NLocaleCode): PageCategoryEntityResponse
   updatePageSubcategory(data: PageSubcategoryInput!, id: ID!, locale: I18NLocaleCode): PageSubcategoryEntityResponse
-  updateTag(data: TagInput!, id: ID!): TagEntityResponse
+  updateTag(data: TagInput!, id: ID!, locale: I18NLocaleCode): TagEntityResponse
   updateUploadFile(data: UploadFileInput!, id: ID!): UploadFileEntityResponse
   updateUploadFolder(data: UploadFolderInput!, id: ID!): UploadFolderEntityResponse
 
@@ -2496,7 +2488,7 @@ type Page {
   pageHeaderSections: [PagePageHeaderSectionsDynamicZone]
   parentPage: PageEntityResponse
   publishedAt: DateTime
-  relatedContents(filters: TagFiltersInput, pagination: PaginationArg = {}, publicationState: PublicationState = LIVE, sort: [String] = []): TagRelationResponseCollection
+  relatedContents(filters: TagFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): TagRelationResponseCollection
   sections: [PageSectionsDynamicZone]
   slug: String
   subtext: String
@@ -2508,11 +2500,9 @@ type PageCategory {
   color: ENUM_PAGECATEGORY_COLOR
   createdAt: DateTime
   icon: ENUM_PAGECATEGORY_ICON
-  iconHover: ENUM_PAGECATEGORY_ICONHOVER
   locale: String
   localizations(filters: PageCategoryFiltersInput, pagination: PaginationArg = {}, publicationState: PublicationState = LIVE, sort: [String] = []): PageCategoryRelationResponseCollection
   pages(filters: PageFiltersInput, pagination: PaginationArg = {}, publicationState: PublicationState = LIVE, sort: [String] = []): PageRelationResponseCollection
-  priority: Int
   publishedAt: DateTime
   shortTitle: String
   subcategories(filters: PageSubcategoryFiltersInput, pagination: PaginationArg = {}, publicationState: PublicationState = LIVE, sort: [String] = []): PageSubcategoryRelationResponseCollection
@@ -2539,14 +2529,12 @@ input PageCategoryFiltersInput {
   color: StringFilterInput
   createdAt: DateTimeFilterInput
   icon: StringFilterInput
-  iconHover: StringFilterInput
   id: IDFilterInput
   locale: StringFilterInput
   localizations: PageCategoryFiltersInput
   not: PageCategoryFiltersInput
   or: [PageCategoryFiltersInput]
   pages: PageFiltersInput
-  priority: IntFilterInput
   publishedAt: DateTimeFilterInput
   shortTitle: StringFilterInput
   subcategories: PageSubcategoryFiltersInput
@@ -2557,9 +2545,7 @@ input PageCategoryFiltersInput {
 input PageCategoryInput {
   color: ENUM_PAGECATEGORY_COLOR
   icon: ENUM_PAGECATEGORY_ICON
-  iconHover: ENUM_PAGECATEGORY_ICONHOVER
   pages: [ID]
-  priority: Int
   publishedAt: DateTime
   shortTitle: String
   subcategories: [ID]
@@ -2642,7 +2628,6 @@ type PageSubcategory {
   localizations(filters: PageSubcategoryFiltersInput, pagination: PaginationArg = {}, publicationState: PublicationState = LIVE, sort: [String] = []): PageSubcategoryRelationResponseCollection
   moreLink: ComponentBlocksPageLink
   pages(filters: ComponentBlocksPageLinkFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): [ComponentBlocksPageLink]
-  priority: Int
   publishedAt: DateTime
   title: String
   updatedAt: DateTime
@@ -2673,7 +2658,6 @@ input PageSubcategoryFiltersInput {
   not: PageSubcategoryFiltersInput
   or: [PageSubcategoryFiltersInput]
   pages: ComponentBlocksPageLinkFiltersInput
-  priority: IntFilterInput
   publishedAt: DateTimeFilterInput
   title: StringFilterInput
   updatedAt: DateTimeFilterInput
@@ -2683,7 +2667,6 @@ input PageSubcategoryInput {
   icon: ENUM_PAGESUBCATEGORY_ICON
   moreLink: ComponentBlocksPageLinkInput
   pages: [ComponentBlocksPageLinkInput]
-  priority: Int
   publishedAt: DateTime
   title: String
 }
@@ -2727,8 +2710,8 @@ type Query {
   pageSubcategories(filters: PageSubcategoryFiltersInput, locale: I18NLocaleCode, pagination: PaginationArg = {}, publicationState: PublicationState = LIVE, sort: [String] = []): PageSubcategoryEntityResponseCollection
   pageSubcategory(id: ID, locale: I18NLocaleCode): PageSubcategoryEntityResponse
   pages(filters: PageFiltersInput, locale: I18NLocaleCode, pagination: PaginationArg = {}, publicationState: PublicationState = LIVE, sort: [String] = []): PageEntityResponseCollection
-  tag(id: ID): TagEntityResponse
-  tags(filters: TagFiltersInput, pagination: PaginationArg = {}, publicationState: PublicationState = LIVE, sort: [String] = []): TagEntityResponseCollection
+  tag(id: ID, locale: I18NLocaleCode): TagEntityResponse
+  tags(filters: TagFiltersInput, locale: I18NLocaleCode, pagination: PaginationArg = {}, sort: [String] = []): TagEntityResponseCollection
   uploadFile(id: ID): UploadFileEntityResponse
   uploadFiles(filters: UploadFileFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): UploadFileEntityResponseCollection
   uploadFolder(id: ID): UploadFolderEntityResponse
@@ -2770,10 +2753,10 @@ input StringFilterInput {
 }
 
 type Tag {
-  blogPosts(filters: BlogPostFiltersInput, pagination: PaginationArg = {}, publicationState: PublicationState = LIVE, sort: [String] = []): BlogPostRelationResponseCollection
   createdAt: DateTime
+  locale: String
+  localizations(filters: TagFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): TagRelationResponseCollection
   pageCategory: PageCategoryEntityResponse
-  publishedAt: DateTime
   title: String
   updatedAt: DateTime
 }
@@ -2794,21 +2777,19 @@ type TagEntityResponseCollection {
 
 input TagFiltersInput {
   and: [TagFiltersInput]
-  blogPosts: BlogPostFiltersInput
   createdAt: DateTimeFilterInput
   id: IDFilterInput
+  locale: StringFilterInput
+  localizations: TagFiltersInput
   not: TagFiltersInput
   or: [TagFiltersInput]
   pageCategory: PageCategoryFiltersInput
-  publishedAt: DateTimeFilterInput
   title: StringFilterInput
   updatedAt: DateTimeFilterInput
 }
 
 input TagInput {
-  blogPosts: [ID]
   pageCategory: ID
-  publishedAt: DateTime
   title: String
 }
 

--- a/strapi/src/api/blog-post/content-types/blog-post/schema.json
+++ b/strapi/src/api/blog-post/content-types/blog-post/schema.json
@@ -4,7 +4,7 @@
   "info": {
     "singularName": "blog-post",
     "pluralName": "blog-posts",
-    "displayName": "Tlačové správy",
+    "displayName": "Články",
     "description": ""
   },
   "options": {

--- a/strapi/src/api/page-category/content-types/page-category/schema.json
+++ b/strapi/src/api/page-category/content-types/page-category/schema.json
@@ -64,30 +64,6 @@
         "kultura_06"
       ]
     },
-    "iconHover": {
-      "pluginOptions": {
-        "i18n": {
-          "localized": true
-        }
-      },
-      "type": "enumeration",
-      "enum": [
-        "mesto_color_01",
-        "doprava_mapy_color_02",
-        "zp_vystavba_color_03",
-        "socialna_pomoc_color_04",
-        "vzdelavanie_color_05",
-        "kultura_color_06"
-      ]
-    },
-    "priority": {
-      "pluginOptions": {
-        "i18n": {
-          "localized": true
-        }
-      },
-      "type": "integer"
-    },
     "pages": {
       "type": "relation",
       "relation": "oneToMany",

--- a/strapi/src/api/page-subcategory/content-types/page-subcategory/schema.json
+++ b/strapi/src/api/page-subcategory/content-types/page-subcategory/schema.json
@@ -24,14 +24,6 @@
       },
       "type": "string"
     },
-    "priority": {
-      "pluginOptions": {
-        "i18n": {
-          "localized": true
-        }
-      },
-      "type": "integer"
-    },
     "icon": {
       "pluginOptions": {
         "i18n": {

--- a/strapi/src/api/tag/content-types/tag/schema.json
+++ b/strapi/src/api/tag/content-types/tag/schema.json
@@ -8,22 +8,26 @@
     "description": ""
   },
   "options": {
-    "draftAndPublish": true
+    "draftAndPublish": false
   },
-  "pluginOptions": {},
+  "pluginOptions": {
+    "i18n": {
+      "localized": true
+    }
+  },
   "attributes": {
     "title": {
-      "type": "string"
+      "type": "string",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
     },
     "pageCategory": {
       "type": "relation",
       "relation": "oneToOne",
       "target": "api::page-category.page-category"
-    },
-    "blogPosts": {
-      "type": "relation",
-      "relation": "oneToMany",
-      "target": "api::blog-post.blog-post"
     }
   }
 }


### PR DESCRIPTION
Allow internationalisation for Tags content type. Closes #809 

Remove unused field in Page Category and Page Subcategory content types.