### PR TITLE
Change IconTitleDescription from div to Markdown

### DIFF
--- a/next/components/ui/IconTitleDescItem/IconTitleDescItem.tsx
+++ b/next/components/ui/IconTitleDescItem/IconTitleDescItem.tsx
@@ -1,4 +1,5 @@
 import { UploadImageSrcEntityFragment } from '@backend/graphql'
+import Markdown from '@components/atoms/Markdown'
 import cx from 'classnames'
 import Image from 'next/image'
 
@@ -31,7 +32,7 @@ export const IconTitleDescItem = ({
       </div>
       <div className="flex w-full flex-col gap-2 text-center">
         <h3 className="text-h4">{title}</h3>
-        <div>{text}</div>
+        <Markdown content={text}/>
       </div>
     </li>
   )


### PR DESCRIPTION
Changed IconTitleDescription to render as <Markdown> instead of <div>.