### PR TITLE
replace custom link icon by `hasLinkIcon` prop in buttons

### DIFF
--- a/next/components/molecules/presentation/BlogPostCard.tsx
+++ b/next/components/molecules/presentation/BlogPostCard.tsx
@@ -50,7 +50,13 @@ const BlogPostCard = ({ imgSrc, imgSizes, date, tag, title, text, linkProps, ...
             </Typography>
           )}
         </div>
-        <Button variant="black-link" stretched {...linkProps} className="mt-4 lg:mt-5" />
+        <Button
+          variant="black-link"
+          stretched
+          hasLinkIcon
+          {...linkProps}
+          className="mt-4 lg:mt-5"
+        />
       </CardContent>
     </CardBase>
   )

--- a/next/components/molecules/presentation/HomepageHorizontalCard.tsx
+++ b/next/components/molecules/presentation/HomepageHorizontalCard.tsx
@@ -38,7 +38,7 @@ const HomepageHorizontalCard = ({
             {title}
           </Typography>
         </div>
-        <Button variant="black-link" stretched {...linkProps} className="mt-6" />
+        <Button variant="black-link" stretched hasLinkIcon {...linkProps} className="mt-6" />
       </CardContent>
     </CardBase>
   )

--- a/next/components/molecules/presentation/MayorAndCouncilCard.tsx
+++ b/next/components/molecules/presentation/MayorAndCouncilCard.tsx
@@ -1,4 +1,3 @@
-import { ArrowRightIcon } from '@assets/ui-icons'
 import { Typography } from '@bratislava/component-library'
 import Button from '@components/forms/simple-components/Button'
 import CardBase from '@components/molecules/presentation/CardBase'
@@ -29,7 +28,7 @@ const MayorAndCouncilCard = ({ title, imageSrc, linkProps }: Props) => {
         <Typography type="h3" size="h4" className="mb-1.5 lg:mb-3">
           {title}
         </Typography>
-        <Button stretched variant="category-link" endIcon={<ArrowRightIcon />} {...linkProps} />
+        <Button stretched variant="category-link" hasLinkIcon {...linkProps} />
       </CardContent>
     </CardBase>
   )

--- a/next/components/molecules/sections/general/CalculatorSection/MinimumCalculator.tsx
+++ b/next/components/molecules/sections/general/CalculatorSection/MinimumCalculator.tsx
@@ -1,6 +1,5 @@
 import MinusIcon from '@assets/images/minus.svg'
 import PlusIcon from '@assets/images/plus.svg'
-import { ArrowRightIcon } from '@assets/ui-icons'
 import { Typography } from '@bratislava/component-library'
 import { Input } from '@bratislava/ui-bratislava/Input/Input'
 import Button from '@components/forms/simple-components/Button'
@@ -166,7 +165,7 @@ const MinimumCalculator = ({
           }}
         />
 
-        <Button variant="category-solid" type="submit" endIcon={<ArrowRightIcon />}>
+        <Button variant="category-solid" type="submit">
           {t('buttonText')}
         </Button>
       </form>

--- a/next/components/molecules/sections/homepage/EventsHomepageSection.tsx
+++ b/next/components/molecules/sections/homepage/EventsHomepageSection.tsx
@@ -1,4 +1,3 @@
-import { ArrowRightIcon } from '@assets/ui-icons'
 import { Typography } from '@bratislava/component-library'
 import Button from '@components/forms/simple-components/Button'
 import EventCard from '@components/molecules/presentation/EventCard'
@@ -61,7 +60,7 @@ export const EventsHomepageSection = () => {
             <Button
               variant="category-outline"
               {...getCommonLinkProps(eventsPageLink)}
-              endIcon={<ArrowRightIcon />}
+              hasLinkIcon
             />
           </div>
         )}

--- a/next/components/molecules/sections/homepage/HomepageTabs/TabPanelLatestNews.tsx
+++ b/next/components/molecules/sections/homepage/HomepageTabs/TabPanelLatestNews.tsx
@@ -1,4 +1,3 @@
-import { ArrowRightIcon } from '@assets/ui-icons'
 import { Typography } from '@bratislava/component-library'
 import Button from '@components/forms/simple-components/Button'
 import MLink from '@components/forms/simple-components/MLink'
