### PR TITLE
chore: added old*.bratislava.sk aliases/redirects

### DIFF
--- a/next/kubernetes/base/kustomization.yml
+++ b/next/kubernetes/base/kustomization.yml
@@ -5,6 +5,7 @@ resources:
   - ukrajina.ingress.yml
   - platbadane.ingress.yml
   - izba.ingress.yml
+  - old_aliases.ingress.yml
 configurations:
   - configuration.yml
 

--- a/next/kubernetes/base/old_aliases.ingress.yml
+++ b/next/kubernetes/base/old_aliases.ingress.yml
@@ -1,0 +1,62 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: old-${BUILD_REPOSITORY_NAME}-ingress
+  namespace: ${NAMESPACE}
+  labels:
+    service: redirect
+  annotations:
+    cert-manager.io/cluster-issuer: cloudflare-dns01
+    cert-manager.io/issue-temporary-certificate: 'true'
+    kubernetes.io/ingress.class: haproxy
+    ingress.kubernetes.io/redirect-to: 'https://www.${BRATISKA_HOSTNAME}/'
+spec:
+  tls:
+    - hosts:
+        - old.${DEPLOYMENT_ENV}bratislava.sk
+        - www.old.${DEPLOYMENT_ENV}bratislava.sk
+        - old2.${DEPLOYMENT_ENV}bratislava.sk
+        - www.old2.${DEPLOYMENT_ENV}bratislava.sk
+      secretName: old-${BUILD_REPOSITORY_NAME}-tls
+  rules:
+    - host: old.${DEPLOYMENT_ENV}bratislava.sk
+      http:
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: ${BUILD_REPOSITORY_NAME}-app
+                port:
+                  number: 80
+    - host: www.old.${DEPLOYMENT_ENV}bratislava.sk
+      http:
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: ${BUILD_REPOSITORY_NAME}-app
+                port:
+                  number: 80
+    - host: old2.${DEPLOYMENT_ENV}bratislava.sk
+      http:
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: ${BUILD_REPOSITORY_NAME}-app
+                port:
+                  number: 80
+    - host: www.old2.${DEPLOYMENT_ENV}bratislava.sk
+      http:
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: ${BUILD_REPOSITORY_NAME}-app
+                port:
+                  number: 80
+


### PR DESCRIPTION
* As `old.bratislava.sk` and `old2.bratislava.sk` are turned off we want users to redirect to official main page