### PR TITLE
Remove native arrows for accordion in Safari, Fix blog card in Safari

### DIFF
--- a/next/components/molecules/presentation/BlogPostCard.tsx
+++ b/next/components/molecules/presentation/BlogPostCard.tsx
@@ -20,7 +20,7 @@ type Props = {
 
 const BlogPostCard = ({ imgSrc, imgSizes, date, tag, title, text, linkProps, ...rest }: Props) => {
   return (
-    <CardBase className="h-full" {...rest}>
+    <CardBase {...rest}>
       <div className="relative aspect-16/10 shrink-0">
         {imgSrc ? (
           <Image src={imgSrc} alt="" sizes={imgSizes} fill className="object-cover" />

--- a/next/styles/globals.css
+++ b/next/styles/globals.css
@@ -226,6 +226,14 @@
   .form-group label.control-label {
     display: none;
   }
+
+  /* Remove native Safari arrows in accordions  */
+  details > summary {
+    list-style: none;
+  }
+  details > summary::-webkit-details-marker {
+    display: none;
+  }
 }
 
 /* styles for vertical timeline START */


### PR DESCRIPTION
I included two Safari fixes in this PR:

- https://github.com/bratislava/bratislava.sk/issues/1074
- https://github.com/bratislava/bratislava.sk/issues/1137

Added styles that remove any `list-style` and also style for removing the native Safari arrows.
Removed full height from CardBase, which was breaking styles on Safari on multiple occasions, while in Chrome it did not affect styles.