### PR TITLE
fix: change HOSTNAME to BRATISKA_HOSTNAME for redirects

### DIFF
--- a/next/kubernetes/base/ukrajina.ingress.yml
+++ b/next/kubernetes/base/ukrajina.ingress.yml
@@ -9,7 +9,7 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-dns01
     cert-manager.io/issue-temporary-certificate: 'true'
     kubernetes.io/ingress.class: haproxy
-    ingress.kubernetes.io/redirect-to: 'https://www.${HOSTNAME}/bratislava-pre-ukrajinu'
+    ingress.kubernetes.io/redirect-to: 'https://www.${BRATISKA_HOSTNAME}/bratislava-pre-ukrajinu'
 spec:
   tls:
     - hosts:


### PR DESCRIPTION
Change env variable HOSTNAME to BRATISKA_HOSTNAME for all redirects that are in bratislava.sk