### PR TITLE
move strapi logger middleware to first place to meet migration guides

### DIFF
--- a/strapi/config/middlewares.ts
+++ b/strapi/config/middlewares.ts
@@ -1,4 +1,5 @@
 module.exports = [
+  'strapi::logger',
   'strapi::errors',
   {
     name: 'strapi::security',
@@ -15,7 +16,6 @@ module.exports = [
   },
   'strapi::cors',
   'strapi::poweredBy',
-  'strapi::logger',
   'strapi::query',
   'strapi::body',
   'strapi::session',


### PR DESCRIPTION
https://docs.strapi.io/dev-docs/migration/v4/migration-guide-4.14.0-to-4.15.5