### PR TITLE
fix: change $HOSTNAME to $BRATISKA_HOSTNAME variable in k8 ingresses

### DIFF
--- a/next/kubernetes/base/ingress.yml
+++ b/next/kubernetes/base/ingress.yml
@@ -12,11 +12,11 @@ metadata:
 spec:
   tls:
     - hosts:
-        - ${HOSTNAME}
-        - www.${HOSTNAME}
+        - ${BRATISKA_HOSTNAME}
+        - www.${BRATISKA_HOSTNAME}
       secretName: ${BUILD_REPOSITORY_NAME}-tls
   rules:
-    - host: ${HOSTNAME}
+    - host: ${BRATISKA_HOSTNAME}
       http:
         paths:
           - path: /
@@ -26,7 +26,7 @@ spec:
                 name: ${BUILD_REPOSITORY_NAME}-app
                 port:
                   number: 80
-    - host: www.${HOSTNAME}
+    - host: www.${BRATISKA_HOSTNAME}
       http:
         paths:
           - path: /

--- a/strapi/kubernetes/base/ingress.yml
+++ b/strapi/kubernetes/base/ingress.yml
@@ -12,11 +12,11 @@ metadata:
 spec:
   tls:
     - hosts:
-        - ${HOSTNAME}
+        - ${BRATISKA_HOSTNAME}
         - ${BUILD_REPOSITORY_NAME}-meilisearch.${DEPLOYMENT_ENV}bratislava.sk
       secretName: ${BUILD_REPOSITORY_NAME}-tls
   rules:
-    - host: ${HOSTNAME}
+    - host: ${BRATISKA_HOSTNAME}
       http:
         paths:
           - path: /


### PR DESCRIPTION
* bratiska-cli old version were using $HOSTNAME to build ingress URLs. This is env variable is reserved also for names of systems running it. Therefore, there was conflict between env names and wrong variable value were inserted into ingress URL