### PR TITLE
fix: change cert issuer to dns01 for all redirects

### DIFF
--- a/next/kubernetes/base/platbadane.ingress.yml
+++ b/next/kubernetes/base/platbadane.ingress.yml
@@ -6,7 +6,7 @@ metadata:
   labels:
     service: redirect
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt
+    cert-manager.io/cluster-issuer: letsencrypt-dns01
     cert-manager.io/issue-temporary-certificate: 'true'
     kubernetes.io/ingress.class: haproxy
     ingress.kubernetes.io/redirect-to: 'https://www.${HOSTNAME}/mesto-bratislava/dane-a-poplatky/dan-z-nehnutelnosti/digitalna-platba'

--- a/next/kubernetes/base/ukrajina.ingress.yml
+++ b/next/kubernetes/base/ukrajina.ingress.yml
@@ -6,7 +6,7 @@ metadata:
   labels:
     service: redirect
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt
+    cert-manager.io/cluster-issuer: letsencrypt-dns01
     cert-manager.io/issue-temporary-certificate: 'true'
     kubernetes.io/ingress.class: haproxy
     ingress.kubernetes.io/redirect-to: 'https://www.${HOSTNAME}/bratislava-pre-ukrajinu'


### PR DESCRIPTION
* change letsencrypt cluster issuer to dns01 websupport for all redirects. All redirects couldn't get normal certificate through http01 challenge. Changing it to dns01 seems to work.