### PR TITLE
1158 3/replace vzn with regulations file list replacement

### DIFF
--- a/next/backend/graphql/index.ts
+++ b/next/backend/graphql/index.ts
@@ -1371,7 +1371,6 @@ export type ComponentSectionsRegulations = {
   __typename?: 'ComponentSectionsRegulations'
   id: Scalars['ID']['output']
   regulations?: Maybe<RegulationRelationResponseCollection>
-  title?: Maybe<Scalars['String']['output']>
 }
 
 export type ComponentSectionsRegulationsRegulationsArgs = {
@@ -4298,7 +4297,6 @@ export type BlogPostBySlugQuery = {
             }
           | {
               __typename: 'ComponentSectionsRegulations'
-              title?: string | null
               regulations?: {
                 __typename?: 'RegulationRelationResponseCollection'
                 data: Array<{
@@ -4669,7 +4667,6 @@ export type LatestPostsByTagsQuery = {
             }
           | {
               __typename: 'ComponentSectionsRegulations'
-              title?: string | null
               regulations?: {
                 __typename?: 'RegulationRelationResponseCollection'
                 data: Array<{
@@ -5241,7 +5238,6 @@ export type BlogPostEntityFragment = {
         }
       | {
           __typename: 'ComponentSectionsRegulations'
-          title?: string | null
           regulations?: {
             __typename?: 'RegulationRelationResponseCollection'
             data: Array<{
@@ -8755,7 +8751,6 @@ export type PageBySlugQuery = {
             }
           | {
               __typename: 'ComponentSectionsRegulations'
-              title?: string | null
               regulations?: {
                 __typename?: 'RegulationRelationResponseCollection'
                 data: Array<{
@@ -9894,7 +9889,6 @@ export type PageEntityFragment = {
         }
       | {
           __typename: 'ComponentSectionsRegulations'
-          title?: string | null
           regulations?: {
             __typename?: 'RegulationRelationResponseCollection'
             data: Array<{
@@ -12103,7 +12097,6 @@ export type RegulationsListSectionFragment = {
 
 export type RegulationsSectionFragment = {
   __typename?: 'ComponentSectionsRegulations'
-  title?: string | null
   regulations?: {
     __typename?: 'RegulationRelationResponseCollection'
     data: Array<{
@@ -12967,7 +12960,6 @@ type Sections_ComponentSectionsProsAndConsSection_Fragment = {
 
 type Sections_ComponentSectionsRegulations_Fragment = {
   __typename: 'ComponentSectionsRegulations'
-  title?: string | null
   regulations?: {
     __typename?: 'RegulationRelationResponseCollection'
     data: Array<{
@@ -14125,7 +14117,6 @@ export const RegulationEntityFragmentDoc = gql`
 `
 export const RegulationsSectionFragmentDoc = gql`
   fragment RegulationsSection on ComponentSectionsRegulations {
-    title
     regulations {
       data {
         ...RegulationEntity

--- a/next/backend/graphql/index.ts
+++ b/next/backend/graphql/index.ts
@@ -148,6 +148,7 @@ export type BlogPostSectionsDynamicZone =
   | ComponentSectionsGallery
   | ComponentSectionsNarrowText
   | ComponentSectionsNumericalList
+  | ComponentSectionsRegulations
   | ComponentSectionsTextWithImage
   | ComponentSectionsVideos
   | Error
@@ -1366,6 +1367,20 @@ export type ComponentSectionsProsAndConsSection = {
   title?: Maybe<Scalars['String']['output']>
 }
 
+export type ComponentSectionsRegulations = {
+  __typename?: 'ComponentSectionsRegulations'
+  id: Scalars['ID']['output']
+  regulations?: Maybe<RegulationRelationResponseCollection>
+  title?: Maybe<Scalars['String']['output']>
+}
+
+export type ComponentSectionsRegulationsRegulationsArgs = {
+  filters?: InputMaybe<RegulationFiltersInput>
+  pagination?: InputMaybe<PaginationArg>
+  publicationState?: InputMaybe<PublicationState>
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>
+}
+
 export type ComponentSectionsRegulationsList = {
   __typename?: 'ComponentSectionsRegulationsList'
   id: Scalars['ID']['output']
@@ -1972,6 +1987,7 @@ export type GenericMorph =
   | ComponentSectionsOfficialBoard
   | ComponentSectionsOrganizationalStructure
   | ComponentSectionsProsAndConsSection
+  | ComponentSectionsRegulations
   | ComponentSectionsRegulationsList
   | ComponentSectionsSpace
   | ComponentSectionsSubpageList
@@ -3134,6 +3150,7 @@ export type PageSectionsDynamicZone =
   | ComponentSectionsOfficialBoard
   | ComponentSectionsOrganizationalStructure
   | ComponentSectionsProsAndConsSection
+  | ComponentSectionsRegulations
   | ComponentSectionsRegulationsList
   | ComponentSectionsSpace
   | ComponentSectionsTextWithImage
@@ -4280,6 +4297,166 @@ export type BlogPostBySlugQuery = {
               } | null> | null
             }
           | {
+              __typename: 'ComponentSectionsRegulations'
+              title?: string | null
+              regulations?: {
+                __typename?: 'RegulationRelationResponseCollection'
+                data: Array<{
+                  __typename?: 'RegulationEntity'
+                  id?: string | null
+                  attributes?: {
+                    __typename?: 'Regulation'
+                    regNumber: string
+                    slug: string
+                    titleText?: string | null
+                    fullTitle: string
+                    effectiveFrom?: any | null
+                    category?: Enum_Regulation_Category | null
+                    isFullTextRegulation?: boolean | null
+                    mainDocument: {
+                      __typename?: 'UploadFileEntityResponse'
+                      data?: {
+                        __typename?: 'UploadFileEntity'
+                        id?: string | null
+                        attributes?: {
+                          __typename?: 'UploadFile'
+                          url: string
+                          name: string
+                          ext?: string | null
+                          size: number
+                          createdAt?: any | null
+                          updatedAt?: any | null
+                        } | null
+                      } | null
+                    }
+                    consolidatedText?: {
+                      __typename?: 'UploadFileEntityResponse'
+                      data?: {
+                        __typename?: 'UploadFileEntity'
+                        id?: string | null
+                        attributes?: {
+                          __typename?: 'UploadFile'
+                          url: string
+                          name: string
+                          ext?: string | null
+                          size: number
+                          createdAt?: any | null
+                          updatedAt?: any | null
+                        } | null
+                      } | null
+                    } | null
+                    attachments?: {
+                      __typename?: 'UploadFileRelationResponseCollection'
+                      data: Array<{
+                        __typename?: 'UploadFileEntity'
+                        id?: string | null
+                        attributes?: {
+                          __typename?: 'UploadFile'
+                          url: string
+                          name: string
+                          ext?: string | null
+                          size: number
+                          createdAt?: any | null
+                          updatedAt?: any | null
+                        } | null
+                      }>
+                    } | null
+                    amendments?: {
+                      __typename?: 'RegulationRelationResponseCollection'
+                      data: Array<{
+                        __typename?: 'RegulationEntity'
+                        id?: string | null
+                        attributes?: {
+                          __typename?: 'Regulation'
+                          regNumber: string
+                          slug: string
+                          effectiveFrom?: any | null
+                          isFullTextRegulation?: boolean | null
+                        } | null
+                      }>
+                    } | null
+                    amending?: {
+                      __typename?: 'RegulationRelationResponseCollection'
+                      data: Array<{
+                        __typename?: 'RegulationEntity'
+                        id?: string | null
+                        attributes?: {
+                          __typename?: 'Regulation'
+                          regNumber: string
+                          slug: string
+                          effectiveFrom?: any | null
+                          cancellation?: {
+                            __typename?: 'RegulationEntityResponse'
+                            data?: {
+                              __typename?: 'RegulationEntity'
+                              id?: string | null
+                              attributes?: {
+                                __typename?: 'Regulation'
+                                regNumber: string
+                                slug: string
+                                effectiveFrom?: any | null
+                              } | null
+                            } | null
+                          } | null
+                          amending?: {
+                            __typename?: 'RegulationRelationResponseCollection'
+                            data: Array<{
+                              __typename?: 'RegulationEntity'
+                              id?: string | null
+                              attributes?: {
+                                __typename?: 'Regulation'
+                                regNumber: string
+                                slug: string
+                                cancellation?: {
+                                  __typename?: 'RegulationEntityResponse'
+                                  data?: {
+                                    __typename?: 'RegulationEntity'
+                                    id?: string | null
+                                    attributes?: {
+                                      __typename?: 'Regulation'
+                                      regNumber: string
+                                      slug: string
+                                      effectiveFrom?: any | null
+                                    } | null
+                                  } | null
+                                } | null
+                              } | null
+                            }>
+                          } | null
+                        } | null
+                      }>
+                    } | null
+                    cancellation?: {
+                      __typename?: 'RegulationEntityResponse'
+                      data?: {
+                        __typename?: 'RegulationEntity'
+                        id?: string | null
+                        attributes?: {
+                          __typename?: 'Regulation'
+                          regNumber: string
+                          slug: string
+                          effectiveFrom?: any | null
+                        } | null
+                      } | null
+                    } | null
+                    cancelling?: {
+                      __typename?: 'RegulationRelationResponseCollection'
+                      data: Array<{
+                        __typename?: 'RegulationEntity'
+                        id?: string | null
+                        attributes?: {
+                          __typename?: 'Regulation'
+                          regNumber: string
+                          slug: string
+                          effectiveFrom?: any | null
+                        } | null
+                      }>
+                    } | null
+                  } | null
+                }>
+              } | null
+            }
+          | {
               __typename: 'ComponentSectionsTextWithImage'
               hasBackground?: boolean | null
               content?: string | null
@@ -4489,6 +4666,166 @@ export type LatestPostsByTagsQuery = {
                 __typename?: 'ComponentBlocksNumericalListItem'
                 text?: string | null
               } | null> | null
+            }
+          | {
+              __typename: 'ComponentSectionsRegulations'
+              title?: string | null
+              regulations?: {
+                __typename?: 'RegulationRelationResponseCollection'
+                data: Array<{
+                  __typename?: 'RegulationEntity'
+                  id?: string | null
+                  attributes?: {
+                    __typename?: 'Regulation'
+                    regNumber: string
+                    slug: string
+                    titleText?: string | null
+                    fullTitle: string
+                    effectiveFrom?: any | null
+                    category?: Enum_Regulation_Category | null
+                    isFullTextRegulation?: boolean | null
+                    mainDocument: {
+                      __typename?: 'UploadFileEntityResponse'
+                      data?: {
+                        __typename?: 'UploadFileEntity'
+                        id?: string | null
+                        attributes?: {
+                          __typename?: 'UploadFile'
+                          url: string
+                          name: string
+                          ext?: string | null
+                          size: number
+                          createdAt?: any | null
+                          updatedAt?: any | null
+                        } | null
+                      } | null
+                    }
+                    consolidatedText?: {
+                      __typename?: 'UploadFileEntityResponse'
+                      data?: {
+                        __typename?: 'UploadFileEntity'
+                        id?: string | null
+                        attributes?: {
+                          __typename?: 'UploadFile'
+                          url: string
+                          name: string
+                          ext?: string | null
+                          size: number
+                          createdAt?: any | null
+                          updatedAt?: any | null
+                        } | null
+                      } | null
+                    } | null
+                    attachments?: {
+                      __typename?: 'UploadFileRelationResponseCollection'
+                      data: Array<{
+                        __typename?: 'UploadFileEntity'
+                        id?: string | null
+                        attributes?: {
+                          __typename?: 'UploadFile'
+                          url: string
+                          name: string
+                          ext?: string | null
+                          size: number
+                          createdAt?: any | null
+                          updatedAt?: any | null
+                        } | null
+                      }>
+                    } | null
+                    amendments?: {
+                      __typename?: 'RegulationRelationResponseCollection'
+                      data: Array<{
+                        __typename?: 'RegulationEntity'
+                        id?: string | null
+                        attributes?: {
+                          __typename?: 'Regulation'
+                          regNumber: string
+                          slug: string
+                          effectiveFrom?: any | null
+                          isFullTextRegulation?: boolean | null
+                        } | null
+                      }>
+                    } | null
+                    amending?: {
+                      __typename?: 'RegulationRelationResponseCollection'
+                      data: Array<{
+                        __typename?: 'RegulationEntity'
+                        id?: string | null
+                        attributes?: {
+                          __typename?: 'Regulation'
+                          regNumber: string
+                          slug: string
+                          effectiveFrom?: any | null
+                          cancellation?: {
+                            __typename?: 'RegulationEntityResponse'
+                            data?: {
+                              __typename?: 'RegulationEntity'
+                              id?: string | null
+                              attributes?: {
+                                __typename?: 'Regulation'
+                                regNumber: string
+                                slug: string
+                                effectiveFrom?: any | null
+                              } | null
+                            } | null
+                          } | null
+                          amending?: {
+                            __typename?: 'RegulationRelationResponseCollection'
+                            data: Array<{
+                              __typename?: 'RegulationEntity'
+                              id?: string | null
+                              attributes?: {
+                                __typename?: 'Regulation'
+                                regNumber: string
+                                slug: string
+                                cancellation?: {
+                                  __typename?: 'RegulationEntityResponse'
+                                  data?: {
+                                    __typename?: 'RegulationEntity'
+                                    id?: string | null
+                                    attributes?: {
+                                      __typename?: 'Regulation'
+                                      regNumber: string
+                                      slug: string
+                                      effectiveFrom?: any | null
+                                    } | null
+                                  } | null
+                                } | null
+                              } | null
+                            }>
+                          } | null
+                        } | null
+                      }>
+                    } | null
+                    cancellation?: {
+                      __typename?: 'RegulationEntityResponse'
+                      data?: {
+                        __typename?: 'RegulationEntity'
+                        id?: string | null
+                        attributes?: {
+                          __typename?: 'Regulation'
+                          regNumber: string
+                          slug: string
+                          effectiveFrom?: any | null
+                        } | null
+                      } | null
+                    } | null
+                    cancelling?: {
+                      __typename?: 'RegulationRelationResponseCollection'
+                      data: Array<{
+                        __typename?: 'RegulationEntity'
+                        id?: string | null
+                        attributes?: {
+                          __typename?: 'Regulation'
+                          regNumber: string
+                          slug: string
+                          effectiveFrom?: any | null
+                        } | null
+                      }>
+                    } | null
+                  } | null
+                }>
+              } | null
             }
           | {
               __typename: 'ComponentSectionsTextWithImage'
@@ -4901,6 +5238,166 @@ export type BlogPostEntityFragment = {
             __typename?: 'ComponentBlocksNumericalListItem'
             text?: string | null
           } | null> | null
+        }
+      | {
+          __typename: 'ComponentSectionsRegulations'
+          title?: string | null
+          regulations?: {
+            __typename?: 'RegulationRelationResponseCollection'
+            data: Array<{
+              __typename?: 'RegulationEntity'
+              id?: string | null
+              attributes?: {
+                __typename?: 'Regulation'
+                regNumber: string
+                slug: string
+                titleText?: string | null
+                fullTitle: string
+                effectiveFrom?: any | null
+                category?: Enum_Regulation_Category | null
+                isFullTextRegulation?: boolean | null
+                mainDocument: {
+                  __typename?: 'UploadFileEntityResponse'
+                  data?: {
+                    __typename?: 'UploadFileEntity'
+                    id?: string | null
+                    attributes?: {
+                      __typename?: 'UploadFile'
+                      url: string
+                      name: string
+                      ext?: string | null
+                      size: number
+                      createdAt?: any | null
+                      updatedAt?: any | null
+                    } | null
+                  } | null
+                }
+                consolidatedText?: {
+                  __typename?: 'UploadFileEntityResponse'
+                  data?: {
+                    __typename?: 'UploadFileEntity'
+                    id?: string | null
+                    attributes?: {
+                      __typename?: 'UploadFile'
+                      url: string
+                      name: string
+                      ext?: string | null
+                      size: number
+                      createdAt?: any | null
+                      updatedAt?: any | null
+                    } | null
+                  } | null
+                } | null
+                attachments?: {
+                  __typename?: 'UploadFileRelationResponseCollection'
+                  data: Array<{
+                    __typename?: 'UploadFileEntity'
+                    id?: string | null
+                    attributes?: {
+                      __typename?: 'UploadFile'
+                      url: string
+                      name: string
+                      ext?: string | null
+                      size: number
+                      createdAt?: any | null
+                      updatedAt?: any | null
+                    } | null
+                  }>
+                } | null
+                amendments?: {
+                  __typename?: 'RegulationRelationResponseCollection'
+                  data: Array<{
+                    __typename?: 'RegulationEntity'
+                    id?: string | null
+                    attributes?: {
+                      __typename?: 'Regulation'
+                      regNumber: string
+                      slug: string
+                      effectiveFrom?: any | null
+                      isFullTextRegulation?: boolean | null
+                    } | null
+                  }>
+                } | null
+                amending?: {
+                  __typename?: 'RegulationRelationResponseCollection'
+                  data: Array<{
+                    __typename?: 'RegulationEntity'
+                    id?: string | null
+                    attributes?: {
+                      __typename?: 'Regulation'
+                      regNumber: string
+                      slug: string
+                      effectiveFrom?: any | null
+                      cancellation?: {
+                        __typename?: 'RegulationEntityResponse'
+                        data?: {
+                          __typename?: 'RegulationEntity'
+                          id?: string | null
+                          attributes?: {
+                            __typename?: 'Regulation'
+                            regNumber: string
+                            slug: string
+                            effectiveFrom?: any | null
+                          } | null
+                        } | null
+                      } | null
+                      amending?: {
+                        __typename?: 'RegulationRelationResponseCollection'
+                        data: Array<{
+                          __typename?: 'RegulationEntity'
+                          id?: string | null
+                          attributes?: {
+                            __typename?: 'Regulation'
+                            regNumber: string
+                            slug: string
+                            cancellation?: {
+                              __typename?: 'RegulationEntityResponse'
+                              data?: {
+                                __typename?: 'RegulationEntity'
+                                id?: string | null
+                                attributes?: {
+                                  __typename?: 'Regulation'
+                                  regNumber: string
+                                  slug: string
+                                  effectiveFrom?: any | null
+                                } | null
+                              } | null
+                            } | null
+                          } | null
+                        }>
+                      } | null
+                    } | null
+                  }>
+                } | null
+                cancellation?: {
+                  __typename?: 'RegulationEntityResponse'
+                  data?: {
+                    __typename?: 'RegulationEntity'
+                    id?: string | null
+                    attributes?: {
+                      __typename?: 'Regulation'
+                      regNumber: string
+                      slug: string
+                      effectiveFrom?: any | null
+                    } | null
+                  } | null
+                } | null
+                cancelling?: {
+                  __typename?: 'RegulationRelationResponseCollection'
+                  data: Array<{
+                    __typename?: 'RegulationEntity'
+                    id?: string | null
+                    attributes?: {
+                      __typename?: 'Regulation'
+                      regNumber: string
+                      slug: string
+                      effectiveFrom?: any | null
+                    } | null
+                  }>
+                } | null
+              } | null
+            }>
+          } | null
         }
       | {
           __typename: 'ComponentSectionsTextWithImage'
@@ -8257,6 +8754,166 @@ export type PageBySlugQuery = {
               }
             }
           | {
+              __typename: 'ComponentSectionsRegulations'
+              title?: string | null
+              regulations?: {
+                __typename?: 'RegulationRelationResponseCollection'
+                data: Array<{
+                  __typename?: 'RegulationEntity'
+                  id?: string | null
+                  attributes?: {
+                    __typename?: 'Regulation'
+                    regNumber: string
+                    slug: string
+                    titleText?: string | null
+                    fullTitle: string
+                    effectiveFrom?: any | null
+                    category?: Enum_Regulation_Category | null
+                    isFullTextRegulation?: boolean | null
+                    mainDocument: {
+                      __typename?: 'UploadFileEntityResponse'
+                      data?: {
+                        __typename?: 'UploadFileEntity'
+                        id?: string | null
+                        attributes?: {
+                          __typename?: 'UploadFile'
+                          url: string
+                          name: string
+                          ext?: string | null
+                          size: number
+                          createdAt?: any | null
+                          updatedAt?: any | null
+                        } | null
+                      } | null
+                    }
+                    consolidatedText?: {
+                      __typename?: 'UploadFileEntityResponse'
+                      data?: {
+                        __typename?: 'UploadFileEntity'
+                        id?: string | null
+                        attributes?: {
+                          __typename?: 'UploadFile'
+                          url: string
+                          name: string
+                          ext?: string | null
+                          size: number
+                          createdAt?: any | null
+                          updatedAt?: any | null
+                        } | null
+                      } | null
+                    } | null
+                    attachments?: {
+                      __typename?: 'UploadFileRelationResponseCollection'
+                      data: Array<{
+                        __typename?: 'UploadFileEntity'
+                        id?: string | null
+                        attributes?: {
+                          __typename?: 'UploadFile'
+                          url: string
+                          name: string
+                          ext?: string | null
+                          size: number
+                          createdAt?: any | null
+                          updatedAt?: any | null
+                        } | null
+                      }>
+                    } | null
+                    amendments?: {
+                      __typename?: 'RegulationRelationResponseCollection'
+                      data: Array<{
+                        __typename?: 'RegulationEntity'
+                        id?: string | null
+                        attributes?: {
+                          __typename?: 'Regulation'
+                          regNumber: string
+                          slug: string
+                          effectiveFrom?: any | null
+                          isFullTextRegulation?: boolean | null
+                        } | null
+                      }>
+                    } | null
+                    amending?: {
+                      __typename?: 'RegulationRelationResponseCollection'
+                      data: Array<{
+                        __typename?: 'RegulationEntity'
+                        id?: string | null
+                        attributes?: {
+                          __typename?: 'Regulation'
+                          regNumber: string
+                          slug: string
+                          effectiveFrom?: any | null
+                          cancellation?: {
+                            __typename?: 'RegulationEntityResponse'
+                            data?: {
+                              __typename?: 'RegulationEntity'
+                              id?: string | null
+                              attributes?: {
+                                __typename?: 'Regulation'
+                                regNumber: string
+                                slug: string
+                                effectiveFrom?: any | null
+                              } | null
+                            } | null
+                          } | null
+                          amending?: {
+                            __typename?: 'RegulationRelationResponseCollection'
+                            data: Array<{
+                              __typename?: 'RegulationEntity'
+                              id?: string | null
+                              attributes?: {
+                                __typename?: 'Regulation'
+                                regNumber: string
+                                slug: string
+                                cancellation?: {
+                                  __typename?: 'RegulationEntityResponse'
+                                  data?: {
+                                    __typename?: 'RegulationEntity'
+                                    id?: string | null
+                                    attributes?: {
+                                      __typename?: 'Regulation'
+                                      regNumber: string
+                                      slug: string
+                                      effectiveFrom?: any | null
+                                    } | null
+                                  } | null
+                                } | null
+                              } | null
+                            }>
+                          } | null
+                        } | null
+                      }>
+                    } | null
+                    cancellation?: {
+                      __typename?: 'RegulationEntityResponse'
+                      data?: {
+                        __typename?: 'RegulationEntity'
+                        id?: string | null
+                        attributes?: {
+                          __typename?: 'Regulation'
+                          regNumber: string
+                          slug: string
+                          effectiveFrom?: any | null
+                        } | null
+                      } | null
+                    } | null
+                    cancelling?: {
+                      __typename?: 'RegulationRelationResponseCollection'
+                      data: Array<{
+                        __typename?: 'RegulationEntity'
+                        id?: string | null
+                        attributes?: {
+                          __typename?: 'Regulation'
+                          regNumber: string
+                          slug: string
+                          effectiveFrom?: any | null
+                        } | null
+                      }>
+                    } | null
+                  } | null
+                }>
+              } | null
+            }
+          | {
               __typename: 'ComponentSectionsRegulationsList'
               title?: string | null
               text?: string | null
@@ -9234,6 +9891,166 @@ export type PageEntityFragment = {
             title: string
             items: Array<{ __typename?: 'ComponentBlocksComparisonItem'; label: string } | null>
           }
+        }
+      | {
+          __typename: 'ComponentSectionsRegulations'
+          title?: string | null
+          regulations?: {
+            __typename?: 'RegulationRelationResponseCollection'
+            data: Array<{
+              __typename?: 'RegulationEntity'
+              id?: string | null
+              attributes?: {
+                __typename?: 'Regulation'
+                regNumber: string
+                slug: string
+                titleText?: string | null
+                fullTitle: string
+                effectiveFrom?: any | null
+                category?: Enum_Regulation_Category | null
+                isFullTextRegulation?: boolean | null
+                mainDocument: {
+                  __typename?: 'UploadFileEntityResponse'
+                  data?: {
+                    __typename?: 'UploadFileEntity'
+                    id?: string | null
+                    attributes?: {
+                      __typename?: 'UploadFile'
+                      url: string
+                      name: string
+                      ext?: string | null
+                      size: number
+                      createdAt?: any | null
+                      updatedAt?: any | null
+                    } | null
+                  } | null
+                }
+                consolidatedText?: {
+                  __typename?: 'UploadFileEntityResponse'
+                  data?: {
+                    __typename?: 'UploadFileEntity'
+                    id?: string | null
+                    attributes?: {
+                      __typename?: 'UploadFile'
+                      url: string
+                      name: string
+                      ext?: string | null
+                      size: number
+                      createdAt?: any | null
+                      updatedAt?: any | null
+                    } | null
+                  } | null
+                } | null
+                attachments?: {
+                  __typename?: 'UploadFileRelationResponseCollection'
+                  data: Array<{
+                    __typename?: 'UploadFileEntity'
+                    id?: string | null
+                    attributes?: {
+                      __typename?: 'UploadFile'
+                      url: string
+                      name: string
+                      ext?: string | null
+                      size: number
+                      createdAt?: any | null
+                      updatedAt?: any | null
+                    } | null
+                  }>
+                } | null
+                amendments?: {
+                  __typename?: 'RegulationRelationResponseCollection'
+                  data: Array<{
+                    __typename?: 'RegulationEntity'
+                    id?: string | null
+                    attributes?: {
+                      __typename?: 'Regulation'
+                      regNumber: string
+                      slug: string
+                      effectiveFrom?: any | null
+                      isFullTextRegulation?: boolean | null
+                    } | null
+                  }>
+                } | null
+                amending?: {
+                  __typename?: 'RegulationRelationResponseCollection'
+                  data: Array<{
+                    __typename?: 'RegulationEntity'
+                    id?: string | null
+                    attributes?: {
+                      __typename?: 'Regulation'
+                      regNumber: string
+                      slug: string
+                      effectiveFrom?: any | null
+                      cancellation?: {
+                        __typename?: 'RegulationEntityResponse'
+                        data?: {
+                          __typename?: 'RegulationEntity'
+                          id?: string | null
+                          attributes?: {
+                            __typename?: 'Regulation'
+                            regNumber: string
+                            slug: string
+                            effectiveFrom?: any | null
+                          } | null
+                        } | null
+                      } | null
+                      amending?: {
+                        __typename?: 'RegulationRelationResponseCollection'
+                        data: Array<{
+                          __typename?: 'RegulationEntity'
+                          id?: string | null
+                          attributes?: {
+                            __typename?: 'Regulation'
+                            regNumber: string
+                            slug: string
+                            cancellation?: {
+                              __typename?: 'RegulationEntityResponse'
+                              data?: {
+                                __typename?: 'RegulationEntity'
+                                id?: string | null
+                                attributes?: {
+                                  __typename?: 'Regulation'
+                                  regNumber: string
+                                  slug: string
+                                  effectiveFrom?: any | null
+                                } | null
+                              } | null
+                            } | null
+                          } | null
+                        }>
+                      } | null
+                    } | null
+                  }>
+                } | null
+                cancellation?: {
+                  __typename?: 'RegulationEntityResponse'
+                  data?: {
+                    __typename?: 'RegulationEntity'
+                    id?: string | null
+                    attributes?: {
+                      __typename?: 'Regulation'
+                      regNumber: string
+                      slug: string
+                      effectiveFrom?: any | null
+                    } | null
+                  } | null
+                } | null
+                cancelling?: {
+                  __typename?: 'RegulationRelationResponseCollection'
+                  data: Array<{
+                    __typename?: 'RegulationEntity'
+                    id?: string | null
+                    attributes?: {
+                      __typename?: 'Regulation'
+                      regNumber: string
+                      slug: string
+                      effectiveFrom?: any | null
+                    } | null
+                  }>
+                } | null
+              } | null
+            }>
+          } | null
         }
       | {
           __typename: 'ComponentSectionsRegulationsList'
@@ -11284,6 +12101,167 @@ export type RegulationsListSectionFragment = {
   text?: string | null
 }
 
+export type RegulationsSectionFragment = {
+  __typename?: 'ComponentSectionsRegulations'
+  title?: string | null
+  regulations?: {
+    __typename?: 'RegulationRelationResponseCollection'
+    data: Array<{
+      __typename?: 'RegulationEntity'
+      id?: string | null
+      attributes?: {
+        __typename?: 'Regulation'
+        regNumber: string
+        slug: string
+        titleText?: string | null
+        fullTitle: string
+        effectiveFrom?: any | null
+        category?: Enum_Regulation_Category | null
+        isFullTextRegulation?: boolean | null
+        mainDocument: {
+          __typename?: 'UploadFileEntityResponse'
+          data?: {
+            __typename?: 'UploadFileEntity'
+            id?: string | null
+            attributes?: {
+              __typename?: 'UploadFile'
+              url: string
+              name: string
+              ext?: string | null
+              size: number
+              createdAt?: any | null
+              updatedAt?: any | null
+            } | null
+          } | null
+        }
+        consolidatedText?: {
+          __typename?: 'UploadFileEntityResponse'
+          data?: {
+            __typename?: 'UploadFileEntity'
+            id?: string | null
+            attributes?: {
+              __typename?: 'UploadFile'
+              url: string
+              name: string
+              ext?: string | null
+              size: number
+              createdAt?: any | null
+              updatedAt?: any | null
+            } | null
+          } | null
+        } | null
+        attachments?: {
+          __typename?: 'UploadFileRelationResponseCollection'
+          data: Array<{
+            __typename?: 'UploadFileEntity'
+            id?: string | null
+            attributes?: {
+              __typename?: 'UploadFile'
+              url: string
+              name: string
+              ext?: string | null
+              size: number
+              createdAt?: any | null
+              updatedAt?: any | null
+            } | null
+          }>
+        } | null
+        amendments?: {
+          __typename?: 'RegulationRelationResponseCollection'
+          data: Array<{
+            __typename?: 'RegulationEntity'
+            id?: string | null
+            attributes?: {
+              __typename?: 'Regulation'
+              regNumber: string
+              slug: string
+              effectiveFrom?: any | null
+              isFullTextRegulation?: boolean | null
+            } | null
+          }>
+        } | null
+        amending?: {
+          __typename?: 'RegulationRelationResponseCollection'
+          data: Array<{
+            __typename?: 'RegulationEntity'
+            id?: string | null
+            attributes?: {
+              __typename?: 'Regulation'
+              regNumber: string
+              slug: string
+              effectiveFrom?: any | null
+              cancellation?: {
+                __typename?: 'RegulationEntityResponse'
+                data?: {
+                  __typename?: 'RegulationEntity'
+                  id?: string | null
+                  attributes?: {
+                    __typename?: 'Regulation'
+                    regNumber: string
+                    slug: string
+                    effectiveFrom?: any | null
+                  } | null
+                } | null
+              } | null
+              amending?: {
+                __typename?: 'RegulationRelationResponseCollection'
+                data: Array<{
+                  __typename?: 'RegulationEntity'
+                  id?: string | null
+                  attributes?: {
+                    __typename?: 'Regulation'
+                    regNumber: string
+                    slug: string
+                    cancellation?: {
+                      __typename?: 'RegulationEntityResponse'
+                      data?: {
+                        __typename?: 'RegulationEntity'
+                        id?: string | null
+                        attributes?: {
+                          __typename?: 'Regulation'
+                          regNumber: string
+                          slug: string
+                          effectiveFrom?: any | null
+                        } | null
+                      } | null
+                    } | null
+                  } | null
+                }>
+              } | null
+            } | null
+          }>
+        } | null
+        cancellation?: {
+          __typename?: 'RegulationEntityResponse'
+          data?: {
+            __typename?: 'RegulationEntity'
+            id?: string | null
+            attributes?: {
+              __typename?: 'Regulation'
+              regNumber: string
+              slug: string
+              effectiveFrom?: any | null
+            } | null
+          } | null
+        } | null
+        cancelling?: {
+          __typename?: 'RegulationRelationResponseCollection'
+          data: Array<{
+            __typename?: 'RegulationEntity'
+            id?: string | null
+            attributes?: {
+              __typename?: 'Regulation'
+              regNumber: string
+              slug: string
+              effectiveFrom?: any | null
+            } | null
+          }>
+        } | null
+      } | null
+    }>
+  } | null
+}
+
 type Sections_ComponentSectionsAccordion_Fragment = {
   __typename: 'ComponentSectionsAccordion'
   title?: string | null
@@ -11987,6 +12965,167 @@ type Sections_ComponentSectionsProsAndConsSection_Fragment = {
   }
 }
 
+type Sections_ComponentSectionsRegulations_Fragment = {
+  __typename: 'ComponentSectionsRegulations'
+  title?: string | null
+  regulations?: {
+    __typename?: 'RegulationRelationResponseCollection'
+    data: Array<{
+      __typename?: 'RegulationEntity'
+      id?: string | null
+      attributes?: {
+        __typename?: 'Regulation'
+        regNumber: string
+        slug: string
+        titleText?: string | null
+        fullTitle: string
+        effectiveFrom?: any | null
+        category?: Enum_Regulation_Category | null
+        isFullTextRegulation?: boolean | null
+        mainDocument: {
+          __typename?: 'UploadFileEntityResponse'
+          data?: {
+            __typename?: 'UploadFileEntity'
+            id?: string | null
+            attributes?: {
+              __typename?: 'UploadFile'
+              url: string
+              name: string
+              ext?: string | null
+              size: number
+              createdAt?: any | null
+              updatedAt?: any | null
+            } | null
+          } | null
+        }
+        consolidatedText?: {
+          __typename?: 'UploadFileEntityResponse'
+          data?: {
+            __typename?: 'UploadFileEntity'
+            id?: string | null
+            attributes?: {
+              __typename?: 'UploadFile'
+              url: string
+              name: string
+              ext?: string | null
+              size: number
+              createdAt?: any | null
+              updatedAt?: any | null
+            } | null
+          } | null
+        } | null
+        attachments?: {
+          __typename?: 'UploadFileRelationResponseCollection'
+          data: Array<{
+            __typename?: 'UploadFileEntity'
+            id?: string | null
+            attributes?: {
+              __typename?: 'UploadFile'
+              url: string
+              name: string
+              ext?: string | null
+              size: number
+              createdAt?: any | null
+              updatedAt?: any | null
+            } | null
+          }>
+        } | null
+        amendments?: {
+          __typename?: 'RegulationRelationResponseCollection'
+          data: Array<{
+            __typename?: 'RegulationEntity'
+            id?: string | null
+            attributes?: {
+              __typename?: 'Regulation'
+              regNumber: string
+              slug: string
+              effectiveFrom?: any | null
+              isFullTextRegulation?: boolean | null
+            } | null
+          }>
+        } | null
+        amending?: {
+          __typename?: 'RegulationRelationResponseCollection'
+          data: Array<{
+            __typename?: 'RegulationEntity'
+            id?: string | null
+            attributes?: {
+              __typename?: 'Regulation'
+              regNumber: string
+              slug: string
+              effectiveFrom?: any | null
+              cancellation?: {
+                __typename?: 'RegulationEntityResponse'
+                data?: {
+                  __typename?: 'RegulationEntity'
+                  id?: string | null
+                  attributes?: {
+                    __typename?: 'Regulation'
+                    regNumber: string
+                    slug: string
+                    effectiveFrom?: any | null
+                  } | null
+                } | null
+              } | null
+              amending?: {
+                __typename?: 'RegulationRelationResponseCollection'
+                data: Array<{
+                  __typename?: 'RegulationEntity'
+                  id?: string | null
+                  attributes?: {
+                    __typename?: 'Regulation'
+                    regNumber: string
+                    slug: string
+                    cancellation?: {
+                      __typename?: 'RegulationEntityResponse'
+                      data?: {
+                        __typename?: 'RegulationEntity'
+                        id?: string | null
+                        attributes?: {
+                          __typename?: 'Regulation'
+                          regNumber: string
+                          slug: string
+                          effectiveFrom?: any | null
+                        } | null
+                      } | null
+                    } | null
+                  } | null
+                }>
+              } | null
+            } | null
+          }>
+        } | null
+        cancellation?: {
+          __typename?: 'RegulationEntityResponse'
+          data?: {
+            __typename?: 'RegulationEntity'
+            id?: string | null
+            attributes?: {
+              __typename?: 'Regulation'
+              regNumber: string
+              slug: string
+              effectiveFrom?: any | null
+            } | null
+          } | null
+        } | null
+        cancelling?: {
+          __typename?: 'RegulationRelationResponseCollection'
+          data: Array<{
+            __typename?: 'RegulationEntity'
+            id?: string | null
+            attributes?: {
+              __typename?: 'Regulation'
+              regNumber: string
+              slug: string
+              effectiveFrom?: any | null
+            } | null
+          }>
+        } | null
+      } | null
+    }>
+  } | null
+}
+
 type Sections_ComponentSectionsRegulationsList_Fragment = {
   __typename: 'ComponentSectionsRegulationsList'
   title?: string | null
@@ -12072,6 +13211,7 @@ export type SectionsFragment =
   | Sections_ComponentSectionsOfficialBoard_Fragment
   | Sections_ComponentSectionsOrganizationalStructure_Fragment
   | Sections_ComponentSectionsProsAndConsSection_Fragment
+  | Sections_ComponentSectionsRegulations_Fragment
   | Sections_ComponentSectionsRegulationsList_Fragment
   | Sections_ComponentSectionsSpace_Fragment
   | Sections_ComponentSectionsTextWithImage_Fragment
@@ -12883,6 +14023,117 @@ export const RegulationsListSectionFragmentDoc = gql`
     text
   }
 `
+export const RegulationEntityFragmentDoc = gql`
+  fragment RegulationEntity on RegulationEntity {
+    id
+    attributes {
+      regNumber
+      slug
+      titleText
+      fullTitle
+      effectiveFrom
+      category
+      isFullTextRegulation
+      mainDocument {
+        data {
+          ...UploadFileEntity
+        }
+      }
+      consolidatedText {
+        data {
+          ...UploadFileEntity
+        }
+      }
+      attachments {
+        data {
+          ...UploadFileEntity
+        }
+      }
+      amendments {
+        data {
+          id
+          attributes {
+            regNumber
+            slug
+            effectiveFrom
+            isFullTextRegulation
+          }
+        }
+      }
+      amending {
+        data {
+          id
+          attributes {
+            regNumber
+            slug
+            effectiveFrom
+            cancellation {
+              data {
+                id
+                attributes {
+                  regNumber
+                  slug
+                  effectiveFrom
+                }
+              }
+            }
+            amending {
+              data {
+                id
+                attributes {
+                  regNumber
+                  slug
+                  cancellation {
+                    data {
+                      id
+                      attributes {
+                        regNumber
+                        slug
+                        effectiveFrom
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      cancellation {
+        data {
+          id
+          attributes {
+            regNumber
+            slug
+            effectiveFrom
+          }
+        }
+      }
+      cancelling {
+        data {
+          id
+          attributes {
+            regNumber
+            slug
+            effectiveFrom
+          }
+        }
+      }
+    }
+  }
+  ${UploadFileEntityFragmentDoc}
+`
+export const RegulationsSectionFragmentDoc = gql`
+  fragment RegulationsSection on ComponentSectionsRegulations {
+    title
+    regulations {
+      data {
+        ...RegulationEntity
+      }
+    }
+  }
+  ${RegulationEntityFragmentDoc}
+`
 export const SectionsFragmentDoc = gql`
   fragment Sections on PageSectionsDynamicZone {
     __typename
@@ -12970,6 +14221,9 @@ export const SectionsFragmentDoc = gql`
     ... on ComponentSectionsRegulationsList {
       ...RegulationsListSection
     }
+    ... on ComponentSectionsRegulations {
+      ...RegulationsSection
+    }
   }
   ${IconTitleDescSectionFragmentDoc}
   ${DocumentListSectionFragmentDoc}
@@ -12999,6 +14253,7 @@ export const SectionsFragmentDoc = gql`
   ${FeaturedBlogPostsSectionFragmentDoc}
   ${ContactsSectionFragmentDoc}
   ${RegulationsListSectionFragmentDoc}
+  ${RegulationsSectionFragmentDoc}
 `
 export const BlogPostEntityFragmentDoc = gql`
   fragment BlogPostEntity on BlogPostEntity {
@@ -13558,106 +14813,6 @@ export const PageEntityFragmentDoc = gql`
   ${PageHeaderSectionsFragmentDoc}
   ${TagEntityFragmentDoc}
   ${PageParentPagesFragmentDoc}
-`
-export const RegulationEntityFragmentDoc = gql`
-  fragment RegulationEntity on RegulationEntity {
-    id
-    attributes {
-      regNumber
-      slug
-      titleText
-      fullTitle
-      effectiveFrom
-      category
-      isFullTextRegulation
-      mainDocument {
-        data {
-          ...UploadFileEntity
-        }
-      }
-      consolidatedText {
-        data {
-          ...UploadFileEntity
-        }
-      }
-      attachments {
-        data {
-          ...UploadFileEntity
-        }
-      }
-      amendments {
-        data {
-          id
-          attributes {
-            regNumber
-            slug
-            effectiveFrom
-            isFullTextRegulation
-          }
-        }
-      }
-      amending {
-        data {
-          id
-          attributes {
-            regNumber
-            slug
-            effectiveFrom
-            cancellation {
-              data {
-                id
-                attributes {
-                  regNumber
-                  slug
-                  effectiveFrom
-                }
-              }
-            }
-            amending {
-              data {
-                id
-                attributes {
-                  regNumber
-                  slug
-                  cancellation {
-                    data {
-                      id
-                      attributes {
-                        regNumber
-                        slug
-                        effectiveFrom
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-      cancellation {
-        data {
-          id
-          attributes {
-            regNumber
-            slug
-            effectiveFrom
-          }
-        }
-      }
-      cancelling {
-        data {
-          id
-          attributes {
-            regNumber
-            slug
-            effectiveFrom
-          }
-        }
-      }
-    }
-  }
-  ${UploadFileEntityFragmentDoc}
 `
 export const BlogPostBySlugDocument = gql`
   query BlogPostBySlug($slug: String!, $locale: I18NLocaleCode!) {

--- a/next/backend/graphql/queries/Sections.graphql
+++ b/next/backend/graphql/queries/Sections.graphql
@@ -465,7 +465,6 @@ fragment RegulationsListSection on ComponentSectionsRegulationsList {
 }
 
 fragment RegulationsSection on ComponentSectionsRegulations {
-  title
   regulations {
     data {
       ...RegulationEntity

--- a/next/backend/graphql/queries/Sections.graphql
+++ b/next/backend/graphql/queries/Sections.graphql
@@ -464,6 +464,15 @@ fragment RegulationsListSection on ComponentSectionsRegulationsList {
   text
 }
 
+fragment RegulationsSection on ComponentSectionsRegulations {
+  title
+  regulations {
+    data {
+      ...RegulationEntity
+    }
+  }
+}
+
 fragment Sections on PageSectionsDynamicZone {
   __typename
 
@@ -579,6 +588,10 @@ fragment Sections on PageSectionsDynamicZone {
 
   ... on ComponentSectionsRegulationsList {
     ...RegulationsListSection
+  }
+
+  ... on ComponentSectionsRegulations {
+    ...RegulationsSection
   }
 }
 

--- a/next/components/molecules/Regulations/RegulationCard.tsx
+++ b/next/components/molecules/Regulations/RegulationCard.tsx
@@ -20,7 +20,7 @@ const RegulationCard = ({ title, path, className, isUplneZnenie }: RegulationCar
   return (
     <div
       className={twMerge(
-        'relative flex h-[132px] flex-col justify-between rounded-lg border-2 border-gray-600 bg-white p-4 lg:h-36',
+        'relative flex h-[132px] flex-col justify-between rounded-lg border-2 border-category-600 bg-white p-4 lg:h-36',
         className,
       )}
     >
@@ -37,14 +37,16 @@ const RegulationCard = ({ title, path, className, isUplneZnenie }: RegulationCar
         </MLink>
         {isUplneZnenie && (
           <Typography type="p" size="p-small" className="line-clamp-1">
+            {/* FIXME: localisation */}
             Úplné znenie
           </Typography>
         )}
       </div>
       <div className="flex items-center gap-2 lg:gap-3">
-        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-100 text-gray-700 lg:h-10 lg:w-10">
+        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-category-100 text-category-700 lg:h-10 lg:w-10">
           <ArrowRightIcon className="h-4 w-4" />
         </div>
+        {/* FIXME: localisation */}
         <Typography type="span">Prejsť na VZN</Typography>
       </div>
     </div>

--- a/next/components/molecules/Regulations/RegulationCard.tsx
+++ b/next/components/molecules/Regulations/RegulationCard.tsx
@@ -23,7 +23,7 @@ const RegulationCard = ({ title, path, className, isUplneZnenie }: RegulationCar
   return (
     <div
       className={twMerge(
-        'relative flex h-[132px] flex-col justify-between rounded-lg border-2 border-category-600 bg-white p-4 lg:h-36',
+        'relative flex flex-col justify-between gap-2 rounded-lg border-2 border-category-600 bg-white p-4 lg:h-36',
         className,
       )}
     >

--- a/next/components/molecules/Regulations/RegulationCard.tsx
+++ b/next/components/molecules/Regulations/RegulationCard.tsx
@@ -1,6 +1,7 @@
 import { ArrowRightIcon } from '@assets/ui-icons'
 import { Typography } from '@bratislava/component-library'
 import MLink from '@components/forms/simple-components/MLink'
+import { useTranslations } from 'next-intl'
 import React from 'react'
 import { twMerge } from 'tailwind-merge'
 
@@ -17,6 +18,8 @@ export type RegulationCardProps = {
  */
 
 const RegulationCard = ({ title, path, className, isUplneZnenie }: RegulationCardProps) => {
+  const t = useTranslations()
+
   return (
     <div
       className={twMerge(
@@ -37,8 +40,7 @@ const RegulationCard = ({ title, path, className, isUplneZnenie }: RegulationCar
         </MLink>
         {isUplneZnenie && (
           <Typography type="p" size="p-small" className="line-clamp-1">
-            {/* FIXME: localisation */}
-            Úplné znenie
+            {t('Regulation.fullTextRegulation')}
           </Typography>
         )}
       </div>
@@ -46,8 +48,7 @@ const RegulationCard = ({ title, path, className, isUplneZnenie }: RegulationCar
         <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-category-100 text-category-700 lg:h-10 lg:w-10">
           <ArrowRightIcon className="h-4 w-4" />
         </div>
-        {/* FIXME: localisation */}
-        <Typography type="span">Prejsť na VZN</Typography>
+        <Typography type="span">{t('Regulation.linkToRegulationMessage')}</Typography>
       </div>
     </div>
   )

--- a/next/components/molecules/Regulations/Regulations.tsx
+++ b/next/components/molecules/Regulations/Regulations.tsx
@@ -2,16 +2,15 @@ import { RegulationEntityFragment } from '@backend/graphql'
 import { Typography } from '@bratislava/component-library'
 import RegulationCard from '@components/molecules/Regulations/RegulationCard'
 import ResponsiveCarousel from '@components/organisms/Carousel/ResponsiveCarousel'
-import { useLocale, useTranslations } from 'next-intl'
+import { useTranslations } from 'next-intl'
 
-export interface Props {
+type Props = {
   className?: string
   regulations?: RegulationEntityFragment[]
 }
 
-export const Regulations = ({ className, regulations }: Props) => {
+const Regulations = ({ className, regulations }: Props) => {
   const t = useTranslations()
-  const locale = useLocale()
 
   return (
     <div className={className}>
@@ -20,10 +19,6 @@ export const Regulations = ({ className, regulations }: Props) => {
         <>
           <div className="mt-6 hidden grid-cols-3 gap-8 lg:grid">
             {regulations?.map((regulation) => {
-              const path =
-                locale === 'en'
-                  ? `/en/vzn/${regulation.attributes?.slug}`
-                  : `/vzn/${regulation.attributes?.slug}`
               return (
                 <div className="w-full">
                   {/* TODO: consider adding english translation GBR instead of VZN  */}
@@ -31,13 +26,13 @@ export const Regulations = ({ className, regulations }: Props) => {
                     title={`VZN ${regulation.attributes?.regNumber ?? ''}`}
                     key={regulation.attributes?.regNumber}
                     isUplneZnenie={false}
-                    path={path}
+                    path={`/vzn/${regulation.attributes?.slug}`}
                   />
                 </div>
               )
             })}
           </div>
-          <div className="block lg:hidden">
+          <div className="lg:hidden">
             <ResponsiveCarousel
               items={regulations?.map((regulation) => (
                 // TODO: consider adding english translation GBR instead of VZN

--- a/next/components/molecules/Regulations/Regulations.tsx
+++ b/next/components/molecules/Regulations/Regulations.tsx
@@ -1,0 +1,59 @@
+import { RegulationEntityFragment } from '@backend/graphql'
+import { Typography } from '@bratislava/component-library'
+import RegulationCard from '@components/molecules/Regulations/RegulationCard'
+import ResponsiveCarousel from '@components/organisms/Carousel/ResponsiveCarousel'
+import { useLocale, useTranslations } from 'next-intl'
+
+export interface Props {
+  className?: string
+  title?: string
+  regulations?: RegulationEntityFragment[]
+}
+
+export const Regulations = ({ className, title, regulations }: Props) => {
+  const locale = useLocale()
+
+  return (
+    <div className={className}>
+      <Typography type="h2">{title}</Typography>
+      {regulations?.length ? (
+        <>
+          <div className="mt-6 hidden grid-cols-3 gap-8 lg:grid">
+            {regulations?.map((regulation) => {
+              const path =
+                locale === 'en'
+                  ? `/en/vzn/${regulation.attributes?.slug}`
+                  : `/vzn/${regulation.attributes?.slug}`
+              return (
+                <div className="w-full">
+                  {/* TODO: consider adding english translation GBR instead of VZN  */}
+                  <RegulationCard
+                    title={`VZN ${regulation.attributes?.regNumber ?? ''}`}
+                    key={regulation.attributes?.regNumber}
+                    isUplneZnenie={false}
+                    path={path}
+                  />
+                </div>
+              )
+            })}
+          </div>
+          <div className="block lg:hidden">
+            <ResponsiveCarousel
+              items={regulations?.map((regulation) => (
+                // eslint-disable-next-line react/no-array-index-key
+                <RegulationCard
+                  title={`VZN ${regulation.attributes?.regNumber ?? ''}`}
+                  key={regulation.attributes?.regNumber}
+                  isUplneZnenie={false}
+                  path={`/vzn/${regulation.attributes?.slug ?? ''}`}
+                />
+              ))}
+            />
+          </div>
+        </>
+      ) : null}
+    </div>
+  )
+}
+
+export default Regulations

--- a/next/components/molecules/Regulations/Regulations.tsx
+++ b/next/components/molecules/Regulations/Regulations.tsx
@@ -6,16 +6,16 @@ import { useLocale, useTranslations } from 'next-intl'
 
 export interface Props {
   className?: string
-  title?: string
   regulations?: RegulationEntityFragment[]
 }
 
-export const Regulations = ({ className, title, regulations }: Props) => {
+export const Regulations = ({ className, regulations }: Props) => {
+  const t = useTranslations()
   const locale = useLocale()
 
   return (
     <div className={className}>
-      <Typography type="h2">{title}</Typography>
+      <Typography type="h2">{t('Regulation.relatedRegulations')}</Typography>
       {regulations?.length ? (
         <>
           <div className="mt-6 hidden grid-cols-3 gap-8 lg:grid">
@@ -40,7 +40,7 @@ export const Regulations = ({ className, title, regulations }: Props) => {
           <div className="block lg:hidden">
             <ResponsiveCarousel
               items={regulations?.map((regulation) => (
-                // eslint-disable-next-line react/no-array-index-key
+                // TODO: consider adding english translation GBR instead of VZN
                 <RegulationCard
                   title={`VZN ${regulation.attributes?.regNumber ?? ''}`}
                   key={regulation.attributes?.regNumber}

--- a/next/components/molecules/Sections.tsx
+++ b/next/components/molecules/Sections.tsx
@@ -32,6 +32,7 @@ import TextWithImageSection from './sections/general/TextWithImageSection'
 import TimelineSection from './sections/general/TimelineSection'
 import VideosSection from './sections/general/VideosSection'
 import WavesSection from './sections/general/WavesSection'
+import RegulationsSection from '@components/molecules/sections/general/RegulationsSection'
 
 const SectionContent = ({ section }: { section: SectionsFragment }) => {
   switch (section.__typename) {
@@ -115,6 +116,9 @@ const SectionContent = ({ section }: { section: SectionsFragment }) => {
 
     case 'ComponentSectionsRegulationsList':
       return <RegulationsListSection section={section} />
+
+    case 'ComponentSectionsRegulations':
+      return <RegulationsSection section={section} />
 
     default:
       return null

--- a/next/components/molecules/sections/general/RegulationsSection.tsx
+++ b/next/components/molecules/sections/general/RegulationsSection.tsx
@@ -1,0 +1,13 @@
+import { RegulationsSectionFragment } from '@backend/graphql'
+import Regulations from '@components/molecules/Regulations/Regulations'
+import React from 'react'
+
+type Props = {
+  section: RegulationsSectionFragment
+}
+
+const RegulationsSection = ({ section }: Props) => {
+  return <Regulations title={section.title ?? ''} regulations={section.regulations?.data} />
+}
+
+export default RegulationsSection

--- a/next/components/molecules/sections/general/RegulationsSection.tsx
+++ b/next/components/molecules/sections/general/RegulationsSection.tsx
@@ -7,7 +7,7 @@ type Props = {
 }
 
 const RegulationsSection = ({ section }: Props) => {
-  return <Regulations title={section.title ?? ''} regulations={section.regulations?.data} />
+  return <Regulations regulations={section.regulations?.data} />
 }
 
 export default RegulationsSection

--- a/next/components/ui/FileList/FileList.tsx
+++ b/next/components/ui/FileList/FileList.tsx
@@ -55,7 +55,7 @@ export const FileList = ({
                     </div>
                   ))}
                 </div>
-                <div className="block lg:hidden">
+                <div className="lg:hidden">
                   <ResponsiveCarousel
                     items={fileSection?.files.map((file, fileIndex) => (
                       // eslint-disable-next-line react/no-array-index-key

--- a/next/messages/en.json
+++ b/next/messages/en.json
@@ -284,6 +284,7 @@
     },
     "mainDocument": "Main document",
     "consolidatedText": "Consolidated text",
+    "fullTextRegulation": "Full text regulation",
     "noConsolidatedTextMessage": "This regulation has no consolidated text document.",
     "attachments": "Attachments",
     "noAttachmentsMessage": "This regulation has no attachments.",
@@ -294,6 +295,8 @@
     "thisRegulationDoesntAmend": "This regulation doesn't amend any regulations.",
     "thisRegulationCancells": "This regulation cancels",
     "thisRegulationDoesntCancell": "This regulation doesn't cancel any regulation.",
+    "linkToRegulationMessage": "Go to regulation",
+    "relatedRegulations": "Related generally binding regulations",
     "category": {
       "daneAPoplatky": "Tax and fees",
       "pomenovanieUlic": "Street naming",

--- a/next/messages/en.json
+++ b/next/messages/en.json
@@ -282,6 +282,18 @@
       "valid": "Valid",
       "since": "since"
     },
+    "mainDocument": "Main document",
+    "consolidatedText": "Consolidated text",
+    "noConsolidatedTextMessage": "This regulation has no consolidated text document.",
+    "attachments": "Attachments",
+    "noAttachmentsMessage": "This regulation has no attachments.",
+    "amendments": "Amendments",
+    "noAmendmentsMessage": "There are no amendments to this regulation.",
+    "influenceOnOtherRegulations": "Influence on other regulations",
+    "thisRegulationAmends": "This regulation amends",
+    "thisRegulationDoesntAmend": "This regulation doesn't amend any regulations.",
+    "thisRegulationCancells": "This regulation cancels",
+    "thisRegulationDoesntCancell": "This regulation doesn't cancel any regulation.",
     "category": {
       "daneAPoplatky": "Tax and fees",
       "pomenovanieUlic": "Street naming",

--- a/next/messages/sk.json
+++ b/next/messages/sk.json
@@ -296,7 +296,7 @@
     "thisRegulationCancells": "Toto VZN zrušuje",
     "thisRegulationDoesntCancell": "Toto VZN nezrušuje žiadne VZN.",
     "linkToRegulationMessage": "Prejsť na VZN",
-    "relatedRegulations": "Related generally binding regulations",
+    "relatedRegulations": "Súvisiace všeobecne záväzné nariadenia",
     "category": {
       "daneAPoplatky": "Dane a poplatky",
       "pomenovanieUlic": "Pomenovanie ulíc",

--- a/next/messages/sk.json
+++ b/next/messages/sk.json
@@ -284,6 +284,7 @@
     },
     "mainDocument": "Hlavný dokument",
     "consolidatedText": "Konsolidované znenie",
+    "fullTextRegulation": "Úplné znenie",
     "noConsolidatedTextMessage": "K tomuto VZN neexistuje konsolidované znenie.",
     "attachments": "Prílohy",
     "noAttachmentsMessage": "Toto VZN nemá prílohy.",
@@ -294,6 +295,8 @@
     "thisRegulationDoesntAmend": "Toto VZN nie je dodatkom k žiadnemu VZN.",
     "thisRegulationCancells": "Toto VZN zrušuje",
     "thisRegulationDoesntCancell": "Toto VZN nezrušuje žiadne VZN.",
+    "linkToRegulationMessage": "Prejsť na VZN",
+    "relatedRegulations": "Related generally binding regulations",
     "category": {
       "daneAPoplatky": "Dane a poplatky",
       "pomenovanieUlic": "Pomenovanie ulíc",

--- a/strapi/schema.graphql
+++ b/strapi/schema.graphql
@@ -1729,7 +1729,6 @@ input ComponentSectionsProsAndConsSectionInput {
 type ComponentSectionsRegulations {
   id: ID!
   regulations(filters: RegulationFiltersInput, pagination: PaginationArg = {}, publicationState: PublicationState = LIVE, sort: [String] = []): RegulationRelationResponseCollection
-  title: String
 }
 
 input ComponentSectionsRegulationsFiltersInput {
@@ -1737,13 +1736,11 @@ input ComponentSectionsRegulationsFiltersInput {
   not: ComponentSectionsRegulationsFiltersInput
   or: [ComponentSectionsRegulationsFiltersInput]
   regulations: RegulationFiltersInput
-  title: StringFilterInput
 }
 
 input ComponentSectionsRegulationsInput {
   id: ID
   regulations: [ID]
-  title: String
 }
 
 type ComponentSectionsRegulationsList {

--- a/strapi/schema.graphql
+++ b/strapi/schema.graphql
@@ -113,7 +113,7 @@ type BlogPostRelationResponseCollection {
   data: [BlogPostEntity!]!
 }
 
-union BlogPostSectionsDynamicZone = ComponentSectionsColumnedText | ComponentSectionsDivider | ComponentSectionsFileList | ComponentSectionsGallery | ComponentSectionsNarrowText | ComponentSectionsNumericalList | ComponentSectionsTextWithImage | ComponentSectionsVideos | Error
+union BlogPostSectionsDynamicZone = ComponentSectionsColumnedText | ComponentSectionsDivider | ComponentSectionsFileList | ComponentSectionsGallery | ComponentSectionsNarrowText | ComponentSectionsNumericalList | ComponentSectionsRegulations | ComponentSectionsTextWithImage | ComponentSectionsVideos | Error
 
 scalar BlogPostSectionsDynamicZoneInput
 
@@ -1726,6 +1726,26 @@ input ComponentSectionsProsAndConsSectionInput {
   title: String
 }
 
+type ComponentSectionsRegulations {
+  id: ID!
+  regulations(filters: RegulationFiltersInput, pagination: PaginationArg = {}, publicationState: PublicationState = LIVE, sort: [String] = []): RegulationRelationResponseCollection
+  title: String
+}
+
+input ComponentSectionsRegulationsFiltersInput {
+  and: [ComponentSectionsRegulationsFiltersInput]
+  not: ComponentSectionsRegulationsFiltersInput
+  or: [ComponentSectionsRegulationsFiltersInput]
+  regulations: RegulationFiltersInput
+  title: StringFilterInput
+}
+
+input ComponentSectionsRegulationsInput {
+  id: ID
+  regulations: [ID]
+  title: String
+}
+
 type ComponentSectionsRegulationsList {
   id: ID!
   text: String
@@ -2365,7 +2385,7 @@ type GeneralRelationResponseCollection {
   data: [GeneralEntity!]!
 }
 
-union GenericMorph = Alert | BlogPost | ComponentAccordionItemsFlatText | ComponentAccordionItemsInstitution | ComponentAccordionItemsInstitutionNarrow | ComponentBlocksBlogPostLink | ComponentBlocksBookmarkLink | ComponentBlocksCommonLink | ComponentBlocksComparisonCard | ComponentBlocksComparisonItem | ComponentBlocksContactCard | ComponentBlocksDocListExtensions | ComponentBlocksFile | ComponentBlocksFileItem | ComponentBlocksFooterColumn | ComponentBlocksFooterContactItem | ComponentBlocksFooterSection | ComponentBlocksGalleryItem | ComponentBlocksHomepageBookmark | ComponentBlocksHomepageHighlightsItem | ComponentBlocksIconWithTitleAndDescription | ComponentBlocksInBa | ComponentBlocksNumericalListItem | ComponentBlocksPageLink | ComponentBlocksProsAndConsCard | ComponentBlocksSpaceInfo | ComponentBlocksSubpage | ComponentBlocksTimelineItem | ComponentBlocksTopServicesItem | ComponentBlocksVideo | ComponentGeneralHeader | ComponentGeneralHeaderLink | ComponentMenuMenuItem | ComponentMenuMenuLink | ComponentMenuMenuSection | ComponentOsItemsAdvancedAccordionDepartment | ComponentOsItemsAdvancedAccordionItem | ComponentOsItemsAdvancedAccordionSubItem | ComponentOsItemsAdvancedAccordionSubSubItem | ComponentSectionsAccordion | ComponentSectionsBanner | ComponentSectionsBlogPostsByCategory | ComponentSectionsBlogPostsByTags | ComponentSectionsBlogPostsList | ComponentSectionsCalculator | ComponentSectionsColumnedText | ComponentSectionsComparisonSection | ComponentSectionsContactsSection | ComponentSectionsDivider | ComponentSectionsDocumentList | ComponentSectionsFeaturedBlogPosts | ComponentSectionsFileList | ComponentSectionsGallery | ComponentSectionsHomepageEvents | ComponentSectionsHomepageHighlights | ComponentSectionsHomepageMayorAndCouncil | ComponentSectionsHomepageTabs | ComponentSectionsIconTitleDesc | ComponentSectionsIframe | ComponentSectionsInbaArticlesList | ComponentSectionsInbaReleases | ComponentSectionsLinks | ComponentSectionsNarrowText | ComponentSectionsNumericalList | ComponentSectionsOfficialBoard | ComponentSectionsOrganizationalStructure | ComponentSectionsProsAndConsSection | ComponentSectionsRegulationsList | ComponentSectionsSpace | ComponentSectionsSubpageList | ComponentSectionsTextWithImage | ComponentSectionsTimeline | ComponentSectionsTopServices | ComponentSectionsVideos | ComponentSectionsWaves | Footer | General | Homepage | I18NLocale | InbaArticle | InbaRelease | InbaTag | Menu | Page | PageCategory | PageSubcategory | Regulation | Tag | UploadFile | UploadFolder | UsersPermissionsPermission | UsersPermissionsRole | UsersPermissionsUser | Vzn
+union GenericMorph = Alert | BlogPost | ComponentAccordionItemsFlatText | ComponentAccordionItemsInstitution | ComponentAccordionItemsInstitutionNarrow | ComponentBlocksBlogPostLink | ComponentBlocksBookmarkLink | ComponentBlocksCommonLink | ComponentBlocksComparisonCard | ComponentBlocksComparisonItem | ComponentBlocksContactCard | ComponentBlocksDocListExtensions | ComponentBlocksFile | ComponentBlocksFileItem | ComponentBlocksFooterColumn | ComponentBlocksFooterContactItem | ComponentBlocksFooterSection | ComponentBlocksGalleryItem | ComponentBlocksHomepageBookmark | ComponentBlocksHomepageHighlightsItem | ComponentBlocksIconWithTitleAndDescription | ComponentBlocksInBa | ComponentBlocksNumericalListItem | ComponentBlocksPageLink | ComponentBlocksProsAndConsCard | ComponentBlocksSpaceInfo | ComponentBlocksSubpage | ComponentBlocksTimelineItem | ComponentBlocksTopServicesItem | ComponentBlocksVideo | ComponentGeneralHeader | ComponentGeneralHeaderLink | ComponentMenuMenuItem | ComponentMenuMenuLink | ComponentMenuMenuSection | ComponentOsItemsAdvancedAccordionDepartment | ComponentOsItemsAdvancedAccordionItem | ComponentOsItemsAdvancedAccordionSubItem | ComponentOsItemsAdvancedAccordionSubSubItem | ComponentSectionsAccordion | ComponentSectionsBanner | ComponentSectionsBlogPostsByCategory | ComponentSectionsBlogPostsByTags | ComponentSectionsBlogPostsList | ComponentSectionsCalculator | ComponentSectionsColumnedText | ComponentSectionsComparisonSection | ComponentSectionsContactsSection | ComponentSectionsDivider | ComponentSectionsDocumentList | ComponentSectionsFeaturedBlogPosts | ComponentSectionsFileList | ComponentSectionsGallery | ComponentSectionsHomepageEvents | ComponentSectionsHomepageHighlights | ComponentSectionsHomepageMayorAndCouncil | ComponentSectionsHomepageTabs | ComponentSectionsIconTitleDesc | ComponentSectionsIframe | ComponentSectionsInbaArticlesList | ComponentSectionsInbaReleases | ComponentSectionsLinks | ComponentSectionsNarrowText | ComponentSectionsNumericalList | ComponentSectionsOfficialBoard | ComponentSectionsOrganizationalStructure | ComponentSectionsProsAndConsSection | ComponentSectionsRegulations | ComponentSectionsRegulationsList | ComponentSectionsSpace | ComponentSectionsSubpageList | ComponentSectionsTextWithImage | ComponentSectionsTimeline | ComponentSectionsTopServices | ComponentSectionsVideos | ComponentSectionsWaves | Footer | General | Homepage | I18NLocale | InbaArticle | InbaRelease | InbaTag | Menu | Page | PageCategory | PageSubcategory | Regulation | Tag | UploadFile | UploadFolder | UsersPermissionsPermission | UsersPermissionsRole | UsersPermissionsUser | Vzn
 
 type Homepage {
   bookmarkTourists: ComponentBlocksHomepageBookmark
@@ -3056,7 +3076,7 @@ type PageRelationResponseCollection {
   data: [PageEntity!]!
 }
 
-union PageSectionsDynamicZone = ComponentSectionsAccordion | ComponentSectionsBanner | ComponentSectionsBlogPostsByCategory | ComponentSectionsBlogPostsByTags | ComponentSectionsBlogPostsList | ComponentSectionsCalculator | ComponentSectionsColumnedText | ComponentSectionsComparisonSection | ComponentSectionsContactsSection | ComponentSectionsDivider | ComponentSectionsDocumentList | ComponentSectionsFeaturedBlogPosts | ComponentSectionsFileList | ComponentSectionsGallery | ComponentSectionsIconTitleDesc | ComponentSectionsIframe | ComponentSectionsInbaArticlesList | ComponentSectionsInbaReleases | ComponentSectionsLinks | ComponentSectionsNarrowText | ComponentSectionsNumericalList | ComponentSectionsOfficialBoard | ComponentSectionsOrganizationalStructure | ComponentSectionsProsAndConsSection | ComponentSectionsRegulationsList | ComponentSectionsSpace | ComponentSectionsTextWithImage | ComponentSectionsTimeline | ComponentSectionsVideos | ComponentSectionsWaves | Error
+union PageSectionsDynamicZone = ComponentSectionsAccordion | ComponentSectionsBanner | ComponentSectionsBlogPostsByCategory | ComponentSectionsBlogPostsByTags | ComponentSectionsBlogPostsList | ComponentSectionsCalculator | ComponentSectionsColumnedText | ComponentSectionsComparisonSection | ComponentSectionsContactsSection | ComponentSectionsDivider | ComponentSectionsDocumentList | ComponentSectionsFeaturedBlogPosts | ComponentSectionsFileList | ComponentSectionsGallery | ComponentSectionsIconTitleDesc | ComponentSectionsIframe | ComponentSectionsInbaArticlesList | ComponentSectionsInbaReleases | ComponentSectionsLinks | ComponentSectionsNarrowText | ComponentSectionsNumericalList | ComponentSectionsOfficialBoard | ComponentSectionsOrganizationalStructure | ComponentSectionsProsAndConsSection | ComponentSectionsRegulations | ComponentSectionsRegulationsList | ComponentSectionsSpace | ComponentSectionsTextWithImage | ComponentSectionsTimeline | ComponentSectionsVideos | ComponentSectionsWaves | Error
 
 scalar PageSectionsDynamicZoneInput
 

--- a/strapi/src/api/blog-post/content-types/blog-post/schema.json
+++ b/strapi/src/api/blog-post/content-types/blog-post/schema.json
@@ -92,6 +92,7 @@
         "sections.columned-text",
         "sections.text-with-image",
         "sections.file-list",
+        "sections.regulations",
         "sections.narrow-text",
         "sections.divider",
         "sections.videos",

--- a/strapi/src/api/page/content-types/page/schema.json
+++ b/strapi/src/api/page/content-types/page/schema.json
@@ -133,6 +133,7 @@
         "sections.official-board",
         "sections.organizational-structure",
         "sections.pros-and-cons-section",
+        "sections.regulations",
         "sections.regulations-list",
         "sections.space",
         "sections.text-with-image",

--- a/strapi/src/components/sections/regulations.json
+++ b/strapi/src/components/sections/regulations.json
@@ -6,9 +6,6 @@
   },
   "options": {},
   "attributes": {
-    "title": {
-      "type": "string"
-    },
     "regulations": {
       "type": "relation",
       "relation": "oneToMany",

--- a/strapi/src/components/sections/regulations.json
+++ b/strapi/src/components/sections/regulations.json
@@ -1,0 +1,18 @@
+{
+  "collectionName": "components_sections_regulations",
+  "info": {
+    "displayName": "Regulations",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "regulations": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::regulation.regulation"
+    }
+  }
+}


### PR DESCRIPTION
### Current goals
- ✅ create new component `Regulations` which behaves similarly to File list, but displays Regulations

### Next steps (in Strapi only)
- in all pages (production), replace current regulations (linked as files in File list) with the new Regulations component
- regulations are also referenced inside texts (sometimes without links, sometimes with links to files) - replace them with links to corresponding regulation pages
 - afterwards we can remove duplicate regulation files from the Media Library 