### PR TITLE
[#1164] fix unwanted onPress propagation in Button

### DIFF
--- a/next/components/forms/simple-components/Button.tsx
+++ b/next/components/forms/simple-components/Button.tsx
@@ -234,6 +234,7 @@ const Button = forwardRef<HTMLAnchorElement | HTMLButtonElement, PolymorphicProp
       return (
         <MLink
           href={rest.href}
+          // made forwardRef possible with useEffect https://stackoverflow.com/a/62238917,
           ref={(node) => {
             myRef.current = node
             if (typeof ref === 'function') {
@@ -255,6 +256,7 @@ const Button = forwardRef<HTMLAnchorElement | HTMLButtonElement, PolymorphicProp
 
     return (
       <RACButton
+        // made forwardRef possible with useEffect https://stackoverflow.com/a/62238917,
         ref={(node) => {
           myRef.current = node
           if (typeof ref === 'function') {


### PR DESCRIPTION
Temporary solution to forbid touch event to propagate to elements placed under initially pressed element.