### PR TITLE
#934: implement Blog Posts list by tags, prepared for future filtering

### DIFF
--- a/next/backend/graphql/index.ts
+++ b/next/backend/graphql/index.ts
@@ -55,6 +55,7 @@ export type AlertRelationResponseCollection = {
 
 export type BlogPost = {
   __typename?: 'BlogPost'
+  addedAt?: Maybe<Scalars['DateTime']>
   author?: Maybe<UsersPermissionsUserEntityResponse>
   coverImage?: Maybe<UploadFileEntityResponse>
   createdAt?: Maybe<Scalars['DateTime']>
@@ -96,6 +97,7 @@ export type BlogPostEntityResponseCollection = {
 }
 
 export type BlogPostFiltersInput = {
+  addedAt?: InputMaybe<DateTimeFilterInput>
   and?: InputMaybe<Array<InputMaybe<BlogPostFiltersInput>>>
   author?: InputMaybe<UsersPermissionsUserFiltersInput>
   createdAt?: InputMaybe<DateTimeFilterInput>
@@ -115,6 +117,7 @@ export type BlogPostFiltersInput = {
 }
 
 export type BlogPostInput = {
+  addedAt?: InputMaybe<Scalars['DateTime']>
   author?: InputMaybe<Scalars['ID']>
   coverImage?: InputMaybe<Scalars['ID']>
   date_added?: InputMaybe<Scalars['DateTime']>
@@ -954,6 +957,20 @@ export type ComponentSectionsBanner = {
   variant: Enum_Componentsectionsbanner_Variant
 }
 
+export type ComponentSectionsBlogPostsList = {
+  __typename?: 'ComponentSectionsBlogPostsList'
+  id: Scalars['ID']
+  tags?: Maybe<TagRelationResponseCollection>
+  text?: Maybe<Scalars['String']>
+  title?: Maybe<Scalars['String']>
+}
+
+export type ComponentSectionsBlogPostsListTagsArgs = {
+  filters?: InputMaybe<TagFiltersInput>
+  pagination?: InputMaybe<PaginationArg>
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
+}
+
 export type ComponentSectionsCalculator = {
   __typename?: 'ComponentSectionsCalculator'
   another_adult_value?: Maybe<Scalars['Float']>
@@ -1788,6 +1805,7 @@ export type GenericMorph =
   | ComponentSectionsAccordion
   | ComponentSectionsArticlesList
   | ComponentSectionsBanner
+  | ComponentSectionsBlogPostsList
   | ComponentSectionsCalculator
   | ComponentSectionsColumnedText
   | ComponentSectionsComparisonSection
@@ -2652,6 +2670,7 @@ export type PageSectionsDynamicZone =
   | ComponentSectionsAccordion
   | ComponentSectionsArticlesList
   | ComponentSectionsBanner
+  | ComponentSectionsBlogPostsList
   | ComponentSectionsCalculator
   | ComponentSectionsColumnedText
   | ComponentSectionsComparisonSection
@@ -6453,6 +6472,15 @@ export type PageBySlugQuery = {
               } | null
             }
           | {
+              __typename: 'ComponentSectionsBlogPostsList'
+              title?: string | null
+              text?: string | null
+              tags?: {
+                __typename?: 'TagRelationResponseCollection'
+                data: Array<{ __typename?: 'TagEntity'; id?: string | null }>
+              } | null
+            }
+          | {
               __typename: 'ComponentSectionsCalculator'
               hasBackground?: boolean | null
               single_adult_value?: number | null
@@ -7280,6 +7308,15 @@ export type PageEntityFragment = {
           } | null
         }
       | {
+          __typename: 'ComponentSectionsBlogPostsList'
+          title?: string | null
+          text?: string | null
+          tags?: {
+            __typename?: 'TagRelationResponseCollection'
+            data: Array<{ __typename?: 'TagEntity'; id?: string | null }>
+          } | null
+        }
+      | {
           __typename: 'ComponentSectionsCalculator'
           hasBackground?: boolean | null
           single_adult_value?: number | null
@@ -8023,6 +8060,16 @@ export type ArticlesListSectionFragment = {
   } | null
 }
 
+export type BlogPostsListSectionFragment = {
+  __typename?: 'ComponentSectionsBlogPostsList'
+  title?: string | null
+  text?: string | null
+  tags?: {
+    __typename?: 'TagRelationResponseCollection'
+    data: Array<{ __typename?: 'TagEntity'; id?: string | null }>
+  } | null
+}
+
 export type IconTitleDescSectionFragment = {
   __typename?: 'ComponentSectionsIconTitleDesc'
   title?: string | null
@@ -8752,6 +8799,16 @@ type Sections_ComponentSectionsBanner_Fragment = {
   } | null
 }
 
+type Sections_ComponentSectionsBlogPostsList_Fragment = {
+  __typename: 'ComponentSectionsBlogPostsList'
+  title?: string | null
+  text?: string | null
+  tags?: {
+    __typename?: 'TagRelationResponseCollection'
+    data: Array<{ __typename?: 'TagEntity'; id?: string | null }>
+  } | null
+}
+
 type Sections_ComponentSectionsCalculator_Fragment = {
   __typename: 'ComponentSectionsCalculator'
   hasBackground?: boolean | null
@@ -9234,6 +9291,7 @@ export type SectionsFragment =
   | Sections_ComponentSectionsAccordion_Fragment
   | Sections_ComponentSectionsArticlesList_Fragment
   | Sections_ComponentSectionsBanner_Fragment
+  | Sections_ComponentSectionsBlogPostsList_Fragment
   | Sections_ComponentSectionsCalculator_Fragment
   | Sections_ComponentSectionsColumnedText_Fragment
   | Sections_ComponentSectionsComparisonSection_Fragment
@@ -9753,6 +9811,17 @@ export const ArticlesListSectionFragmentDoc = gql`
     filtering
   }
 `
+export const BlogPostsListSectionFragmentDoc = gql`
+  fragment BlogPostsListSection on ComponentSectionsBlogPostsList {
+    title
+    text
+    tags {
+      data {
+        id
+      }
+    }
+  }
+`
 export const OrganizationalStructureSectionFragmentDoc = gql`
   fragment OrganizationalStructureSection on ComponentSectionsOrganizationalStructure {
     title
@@ -9981,6 +10050,9 @@ export const SectionsFragmentDoc = gql`
     ... on ComponentSectionsArticlesList {
       ...ArticlesListSection
     }
+    ... on ComponentSectionsBlogPostsList {
+      ...BlogPostsListSection
+    }
     ... on ComponentSectionsOrganizationalStructure {
       ...OrganizationalStructureSection
     }
@@ -10017,6 +10089,7 @@ export const SectionsFragmentDoc = gql`
   ${VideosSectionFragmentDoc}
   ${NumericalListSectionFragmentDoc}
   ${ArticlesListSectionFragmentDoc}
+  ${BlogPostsListSectionFragmentDoc}
   ${OrganizationalStructureSectionFragmentDoc}
   ${ProsAndConsSectionFragmentDoc}
   ${ComparisonSectionFragmentDoc}

--- a/next/backend/graphql/queries/Sections.graphql
+++ b/next/backend/graphql/queries/Sections.graphql
@@ -122,6 +122,16 @@ fragment ArticlesListSection on ComponentSectionsArticlesList {
   filtering
 }
 
+fragment BlogPostsListSection on ComponentSectionsBlogPostsList {
+  title
+  text
+  tags {
+    data {
+      id
+    }
+  }
+}
+
 fragment IconTitleDescSection on ComponentSectionsIconTitleDesc {
   title
   hasBackground
@@ -488,6 +498,10 @@ fragment Sections on PageSectionsDynamicZone {
 
   ... on ComponentSectionsArticlesList {
     ...ArticlesListSection
+  }
+
+  ... on ComponentSectionsBlogPostsList {
+    ...BlogPostsListSection
   }
 
   ... on ComponentSectionsOrganizationalStructure {

--- a/next/backend/meili/fetchers/blogPostsFetcherReactQuery.ts
+++ b/next/backend/meili/fetchers/blogPostsFetcherReactQuery.ts
@@ -1,0 +1,101 @@
+import { LatestBlogPostEntityFragment } from '@backend/graphql'
+
+import { meiliClient } from '../meiliClient'
+import { BlogPostMeili, SearchIndexWrapped } from '../types'
+import { getMeilisearchPageOptions, unwrapFromSearchIndex } from '../utils'
+
+export type BlogPostsFilters = {
+  search: string
+  pageSize: number
+  page: number
+  tagIds: string[]
+}
+
+export const blogPostsDefaultFilters: BlogPostsFilters = {
+  search: '',
+  pageSize: 9,
+  page: 1,
+  tagIds: [],
+}
+
+export const getBlogPostsQueryKey = (filters: BlogPostsFilters, locale: string) => [
+  'BlogPost',
+  filters,
+  locale,
+]
+
+export const blogPostsFetcher = (filters: BlogPostsFilters, locale: string) => {
+  // Tmp fix:
+  // We sort first in meilisearch by publish date because date_added is not required and then in FE by date_added
+  // TODO make date_added require
+  return meiliClient
+    .index('search_index')
+    .search<SearchIndexWrapped<'blog-post', BlogPostMeili>>(filters.search, {
+      ...getMeilisearchPageOptions({ page: filters.page, pageSize: filters.pageSize }),
+      filter: [
+        'type = "blog-post"',
+        `locale = ${locale}`,
+        filters.tagIds.length > 0 ? `blog-post.tag.id IN [${filters.tagIds.join(',')}]` : '',
+      ],
+      sort: ['blog-post.publishedAtTimestamp:desc'],
+      attributesToRetrieve: [
+        // Only properties that are required to display listing are retrieved
+        'blog-post.id',
+        'blog-post.title',
+        'blog-post.text',
+        'blog-post.slug',
+        'blog-post.coverImage.url',
+        'blog-post.publishedAt',
+        'blog-post.date_added',
+        'blog-post.tag.title',
+        'blog-post.tag.pageCategory.color',
+        'blog-post.tag.pageCategory.shortTitle',
+      ],
+    })
+    .then(unwrapFromSearchIndex('blog-post'))
+    .then((response) => {
+      const hits = response.hits
+        .map((blogPost) => {
+          return {
+            attributes: {
+              title: blogPost.title,
+              slug: blogPost.slug,
+              publishedAt: blogPost.publishedAt,
+              date_added: blogPost.date_added,
+              coverImage: {
+                data: {
+                  attributes: {
+                    url: blogPost.coverImage?.url,
+                  },
+                },
+              },
+              tag: {
+                data: {
+                  attributes: {
+                    title: blogPost.tag?.title,
+                    pageCategory: {
+                      data: {
+                        attributes: {
+                          color: blogPost.tag?.pageCategory?.color,
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          } as LatestBlogPostEntityFragment
+        })
+        .sort((a, b) => {
+          if (!a.attributes?.date_added || !b.attributes?.date_added) {
+            return 0
+          }
+          return (
+            new Date(b.attributes.date_added).getTime() -
+            new Date(a.attributes.date_added).getTime()
+          )
+        })
+
+      return { ...response, hits }
+    })
+}

--- a/next/components/molecules/Sections.tsx
+++ b/next/components/molecules/Sections.tsx
@@ -1,5 +1,6 @@
 import { SectionsFragment } from '@backend/graphql'
 import { SectionContainer } from '@bratislava/ui-bratislava/SectionContainer/SectionContainer'
+import BlogPostsByTags from '@components/molecules/sections/general/ArticlesListSection/BlogPostsByTags'
 import FeaturedBlogPostsSection from '@components/molecules/sections/pageHeader/FeaturedBlogPostsSection'
 import cx from 'classnames'
 import * as React from 'react'
@@ -72,6 +73,9 @@ const SectionContent = ({ section }: { section: SectionsFragment }) => {
 
     case 'ComponentSectionsArticlesList':
       return <ArticlesListSection section={section} />
+
+    case 'ComponentSectionsBlogPostsList':
+      return <BlogPostsByTags section={section} />
 
     case 'ComponentSectionsOrganizationalStructure':
       return <OrganizationalStructureSection section={section} />

--- a/next/components/molecules/sections/general/ArticlesListSection/BlogPostsByTags.tsx
+++ b/next/components/molecules/sections/general/ArticlesListSection/BlogPostsByTags.tsx
@@ -1,0 +1,100 @@
+import { BlogPostsListSectionFragment } from '@backend/graphql'
+import {
+  blogPostsDefaultFilters,
+  blogPostsFetcher,
+  getBlogPostsQueryKey,
+} from '@backend/meili/fetchers/blogPostsFetcherReactQuery'
+import BlogPostCard from '@components/molecules/presentation/BlogPostCard'
+import Pagination from '@components/ui/Pagination/Pagination'
+import { useQuery } from '@tanstack/react-query'
+import { getCategoryColorLocalStyle } from '@utils/colors'
+import { generateImageSizes } from '@utils/generateImageSizes'
+import { isDefined } from '@utils/isDefined'
+import { getNumericLocalDate } from '@utils/local-date'
+import { useRoutePreservedState } from '@utils/useRoutePreservedState'
+import { useLocale, useTranslations } from 'next-intl'
+import React from 'react'
+
+const imageSizes = generateImageSizes({ default: '100vw', md: '50vw', lg: '33vw' })
+
+type Props = {
+  section: BlogPostsListSectionFragment
+}
+
+const BlogPostsByTags = ({ section }: Props) => {
+  const t = useTranslations()
+  const locale = useLocale()
+
+  const { title, text, tags } = section
+
+  const tagIds = tags?.data.map((tag) => tag.id).filter(isDefined) ?? []
+
+  const [filters, setFilters] = useRoutePreservedState({
+    ...blogPostsDefaultFilters,
+    tagIds,
+  })
+
+  // TODO prefetch section
+  const { data } = useQuery({
+    queryKey: getBlogPostsQueryKey(filters, locale),
+    queryFn: () => blogPostsFetcher(filters, locale),
+    keepPreviousData: true,
+  })
+
+  const handlePageChange = (page: number) => {
+    setFilters({ ...filters, page })
+  }
+
+  return (
+    <div className="flex flex-col gap-8">
+      {title || text ? (
+        <div className="flex flex-col gap-2">
+          {title && <h2 className="text-h2">{title}</h2>}
+          {text && <div>{text}</div>}
+        </div>
+      ) : null}
+      <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
+        {data?.hits.map((card) => {
+          if (!card.attributes) return null
+
+          // TODO refactor sections that use BlogPostCard - it needs too much duplicate code while passing props
+          const {
+            title: blogPostTitle,
+            slug,
+            coverImage,
+            tag,
+            date_added,
+            publishedAt,
+          } = card.attributes
+          const tagColor = tag?.data?.attributes?.pageCategory?.data?.attributes?.color
+          const tagTitle = tag?.data?.attributes?.title
+
+          return (
+            <BlogPostCard
+              key={card.id}
+              style={getCategoryColorLocalStyle({ color: tagColor })}
+              variant="shadow"
+              date={getNumericLocalDate(date_added ?? publishedAt)}
+              tag={tagTitle ?? undefined}
+              title={blogPostTitle ?? ''}
+              linkProps={{ children: t('readMore'), href: `/blog/${slug}` }}
+              imgSrc={coverImage?.data?.attributes?.url}
+              imgSizes={imageSizes}
+            />
+          )
+        })}
+      </div>
+
+      {data?.estimatedTotalHits && (
+        <Pagination
+          key={filters.search}
+          totalCount={Math.ceil(data.estimatedTotalHits / filters.pageSize)}
+          currentPage={filters.page}
+          onPageChange={handlePageChange}
+        />
+      )}
+    </div>
+  )
+}
+
+export default BlogPostsByTags

--- a/next/utils/useRoutePreservedState.ts
+++ b/next/utils/useRoutePreservedState.ts
@@ -1,0 +1,36 @@
+// eslint-disable-next-line eslint-comments/disable-enable-pair
+/* eslint-disable no-restricted-globals */
+import { useEffect, useState } from 'react'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const historyStateKeyStateMap = new Map<string, any>()
+
+/**
+ * This hook is copied from MKB project: https://github.com/bratislava/mestskakniznica.sk/blob/master/next/utils/useRoutePreservedState.ts
+ *
+ * Synchronizes state with current history state key. If user goes back, the state is retrieved from
+ * cache. If user visits the same page in a new instance, historical state is not retrieved.
+ *
+ * Limitation: Can be used only once on one page (otherwise id must be implemented).
+ */
+export const useRoutePreservedState = <T>(defaultValue: T) => {
+  const historyStateKey =
+    typeof history === 'undefined' ? null : (history.state as { key: string }).key
+
+  const getDefaultState = () => {
+    if (!historyStateKey) {
+      return defaultValue
+    }
+
+    const historyData = historyStateKeyStateMap.get(historyStateKey) as T
+    return historyData ?? defaultValue
+  }
+  const useStateReturnValue = useState<T>(getDefaultState())
+  const [state] = useStateReturnValue
+
+  useEffect(() => {
+    historyStateKeyStateMap.set((history.state as { key: string }).key, state)
+  }, [state])
+
+  return useStateReturnValue
+}

--- a/strapi/config/plugins.meilisearch.config.ts
+++ b/strapi/config/plugins.meilisearch.config.ts
@@ -35,6 +35,7 @@ const searchIndexSettings = {
     'type',
     // Page + Blog post
     'locale',
+    'blog-post.tag.id',
   ],
   sortableAttributes: [
     // Article
@@ -67,6 +68,7 @@ const config = {
     indexName: 'search_index',
     entriesQuery: {
       locale: 'all',
+      populate: ['tag.pageCategory', 'coverImage'],
     },
     settings: searchIndexSettings,
     transformEntry: ({ entry }) =>

--- a/strapi/schema.graphql
+++ b/strapi/schema.graphql
@@ -44,6 +44,7 @@ type AlertRelationResponseCollection {
 }
 
 type BlogPost {
+  addedAt: DateTime
   author: UsersPermissionsUserEntityResponse
   coverImage: UploadFileEntityResponse
   createdAt: DateTime
@@ -75,6 +76,7 @@ type BlogPostEntityResponseCollection {
 }
 
 input BlogPostFiltersInput {
+  addedAt: DateTimeFilterInput
   and: [BlogPostFiltersInput]
   author: UsersPermissionsUserFiltersInput
   createdAt: DateTimeFilterInput
@@ -94,6 +96,7 @@ input BlogPostFiltersInput {
 }
 
 input BlogPostInput {
+  addedAt: DateTime
   author: ID
   coverImage: ID
   date_added: DateTime
@@ -1054,6 +1057,29 @@ input ComponentSectionsBannerInput {
   tertiaryLink: ComponentBlocksCommonLinkInput
   title: String
   variant: ENUM_COMPONENTSECTIONSBANNER_VARIANT
+}
+
+type ComponentSectionsBlogPostsList {
+  id: ID!
+  tags(filters: TagFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): TagRelationResponseCollection
+  text: String
+  title: String
+}
+
+input ComponentSectionsBlogPostsListFiltersInput {
+  and: [ComponentSectionsBlogPostsListFiltersInput]
+  not: ComponentSectionsBlogPostsListFiltersInput
+  or: [ComponentSectionsBlogPostsListFiltersInput]
+  tags: TagFiltersInput
+  text: StringFilterInput
+  title: StringFilterInput
+}
+
+input ComponentSectionsBlogPostsListInput {
+  id: ID
+  tags: [ID]
+  text: String
+  title: String
 }
 
 type ComponentSectionsCalculator {
@@ -2201,7 +2227,7 @@ type GeneralRelationResponseCollection {
   data: [GeneralEntity!]!
 }
 
-union GenericMorph = Alert | BlogPost | ComponentAccordionItemsFlatText | ComponentAccordionItemsInstitution | ComponentAccordionItemsInstitutionNarrow | ComponentBlocksBlogPostLink | ComponentBlocksBookmarkLink | ComponentBlocksCommonLink | ComponentBlocksComparisonCard | ComponentBlocksComparisonItem | ComponentBlocksDocListExtensions | ComponentBlocksFile | ComponentBlocksFileItem | ComponentBlocksFooterColumn | ComponentBlocksFooterSection | ComponentBlocksGalleryItem | ComponentBlocksHomepageBookmark | ComponentBlocksHomepageHighlightsItem | ComponentBlocksIconWithTitleAndDescription | ComponentBlocksInBa | ComponentBlocksNumericalListItem | ComponentBlocksPageLink | ComponentBlocksProsAndConsCard | ComponentBlocksSpaceInfo | ComponentBlocksSubpage | ComponentBlocksTimelineItem | ComponentBlocksTopServicesItem | ComponentBlocksVideo | ComponentGeneralHeader | ComponentGeneralHeaderLink | ComponentMenuMenuItem | ComponentMenuMenuLink | ComponentMenuMenuSection | ComponentOsItemsAdvancedAccordionDepartment | ComponentOsItemsAdvancedAccordionItem | ComponentOsItemsAdvancedAccordionSubItem | ComponentOsItemsAdvancedAccordionSubSubItem | ComponentSectionsAccordion | ComponentSectionsArticlesList | ComponentSectionsBanner | ComponentSectionsCalculator | ComponentSectionsColumnedText | ComponentSectionsComparisonSection | ComponentSectionsContact | ComponentSectionsDivider | ComponentSectionsDocumentList | ComponentSectionsFeaturedBlogPosts | ComponentSectionsFileList | ComponentSectionsGallery | ComponentSectionsHomepageEvents | ComponentSectionsHomepageHighlights | ComponentSectionsHomepageMayorAndCouncil | ComponentSectionsHomepageTabs | ComponentSectionsIconTitleDesc | ComponentSectionsIframe | ComponentSectionsLinks | ComponentSectionsNarrowText | ComponentSectionsNewsletter | ComponentSectionsNumericalList | ComponentSectionsOfficialBoard | ComponentSectionsOrganizationalStructure | ComponentSectionsProsAndConsSection | ComponentSectionsSpace | ComponentSectionsSubpageList | ComponentSectionsTextWithImage | ComponentSectionsTimeline | ComponentSectionsTopServices | ComponentSectionsVideos | ComponentSectionsWaves | Footer | General | Homepage | I18NLocale | Menu | Page | PageCategory | PageSubcategory | Tag | UploadFile | UploadFolder | UsersPermissionsPermission | UsersPermissionsRole | UsersPermissionsUser | Vzn
+union GenericMorph = Alert | BlogPost | ComponentAccordionItemsFlatText | ComponentAccordionItemsInstitution | ComponentAccordionItemsInstitutionNarrow | ComponentBlocksBlogPostLink | ComponentBlocksBookmarkLink | ComponentBlocksCommonLink | ComponentBlocksComparisonCard | ComponentBlocksComparisonItem | ComponentBlocksDocListExtensions | ComponentBlocksFile | ComponentBlocksFileItem | ComponentBlocksFooterColumn | ComponentBlocksFooterSection | ComponentBlocksGalleryItem | ComponentBlocksHomepageBookmark | ComponentBlocksHomepageHighlightsItem | ComponentBlocksIconWithTitleAndDescription | ComponentBlocksInBa | ComponentBlocksNumericalListItem | ComponentBlocksPageLink | ComponentBlocksProsAndConsCard | ComponentBlocksSpaceInfo | ComponentBlocksSubpage | ComponentBlocksTimelineItem | ComponentBlocksTopServicesItem | ComponentBlocksVideo | ComponentGeneralHeader | ComponentGeneralHeaderLink | ComponentMenuMenuItem | ComponentMenuMenuLink | ComponentMenuMenuSection | ComponentOsItemsAdvancedAccordionDepartment | ComponentOsItemsAdvancedAccordionItem | ComponentOsItemsAdvancedAccordionSubItem | ComponentOsItemsAdvancedAccordionSubSubItem | ComponentSectionsAccordion | ComponentSectionsArticlesList | ComponentSectionsBanner | ComponentSectionsBlogPostsList | ComponentSectionsCalculator | ComponentSectionsColumnedText | ComponentSectionsComparisonSection | ComponentSectionsContact | ComponentSectionsDivider | ComponentSectionsDocumentList | ComponentSectionsFeaturedBlogPosts | ComponentSectionsFileList | ComponentSectionsGallery | ComponentSectionsHomepageEvents | ComponentSectionsHomepageHighlights | ComponentSectionsHomepageMayorAndCouncil | ComponentSectionsHomepageTabs | ComponentSectionsIconTitleDesc | ComponentSectionsIframe | ComponentSectionsLinks | ComponentSectionsNarrowText | ComponentSectionsNewsletter | ComponentSectionsNumericalList | ComponentSectionsOfficialBoard | ComponentSectionsOrganizationalStructure | ComponentSectionsProsAndConsSection | ComponentSectionsSpace | ComponentSectionsSubpageList | ComponentSectionsTextWithImage | ComponentSectionsTimeline | ComponentSectionsTopServices | ComponentSectionsVideos | ComponentSectionsWaves | Footer | General | Homepage | I18NLocale | Menu | Page | PageCategory | PageSubcategory | Tag | UploadFile | UploadFolder | UsersPermissionsPermission | UsersPermissionsRole | UsersPermissionsUser | Vzn
 
 type Homepage {
   bookmarkTourists: ComponentBlocksHomepageBookmark
@@ -2711,7 +2737,7 @@ type PageRelationResponseCollection {
   data: [PageEntity!]!
 }
 
-union PageSectionsDynamicZone = ComponentSectionsAccordion | ComponentSectionsArticlesList | ComponentSectionsBanner | ComponentSectionsCalculator | ComponentSectionsColumnedText | ComponentSectionsComparisonSection | ComponentSectionsContact | ComponentSectionsDivider | ComponentSectionsDocumentList | ComponentSectionsFeaturedBlogPosts | ComponentSectionsFileList | ComponentSectionsGallery | ComponentSectionsIconTitleDesc | ComponentSectionsIframe | ComponentSectionsLinks | ComponentSectionsNarrowText | ComponentSectionsNewsletter | ComponentSectionsNumericalList | ComponentSectionsOfficialBoard | ComponentSectionsOrganizationalStructure | ComponentSectionsProsAndConsSection | ComponentSectionsSpace | ComponentSectionsTextWithImage | ComponentSectionsTimeline | ComponentSectionsVideos | ComponentSectionsWaves | Error
+union PageSectionsDynamicZone = ComponentSectionsAccordion | ComponentSectionsArticlesList | ComponentSectionsBanner | ComponentSectionsBlogPostsList | ComponentSectionsCalculator | ComponentSectionsColumnedText | ComponentSectionsComparisonSection | ComponentSectionsContact | ComponentSectionsDivider | ComponentSectionsDocumentList | ComponentSectionsFeaturedBlogPosts | ComponentSectionsFileList | ComponentSectionsGallery | ComponentSectionsIconTitleDesc | ComponentSectionsIframe | ComponentSectionsLinks | ComponentSectionsNarrowText | ComponentSectionsNewsletter | ComponentSectionsNumericalList | ComponentSectionsOfficialBoard | ComponentSectionsOrganizationalStructure | ComponentSectionsProsAndConsSection | ComponentSectionsSpace | ComponentSectionsTextWithImage | ComponentSectionsTimeline | ComponentSectionsVideos | ComponentSectionsWaves | Error
 
 scalar PageSectionsDynamicZoneInput
 

--- a/strapi/src/api/blog-post/content-types/blog-post/schema.json
+++ b/strapi/src/api/blog-post/content-types/blog-post/schema.json
@@ -8,8 +8,6 @@
     "description": ""
   },
   "options": {
-    "increments": true,
-    "timestamps": true,
     "draftAndPublish": true
   },
   "pluginOptions": {
@@ -100,6 +98,14 @@
         "sections.numerical-list",
         "sections.gallery"
       ]
+    },
+    "addedAt": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": false
+        }
+      },
+      "type": "datetime"
     }
   }
 }

--- a/strapi/src/api/page/content-types/page/schema.json
+++ b/strapi/src/api/page/content-types/page/schema.json
@@ -69,25 +69,13 @@
         }
       },
       "type": "enumeration",
-      "enum": [
-        "red",
-        "blue",
-        "green",
-        "yellow",
-        "purple",
-        "brown"
-      ]
+      "enum": ["red", "blue", "green", "yellow", "purple", "brown"]
     },
     "pageBackgroundImage": {
       "type": "media",
       "multiple": false,
       "required": false,
-      "allowedTypes": [
-        "images",
-        "files",
-        "videos",
-        "audios"
-      ],
+      "allowedTypes": ["images", "files", "videos", "audios"],
       "pluginOptions": {
         "i18n": {
           "localized": true
@@ -111,9 +99,7 @@
         }
       },
       "type": "dynamiczone",
-      "components": [
-        "sections.subpage-list"
-      ]
+      "components": ["sections.subpage-list"]
     },
     "sections": {
       "pluginOptions": {
@@ -126,6 +112,7 @@
         "sections.accordion",
         "sections.articles-list",
         "sections.banner",
+        "sections.blog-posts-list",
         "sections.calculator",
         "sections.columned-text",
         "sections.comparison-section",

--- a/strapi/src/components/sections/blog-posts-list.json
+++ b/strapi/src/components/sections/blog-posts-list.json
@@ -1,0 +1,20 @@
+{
+  "collectionName": "components_sections_blog_posts_lists",
+  "info": {
+    "displayName": "Blog posts list"
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "text": {
+      "type": "text"
+    },
+    "tags": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::tag.tag"
+    }
+  }
+}


### PR DESCRIPTION
Note:
- add `addedAt` datetime field to BlogPosts, this filed will replace `date_added` and will be required in future (migration needed).