@@ -120,7 +119,7 @@ const TabPanelLatestNews = () => {
         <div className="flex justify-center">
           <Button
             variant="category-outline"
-            endIcon={<ArrowRightIcon />}
+            hasLinkIcon
             {...getCommonLinkProps(tabs?.newsPageLink)}
           />
         </div>

--- a/next/components/molecules/sections/homepage/HomepageTabs/TabPanelOfficialBoard.tsx
+++ b/next/components/molecules/sections/homepage/HomepageTabs/TabPanelOfficialBoard.tsx
@@ -1,4 +1,3 @@
-import { ArrowRightIcon } from '@assets/ui-icons'
 import { ParsedOfficialBoardDocument } from '@backend/services/ginis'
 import Button from '@components/forms/simple-components/Button'
 import { OfficialBoardCard } from '@components/ui/OfficialBoardCard/OfficialBoardCard'
@@ -42,7 +41,7 @@ const TabPanelOfficialBoard = () => {
           <div className="flex justify-center">
             <Button
               variant="category-outline"
-              endIcon={<ArrowRightIcon />}
+              hasLinkIcon
               {...getCommonLinkProps(tabs.officialBoardPageLink)}
             />
           </div>

--- a/next/components/molecules/sections/homepage/HomepageTabs/TabPanelRoadClosures.tsx
+++ b/next/components/molecules/sections/homepage/HomepageTabs/TabPanelRoadClosures.tsx
@@ -1,4 +1,3 @@
-import { ArrowRightIcon } from '@assets/ui-icons'
 import { Typography } from '@bratislava/component-library'
 import Button from '@components/forms/simple-components/Button'
 import MLink from '@components/forms/simple-components/MLink'
@@ -130,7 +129,7 @@ const TabPanelRoadClosures = () => {
         <div className="flex justify-center">
           <Button
             variant="category-outline"
-            endIcon={<ArrowRightIcon />}
+            hasLinkIcon
             {...getCommonLinkProps(tabs.roadClosuresPageLink)}
           />
         </div>

--- a/next/components/ui/Banner/Banner.tsx
+++ b/next/components/ui/Banner/Banner.tsx
@@ -1,4 +1,3 @@
-import { ArrowRightIcon } from '@assets/ui-icons'
 import { CommonLinkFragment, Enum_Componentsectionsbanner_Variant } from '@backend/graphql'
 import { Typography } from '@bratislava/component-library'
 import Markdown from '@components/atoms/Markdown'
@@ -75,7 +74,7 @@ const Banner = ({
                 'text-white hover:text-white/80 focus:text-white/80': variant === 'dark',
               })}
               variant="category-link"
-              endIcon={<ArrowRightIcon />}
+              hasLinkIcon
               {...getCommonLinkProps(tertiaryLink)}
             />
           )}

--- a/next/components/ui/InBaCard/InBaCard.tsx
+++ b/next/components/ui/InBaCard/InBaCard.tsx
@@ -1,4 +1,3 @@
-import { ArrowRightIcon } from '@assets/ui-icons'
 import { Typography } from '@bratislava/component-library'
 import Button from '@components/forms/simple-components/Button'
 import CardBase from '@components/molecules/presentation/CardBase'
@@ -56,7 +55,7 @@ export const InBaCard = ({
           {title}
         </Typography>
         <Typography type="p">{content}</Typography>
-        <Button variant="black-link" {...linkProps} stretched endIcon={<ArrowRightIcon />} />
+        <Button variant="black-link" {...linkProps} stretched hasLinkIcon />
       </div>
     </CardBase>
   )

--- a/next/components/ui/NumericalListSectionUI/NumericalListSectionUI.tsx
+++ b/next/components/ui/NumericalListSectionUI/NumericalListSectionUI.tsx
@@ -1,4 +1,3 @@
-import { ArrowRightIcon } from '@assets/ui-icons'
 import { Waves } from '@bratislava/ui-bratislava/Waves/Waves'
 import Button from '@components/forms/simple-components/Button'
 import cx from 'classnames'
@@ -53,12 +52,7 @@ export const NumericalListSectionUI = ({
           <NumericalList items={items} hasBackground={hasBackground} variant={variant} />
         </div>
         {variant !== 'roadmap' && buttonText && (
-          <Button
-            href={href}
-            className="pt-10"
-            variant="category-outline"
-            endIcon={<ArrowRightIcon />}
-          >
+          <Button href={href} className="pt-10" variant="category-outline" hasLinkIcon>
             {buttonText}
           </Button>
         )}

--- a/next/components/ui/OfficialBoardCard/OfficialBoardCard.tsx
+++ b/next/components/ui/OfficialBoardCard/OfficialBoardCard.tsx
@@ -1,5 +1,5 @@
 // @ts-strict-ignore
-import { ArrowRightIcon } from '@assets/ui-icons'
+import { EyeIcon } from '@assets/ui-icons'
 import { Typography } from '@bratislava/component-library'
 import Button from '@components/forms/simple-components/Button'
 import Dialog from '@components/ui/ModalDialog/Dialog'
@@ -46,7 +46,7 @@ export const OfficialBoardCard = ({
         <Typography type="p">{content}</Typography>
         <div className="flex flex-col items-start gap-x-6">
           <DialogTrigger>
-            <Button variant="category-outline" endIcon={<ArrowRightIcon />}>
+            <Button variant="category-outline" endIcon={<EyeIcon />}>
               {viewButtonText}
             </Button>
 

--- a/next/pages/404.tsx
+++ b/next/pages/404.tsx
@@ -1,4 +1,3 @@
-import { ArrowRightIcon } from '@assets/ui-icons'
 import { Typography } from '@bratislava/component-library'
 import Button from '@components/forms/simple-components/Button'
 import { useTitle } from '@utils/useTitle'
@@ -36,7 +35,7 @@ const NotFoundPage = () => {
               {t('sorryNoResultsFound')}
             </Typography>
 
-            <Button variant="category-outline" href="/" endIcon={<ArrowRightIcon />}>
+            <Button variant="category-outline" href="/" hasLinkIcon>
               {t('toTheMainPage')}
             </Button>
           </div>


### PR DESCRIPTION
In future, consider to show link icon always by default, when button rendered as link.