### PR TITLE
Fix behaviour of ColumnedText allowing  more than 4 columns

### DIFF
--- a/next/components/ui/ColumnedText/ColumnedText.tsx
+++ b/next/components/ui/ColumnedText/ColumnedText.tsx
@@ -1,4 +1,5 @@
 import Markdown from '@components/atoms/Markdown'
+import cx from 'classnames'
 
 export interface ColumnedTextProps {
   className?: string
@@ -10,23 +11,16 @@ export const ColumnedText = ({ content, hasBackground }: ColumnedTextProps) => {
   const breakWord = '<break>'
   const columns = content.split(breakWord)
   if (!content) return null
-  const columnLength = columns.length >= 12 ? 12 : columns.length
   return (
     <div
-      // className={cx(className, 'columns-1 md:flex md:gap-7', {
-      //   'md:columns-2': columns.length === 2,
-      //   'md:columns-3': columns.length === 3,
-      //   'md:columns-4': columns.length === 4,
-      //   'md:columns-5': columns.length === 5,
-      //   'md:columns-6': columns.length === 6,
-      //   'md:columns-7': columns.length === 7,
-      //   'md:columns-8': columns.length === 8,
-      //   'md:columns-9': columns.length === 9,
-      //   'md:columns-10': columns.length === 10,
-      //   'md:columns-11': columns.length === 11,
-      //   'md:columns-12': columns.length >= 12,
-      // })}
-      className={`md:grid-cols-${columnLength} grid grid-cols-1 md:gap-7`}
+      className={cx('grid gap-6', {
+        'grid-cols-1': columns.length === 1,
+        'grid-cols-2': columns.length === 2,
+        'grid-cols-2 md:grid-cols-3': columns.length === 3,
+        'grid-cols-2 md:grid-cols-4': columns.length === 4,
+        'grid-cols-2 md:grid-cols-4 lg:grid-cols-5': columns.length === 5,
+        'grid-cols-2 md:grid-cols-4 lg:grid-cols-6': columns.length >= 6,
+      })}
     >
       {columns.map((column, i) => (
         <div key={i}>

--- a/next/components/ui/ColumnedText/ColumnedText.tsx
+++ b/next/components/ui/ColumnedText/ColumnedText.tsx
@@ -15,9 +15,9 @@ export const ColumnedText = ({ content, hasBackground }: ColumnedTextProps) => {
     <div
       className={cx('grid gap-6', {
         'grid-cols-1': columns.length === 1,
-        'grid-cols-2': columns.length === 2,
-        'grid-cols-2 md:grid-cols-3': columns.length === 3,
-        'grid-cols-2 md:grid-cols-4': columns.length === 4,
+        'grid-cols-1 md:grid-cols-2': columns.length === 2,
+        'grid-cols-1 md:grid-cols-3': columns.length === 3,
+        'grid-cols-1 md:grid-cols-4': columns.length === 4,
         'grid-cols-2 md:grid-cols-4 lg:grid-cols-5': columns.length === 5,
         'grid-cols-2 md:grid-cols-4 lg:grid-cols-6': columns.length >= 6,
       })}


### PR DESCRIPTION
New grid layout for different screen sizes:

lg allows at most 6 columns, stretches columns if fewer
md allows at most 4 columns, stretches columns if fewer
sm allows at most 2 columns, stretches columns if fewer
