### PR TITLE
#1261 Cleanup duplicate redirects

### DIFF
--- a/next/next.config.js
+++ b/next/next.config.js
@@ -67,6 +67,95 @@ const nextConfig = {
         destination: '/blog/:path*',
         permanent: true,
       },
+      /// Obmedzenia a poruchy
+      {
+        source: '/rozkopavka-alebo-uzavierka/:slug',
+        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy', // ignore slug, redirect to listing page
+        permanent: true,
+      },
+      {
+        source: '/filter/rozkopavky-a-uzavierky',
+        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
+        permanent: true,
+      },
+      {
+        source: '/rss/rozkopavky-a-uzavierky',
+        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
+        permanent: true,
+      },
+      {
+        source: '/uzavery-d4-r7-a-mlynske-nivy',
+        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
+        permanent: true,
+      },
+      {
+        source: '/najnovsie-rozkopavky-a-uzavierky',
+        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
+        permanent: true,
+      },
+      {
+        source: '/situacia-v-bratislave-od-15-2-2019',
+        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
+        permanent: true,
+      },
+      {
+        source: '/iframe/rozkopavky-a-uzavierky',
+        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
+        permanent: true,
+      },
+      {
+        source: '/rozkopavky-a-uzavierky/d-77246/p1=11049948',
+        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
+        permanent: true,
+      },
+      {
+        source: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/rozkopavky-a-uzavery',
+        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
+        permanent: true,
+      },
+      /// Uzemny plan a dodatky
+      {
+        source: '/uzemny-plan-hlavneho-mesta-sr-bratislavy-zmeny-a-doplnky-01',
+        destination:
+          '/zivotne-prostredie-a-vystavba/rozvoj-mesta/platna-uzemnoplanovacia-dokumentacia/uzemny-plan-mesta-a-jeho-zmeny-a-doplnky/zmeny-a-doplnky-01',
+        permanent: true,
+      },
+      {
+        source: '/uzemny-plan-hlavneho-mesta-sr-bratislavy-zmeny-a-doplnky-02',
+        destination:
+          '/zivotne-prostredie-a-vystavba/rozvoj-mesta/platna-uzemnoplanovacia-dokumentacia/uzemny-plan-mesta-a-jeho-zmeny-a-doplnky/zmeny-a-doplnky-02',
+        permanent: true,
+      },
+      {
+        source: '/uzemny-plan-hlavneho-mesta-sr-bratislavy-zmeny-a-doplnky-03',
+        destination:
+          '/zivotne-prostredie-a-vystavba/rozvoj-mesta/platna-uzemnoplanovacia-dokumentacia/uzemny-plan-mesta-a-jeho-zmeny-a-doplnky/zmeny-a-doplnky-03',
+        permanent: true,
+      },
+      {
+        source: '/uzemny-plan-hlavneho-mesta-sr-bratislavy-zmeny-a-doplnky-05',
+        destination:
+          '/zivotne-prostredie-a-vystavba/rozvoj-mesta/platna-uzemnoplanovacia-dokumentacia/uzemny-plan-mesta-a-jeho-zmeny-a-doplnky/zmeny-a-doplnky-05',
+        permanent: true,
+      },
+      {
+        source: '/uzemny-plan-hlavneho-mesta-sr-bratislavy-zmeny-a-doplnky-06',
+        destination:
+          '/zivotne-prostredie-a-vystavba/rozvoj-mesta/platna-uzemnoplanovacia-dokumentacia/uzemny-plan-mesta-a-jeho-zmeny-a-doplnky/zmeny-a-doplnky-06',
+        permanent: true,
+      },
+      {
+        source: '/uzemny-plan-hlavneho-mesta-sr-bratislavy-zmeny-a-doplnky-07',
+        destination:
+          '/zivotne-prostredie-a-vystavba/rozvoj-mesta/platna-uzemnoplanovacia-dokumentacia/uzemny-plan-mesta-a-jeho-zmeny-a-doplnky/zmeny-a-doplnky-07',
+        permanent: true,
+      },
+      {
+        source: '/uzemny-plan-hlavneho-mesta-sr-bratislavy-zmeny-a-doplnky-08',
+        destination:
+          '/zivotne-prostredie-a-vystavba/rozvoj-mesta/platna-uzemnoplanovacia-dokumentacia/uzemny-plan-mesta-a-jeho-zmeny-a-doplnky/zmeny-a-doplnky-08',
+        permanent: true,
+      },
       {
         source: '/dan-z-nehnutelnosti',
         destination: '/mesto-bratislava/dane-a-poplatky/dan-z-nehnutelnosti',
@@ -85,6 +174,11 @@ const nextConfig = {
       {
         source: '/mesto-bratislava/sprava-mesta/magistrat/organizacna-struktura-a-kontakty',
         destination: '/mesto-bratislava/sprava-mesta/magistrat/organizacna-struktura',
+        permanent: true,
+      },
+      {
+        source: '/mesto-bratislava/kontakty',
+        destination: '/kontakty',
         permanent: true,
       },
       {
@@ -203,13 +297,6 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source:
-          '/sprava/bratislava-vyhlasuje-sutaz-o-rocne-elektricenky-pre-zaockovanych-chce-rychlejsie-dosiahnut-kolektivnu-imunitu',
-        destination:
-          '/blog/bratislava-vyhlasuje-sutaz-o-rocne-elektricenky-pre-zaockovanych-chce-rychlejsie-dosiahnut-kolektivnu-imunitu',
-        permanent: true,
-      },
-      {
         source: '/danove-ulavy-pre-fyzicke-osoby',
         destination: '/mesto-bratislava/dane-a-poplatky/dan-z-nehnutelnosti',
         permanent: true,
@@ -228,13 +315,6 @@ const nextConfig = {
         source: '/zmena-sposobu-zberu-a-odvozu-vytriedeneho-odpadu-z-rodinnych-domov',
         destination:
           '/zivotne-prostredie-a-vystavba/zivotne-prostredie/odpady/triedeny-zber/zber-a-odvoz-vytriedeneho-odpadu-z-rodinnych-domov',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/prve-udaje-zo-scitania-obyvatelov-bratislavy-vykazuju-zasadny-rozdiel-medzi-evidenciou-obce-a-vysledkom-statistov',
-        destination:
-          '/blog/prve-udaje-zo-scitania-obyvatelov-bratislavy-vykazuju-zasadny-rozdiel-medzi-evidenciou-obce-a-vysledkom-statistov',
         permanent: true,
       },
       {
@@ -263,26 +343,8 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source: '/uzemny-plan-hlavneho-mesta-sr-bratislavy-zmeny-a-doplnky-06',
-        destination:
-          '/zivotne-prostredie-a-vystavba/rozvoj-mesta/platna-uzemnoplanovacia-dokumentacia/uzemny-plan-mesta-a-jeho-zmeny-a-doplnky/zmeny-a-doplnky-06',
-        permanent: true,
-      },
-      {
-        source: '/filter/rozkopavky-a-uzavierky',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
         source: '/filter/predaj-a-prenajom-nehnutelnosti',
         destination: '/mesto-bratislava/transparentne-mesto/majetok-mesta',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/bratislavske-letne-kupaliska-sa-pripravuju-na-sezonu-mesto-ponuka-akciu-na-zvyhodnenu-permanentku',
-        destination:
-          '/blog/bratislavske-letne-kupaliska-sa-pripravuju-na-sezonu-mesto-ponuka-akciu-na-zvyhodnenu-permanentku',
         permanent: true,
       },
       {
@@ -372,12 +434,6 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source: '/uzemny-plan-hlavneho-mesta-sr-bratislavy-zmeny-a-doplnky-02',
-        destination:
-          '/zivotne-prostredie-a-vystavba/rozvoj-mesta/platna-uzemnoplanovacia-dokumentacia/uzemny-plan-mesta-a-jeho-zmeny-a-doplnky/zmeny-a-doplnky-02',
-        permanent: true,
-      },
-      {
         source: '/transparentne-mesto',
         destination: '/mesto-bratislava/transparentne-mesto',
         permanent: true,
@@ -419,11 +475,6 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source: '/filter/pracovne-prilezitosti',
-        destination: '/mesto-bratislava/sprava-mesta/magistrat/pracovne-prilezitosti',
-        permanent: true,
-      },
-      {
         source: '/rozvoj-najomneho-byvania',
         destination: '/socialne-sluzby-a-byvanie/byvanie-a-ubytovanie/rozvoj-najomneho-byvania',
         permanent: true,
@@ -439,20 +490,8 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source: '/uzemny-plan-hlavneho-mesta-sr-bratislavy-zmeny-a-doplnky-01',
-        destination:
-          '/zivotne-prostredie-a-vystavba/rozvoj-mesta/uzemnoplanovacie-dokumenty/platna-uzemnoplanovacia-dokumentacia/uzemny-plan-mesta-a-jeho-zmeny-a-doplnky/zmeny-a-doplnky-01',
-        permanent: true,
-      },
-      {
         source: '/братислава-для-украіни',
         destination: '/kultura-a-komunity/komunity/братислава-для-украіни',
-        permanent: true,
-      },
-      {
-        source: '/uzemny-plan-hlavneho-mesta-sr-bratislavy-zmeny-a-doplnky-07',
-        destination:
-          'zivotne-prostredie-a-vystavba/rozvoj-mesta/uzemnoplanovacie-dokumenty/platna-uzemnoplanovacia-dokumentacia/uzemny-plan-mesta-a-jeho-zmeny-a-doplnky/zmeny-a-doplnky-07',
         permanent: true,
       },
       {
@@ -582,12 +621,6 @@ const nextConfig = {
       {
         source: '/mestska-hromadna-doprava',
         destination: '/doprava-a-mapy/mestska-hromadna-doprava',
-        permanent: true,
-      },
-      {
-        source: '/uzemny-plan-hlavneho-mesta-sr-bratislavy-zmeny-a-doplnky-05',
-        destination:
-          'zivotne-prostredie-a-vystavba/rozvoj-mesta/uzemnoplanovacie-dokumenty/platna-uzemnoplanovacia-dokumentacia/uzemny-plan-mesta-a-jeho-zmeny-a-doplnky/zmeny-a-doplnky-05',
         permanent: true,
       },
       {
@@ -757,13 +790,6 @@ const nextConfig = {
       },
       {
         source:
-          '/sprava/bratislava-ma-novy-geoportal-data-o-meste-spristupnuje-na-prehladnych-mapach-ci-vizualizaciach',
-        destination:
-          '/blog/bratislava-ma-novy-geoportal-data-o-meste-spristupnuje-na-prehladnych-mapach-ci-vizualizaciach',
-        permanent: true,
-      },
-      {
-        source:
           '/organizacia-alebo-institucia/bratislavska-organizacia-cestovneho-ruchu-bratislava-tourist-board',
         destination:
           '/mesto-bratislava/sprava-mesta/organizacie-mesta/ostatne-organizacie/bratislavska-organizacia-cestovneho-ruchu',
@@ -772,12 +798,6 @@ const nextConfig = {
       {
         source: '/nove-sadzby-dane-z-nehnutelnosti',
         destination: '/mesto-bratislava/dane-a-poplatky/dan-z-nehnutelnosti',
-        permanent: true,
-      },
-      {
-        source: '/uzemny-plan-hlavneho-mesta-sr-bratislavy-zmeny-a-doplnky-03',
-        destination:
-          'zivotne-prostredie-a-vystavba/rozvoj-mesta/uzemnoplanovacie-dokumenty/platna-uzemnoplanovacia-dokumentacia/uzemny-plan-mesta-a-jeho-zmeny-a-doplnky/zmeny-a-doplnky-03',
         permanent: true,
       },
       {
@@ -841,13 +861,6 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source:
-          '/sprava/vianocne-stromceky-budeme-po-novom-zbierat-podla-harmonogramu-a-aj-zo-specialnych-drevenych-ohradok',
-        destination:
-          '/blog/vianocne-stromceky-budeme-po-novom-zbierat-podla-harmonogramu-a-aj-zo-specialnych-drevenych-ohradok',
-        permanent: true,
-      },
-      {
         source: '/uzemny-plan-zony-machnac',
         destination:
           '/zivotne-prostredie-a-vystavba/rozvoj-mesta/uzemnoplanovacie-dokumenty/platna-uzemnoplanovacia-dokumentacia/uzemne-plany-zon/uzemny-plan-zony-machnac',
@@ -861,11 +874,6 @@ const nextConfig = {
       {
         source: '/organizacia-alebo-institucia/centrum-volneho-casu-hlinicka-3',
         destination: '/vzdelavanie-a-volny-cas/skolstvo/centra-volneho-casu',
-        permanent: true,
-      },
-      {
-        source: '/dan-z-nehnutelnosti',
-        destination: '/mesto-bratislava/dane-a-poplatky/dan-z-nehnutelnosti',
         permanent: true,
       },
       {
@@ -1018,13 +1026,6 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source:
-          '/sprava/hlavna-stanica-sa-bude-riesit-komplexne-ministerstvo-dopravy-zeleznice-slovenskej-republiky-a-hlavne-mesto-bratislava-podpisali-memorandum-o-spolupraci-pri-realizacii-projektu-rozvoja-hlavnej-stanice-a-jej-prilahleho-uzemia',
-        destination:
-          '/blog/hlavna-stanica-sa-bude-riesit-komplexne-ministerstvo-dopravy-zeleznice-slovenskej-republiky-a-hlavne-mesto-bratislava-podpisali-memorandum-o-spolupraci-pri-realizacii-projektu-rozvoja-hlavnej-stanice-a-jej-prilahleho-uzemia',
-        permanent: true,
-      },
-      {
         source: '/koncepcia-kultury',
         destination: '/kultura-a-komunity/koncepcia-kultury',
         permanent: true,
@@ -1091,13 +1092,6 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source:
-          '/sprava/hlavne-mesto-bratislava-sa-opat-zapaja-do-celosvetovej-iniciativy-climathon-a-podpori-inovativne-riesenia-bojujuce-s-klimatickou-krizou',
-        destination:
-          '/blog/hlavne-mesto-bratislava-sa-opat-zapaja-do-celosvetovej-iniciativy-climathon-a-podpori-inovativne-riesenia-bojujuce-s-klimatickou-krizou',
-        permanent: true,
-      },
-      {
         source: '/odborne-komisie',
         destination: '/kultura-a-komunity/koncepcia-kultury/odborne-komisie',
         permanent: true,
@@ -1143,13 +1137,6 @@ const nextConfig = {
         source: '/uzemny-generel-vodnych-tokov-a-protipovodnovej-ochrany-mesta-bratislavy',
         destination:
           '/zivotne-prostredie-a-vystavba/rozvoj-mesta/uzemnoplanovacie-dokumenty/prerokovane-uzemnoplanovacie-podklady/uzemne-generely',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/vznika-novy-mestsky-podnik-technicke-siete-bratislava-do-konca-roku-2025-zmodernizuje-osvetlenie-v-hlavnom-meste',
-        destination:
-          '/blog/vznika-novy-mestsky-podnik-technicke-siete-bratislava-do-konca-roku-2025-zmodernizuje-osvetlenie-v-hlavnom-meste',
         permanent: true,
       },
       {
@@ -1247,29 +1234,8 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source:
-          '/sprava/od-jula-pride-k-viacerym-zmenam-v-mhd-predlzenie-trasy-66-ky-a-lepsie-nadvazovanie-ostatnych-liniek',
-        destination:
-          '/blog/od-jula-pride-k-viacerym-zmenam-v-mhd-predlzenie-trasy-66-ky-a-lepsie-nadvazovanie-ostatnych-liniek',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/mesto-bratislava-otvara-grantovu-vyzvu-na-podporu-pohybovych-aktivit-a-neformalneho-vzdelavania-deti-mladeze-a-pracovnikov-v-oblasti-prace-s-detmi-a-mladezou',
-        destination:
-          '/blog/mesto-bratislava-otvara-grantovu-vyzvu-na-podporu-pohybovych-aktivit-a-neformalneho-vzdelavania-deti-mladeze-a-pracovnikov-v-oblasti-prace-s-detmi-a-mladezou',
-        permanent: true,
-      },
-      {
         source: '/organizacia-alebo-institucia/zakladna-umelecka-skola-exnarova-6',
         destination: '/vzdelavanie-a-volny-cas/skolstvo/zakladne-umelecke-skoly',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/vitazny-navrh-pre-zive-namestie-opat-po-desatrociach-zjednoti-kamenne-namestie-namestie-neznej-revolucie-a-namestie-snp',
-        destination:
-          '/blog/vitazny-navrh-pre-zive-namestie-opat-po-desatrociach-zjednoti-kamenne-namestie-namestie-neznej-revolucie-a-namestie-snp',
         permanent: true,
       },
       {
@@ -1303,13 +1269,6 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source:
-          '/sprava/mesto-tvori-novu-viziu-pre-bratislavu-ako-bude-vyzerat-bratislava-v-roku-2030-mozu-ovplyvnit-aj-bratislavcanky-a-bratislavcania',
-        destination:
-          '/blog/mesto-tvori-novu-viziu-pre-bratislavu-ako-bude-vyzerat-bratislava-v-roku-2030-mozu-ovplyvnit-aj-bratislavcanky-a-bratislavcania',
-        permanent: true,
-      },
-      {
         source: '/zmluvy',
         destination: '/mesto-bratislava/transparentne-mesto/zmluvy-faktury-objednavky',
         permanent: true,
@@ -1320,29 +1279,8 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source:
-          '/sprava/hlavne-mesto-vyhlasuje-grantovu-vyzvu-na-podporu-investicii-do-sportovej-infrastruktury-na-rok-2022-2',
-        destination:
-          '/blog/hlavne-mesto-vyhlasuje-grantovu-vyzvu-na-podporu-investicii-do-sportovej-infrastruktury-na-rok-2022-2',
-        permanent: true,
-      },
-      {
         source: '/organizacia-alebo-institucia/zakladna-umelecka-skola-istrijska-22',
         destination: '/vzdelavanie-a-volny-cas/skolstvo/zakladne-umelecke-skoly',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/mestske-zastupitelstvo-schvalilo-v-ramci-zmien-a-doplnkov-uzemneho-planu-novu-regulaciu-reklamnych-stavieb',
-        destination:
-          '/blog/mestske-zastupitelstvo-schvalilo-v-ramci-zmien-a-doplnkov-uzemneho-planu-novu-regulaciu-reklamnych-stavieb',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/od-septembra-pride-k-viacerym-zmenam-v-mhd-obnovenie-plnej-prevadzky-podla-rezimu-skolsky-rok-a-zlepsenie-obsluznosti-vo-viacerych-castiach-mesta',
-        destination:
-          '/blog/od-septembra-pride-k-viacerym-zmenam-v-mhd-obnovenie-plnej-prevadzky-podla-rezimu-skolsky-rok-a-zlepsenie-obsluznosti-vo-viacerych-castiach-mesta',
         permanent: true,
       },
       {
@@ -1362,13 +1300,6 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source:
-          '/sprava/vodna-veza-v-bratislavskom-podhradi-prejde-citlivou-obnovou-investor-je-tesne-pred-vyhlasenim-architektonickej-sutaze',
-        destination:
-          '/blog/vodna-veza-v-bratislavskom-podhradi-prejde-citlivou-obnovou-investor-je-tesne-pred-vyhlasenim-architektonickej-sutaze',
-        permanent: true,
-      },
-      {
         source: '/zastava',
         destination: '/mesto-bratislava/sprava-mesta/vizualna-identita/symboly-mesta',
         permanent: true,
@@ -1379,46 +1310,13 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source:
-          '/sprava/dnes-bolo-ukoncene-predkladanie-ponuk-verejneho-obstaravania-na-zhotovitela-novej-elektrickovej-trate-v-petrzalke',
-        destination:
-          '/blog/dnes-bolo-ukoncene-predkladanie-ponuk-verejneho-obstaravania-na-zhotovitela-novej-elektrickovej-trate-v-petrzalke',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/bratislava-bude-mat-po-vzore-inych-europskych-miest-vlastnu-dlazbu-inspirovana-je-fullom-ciparom-a-dobesom',
-        destination:
-          '/blog/bratislava-bude-mat-po-vzore-inych-europskych-miest-vlastnu-dlazbu-inspirovana-je-fullom-ciparom-a-dobesom',
-        permanent: true,
-      },
-      {
         source: '/medzinarodna-spolupraca',
         destination: '/mesto-bratislava/sprava-mesta/medzinarodna-spolupraca',
         permanent: true,
       },
       {
-        source:
-          '/sprava/mesto-obnovuje-cinnost-organizacie-pre-potreby-realizacie-politiky-mestskeho-najomneho-byvania',
-        destination:
-          '/blog/mesto-obnovuje-cinnost-organizacie-pre-potreby-realizacie-politiky-mestskeho-najomneho-byvania',
-        permanent: true,
-      },
-      {
         source: '/zdielana-mobilita',
         destination: '/doprava-a-mapy/zdielana-mobilita',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-most-snp',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/den-otvorenych-dveri-dopravneho-podniku-bratislava-prehliadka-vozidiel-dielni-a-bohaty-program',
-        destination:
-          '/blog/den-otvorenych-dveri-dopravneho-podniku-bratislava-prehliadka-vozidiel-dielni-a-bohaty-program',
         permanent: true,
       },
       {
@@ -1430,19 +1328,6 @@ const nextConfig = {
       {
         source: '/vyhladavanie-podani',
         destination: '/sledovanie-podania',
-        permanent: true,
-      },
-      {
-        source:
-          '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-karpatskej-ulice-podkolibskej-ulice-a-pionierskej-ulice',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/mesto-bratislava-podpori-v-roku-2022-kulturne-a-komunitne-projekty-rekordnou-sumou-1-2-miliona-eur',
-        destination:
-          '/blog/mesto-bratislava-podpori-v-roku-2022-kulturne-a-komunitne-projekty-rekordnou-sumou-1-2-miliona-eur',
         permanent: true,
       },
       {
@@ -1472,13 +1357,6 @@ const nextConfig = {
         source:
           '/organizacia-alebo-institucia/sprava-telovychovnych-a-rekreacnych-zariadeni-hlavneho-mesta-sr-bratislava-starz',
         destination: '/vzdelavanie-a-volny-cas/sport/STARZ',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/bratislava-ziskala-v-ramci-ocenenia-zlate-vedro-2020-od-odkazprestarostu-sk-2-miesto-v-kategorii-komunikacia',
-        destination:
-          '/blog/bratislava-ziskala-v-ramci-ocenenia-zlate-vedro-2020-od-odkazprestarostu-sk-2-miesto-v-kategorii-komunikacia',
         permanent: true,
       },
       {
@@ -1526,23 +1404,9 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source:
-          '/sprava/architekti-navrhli-novu-podobu-zanedbaneho-priestoru-v-okoli-domu-sluzieb-v-dubravke-pribudne-vodna-plocha-aj-multifunkcny-pavilon',
-        destination:
-          '/blog/architekti-navrhli-novu-podobu-zanedbaneho-priestoru-v-okoli-domu-sluzieb-v-dubravke-pribudne-vodna-plocha-aj-multifunkcny-pavilon',
-        permanent: true,
-      },
-      {
         source: '/organizacia-alebo-institucia/mestsky-ustav-ochrany-pamiatok',
         destination:
           '/kultura-a-komunity/mestske-kulturne-organizacie/mestsky-ustav-ochrany-pamiatok',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/spustenie-ankety-o-najuspesnejsieho-sportovca-sportovkynu-a-sportovy-kolektiv-bratislavy-a-bratislavskeho-kraja-za-rok-2021',
-        destination:
-          '/blog/spustenie-ankety-o-najuspesnejsieho-sportovca-sportovkynu-a-sportovy-kolektiv-bratislavy-a-bratislavskeho-kraja-za-rok-2021',
         permanent: true,
       },
       {
@@ -1552,48 +1416,8 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source:
-          '/sprava/bratislava-ziska-300-novych-bratislavskych-laviciek-vdaka-partnerstvu-s-csob-prve-pribudnu-v-uliciach-hlavneho-mesta-do-konca-roka',
-        destination:
-          '/blog/bratislava-ziska-300-novych-bratislavskych-laviciek-vdaka-partnerstvu-s-csob-prve-pribudnu-v-uliciach-hlavneho-mesta-do-konca-roka',
-        permanent: true,
-      },
-      {
         source: '/mestsky-parlament-mladych',
         destination: '/vzdelavanie-a-volny-cas/deti-a-mladez/mestsky-parlament-mladych',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/bratislava-ma-na-dosah-tridsat-novych-elektriciek-najnovsie-kusy-budu-vybavene-modernymi-technologiami-a-nahradia-zastarane-ktore-sluzia-aj-viac-ako-styri-dekady',
-        destination:
-          '/blog/bratislava-ma-na-dosah-tridsat-novych-elektriciek-najnovsie-kusy-budu-vybavene-modernymi-technologiami-a-nahradia-zastarane-ktore-sluzia-aj-viac-ako-styri-dekady',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/uplna-uzavierka-pribinova-culenova-a-kosicka',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/mobilna-aplikacia-ids-bk-prinasa-jednoduche-a-sikovne-cestovanie-po-novom-v-bratislavskom-kraji',
-        destination:
-          '/blog/mobilna-aplikacia-ids-bk-prinasa-jednoduche-a-sikovne-cestovanie-po-novom-v-bratislavskom-kraji',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/startovne-z-jubilujuceho-narodneho-behu-devin-bratislava-je-na-ceste-k-zdravotnikom-poputuje-im-viac-ako-29-tisic-eur',
-        destination:
-          '/blog/startovne-z-jubilujuceho-narodneho-behu-devin-bratislava-je-na-ceste-k-zdravotnikom-poputuje-im-viac-ako-29-tisic-eur',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/v-hlavnom-meste-pribudnu-nove-a-modernizovane-trolejbusove-trate-projektanti-sa-mozu-pustit-do-prace',
-        destination:
-          '/blog/v-hlavnom-meste-pribudnu-nove-a-modernizovane-trolejbusove-trate-projektanti-sa-mozu-pustit-do-prace',
         permanent: true,
       },
       {
@@ -1612,47 +1436,6 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source:
-          '/sprava/v-klimatickom-atlase-bratislavy-je-zhodnotena-zranitelnost-mesta-na-dosledky-klimatickej-krizy',
-        destination:
-          '/blog/v-klimatickom-atlase-bratislavy-je-zhodnotena-zranitelnost-mesta-na-dosledky-klimatickej-krizy',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/cestujuci-dostanu-vyse-dvesto-vylepsenych-zastavok-dopravny-podnik-bratislava-osadi-nove-pristresky-aj-oznacniky',
-        destination:
-          '/blog/cestujuci-dostanu-vyse-dvesto-vylepsenych-zastavok-dopravny-podnik-bratislava-osadi-nove-pristresky-aj-oznacniky',
-        permanent: true,
-      },
-      {
-        source:
-          '/rozkopavka-alebo-uzavierka/uplne-uzavierky-spojene-s-podujatim-csob-bratislava-marathon-2019',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/vysledok-apriloveho-vyberoveho-konania-na-poziciu-riaditel-ka-prispevkovej-organizacie-marianum-pohrebnictvo-mesta-bratislava',
-        destination:
-          '/blog/vysledok-apriloveho-vyberoveho-konania-na-poziciu-riaditel-ka-prispevkovej-organizacie-marianum-pohrebnictvo-mesta-bratislava',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/bratislavska-spolocnost-olo-spustila-proces-modernizacie-a-ekologizacie-zariadenia-na-energeticke-vyuzitie-odpadu',
-        destination:
-          '/blog/bratislavska-spolocnost-olo-spustila-proces-modernizacie-a-ekologizacie-zariadenia-na-energeticke-vyuzitie-odpadu',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/vysledok-vyberoveho-konania-na-poziciu-riaditel-ka-a-konatel-ka-firmy-mestsky-parkovaci-system-spol-s-r-o',
-        destination:
-          '/blog/vysledok-vyberoveho-konania-na-poziciu-riaditel-ka-a-konatel-ka-firmy-mestsky-parkovaci-system-spol-s-r-o',
-        permanent: true,
-      },
-      {
         source: '/vyberove-konanie-predseda-predstavenstva-bvs',
         destination: '/mesto-bratislava/transparentne-mesto/vyberove-konania',
         permanent: true,
@@ -1664,11 +1447,6 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-mlynske-nivy-56',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
         source: '/informacie-o-plneni-a-cerpani-rozpoctu',
         destination: '/mesto-bratislava/transparentne-mesto/rozpocet-a-hospodarenie',
         permanent: true,
@@ -1676,25 +1454,6 @@ const nextConfig = {
       {
         source: '/vyberove-konanie-clen-predstavenstva-cfo',
         destination: '/mesto-bratislava/transparentne-mesto/vyberove-konania',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/bratislava-podporuje-neverejnych-poskytovatelov-socialnych-sluzieb-v-zariadeniach-pre-seniorov',
-        destination:
-          '/blog/bratislava-podporuje-neverejnych-poskytovatelov-socialnych-sluzieb-v-zariadeniach-pre-seniorov',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/smart-city-projekt-atelier-inteligentne-mesta-riadene-komunitami-sa-zameria-na-rozvoj-pozitivne-energetickych-oblasti',
-        destination:
-          '/blog/smart-city-projekt-atelier-inteligentne-mesta-riadene-komunitami-sa-zameria-na-rozvoj-pozitivne-energetickych-oblasti',
-        permanent: true,
-      },
-      {
-        source: '/rss/rozkopavky-a-uzavierky',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
         permanent: true,
       },
       {
@@ -1735,25 +1494,6 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source: '/rozkopavka-alebo-uzavierka/uplna-uzavierka-prokopa-velkeho',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/zanedbany-verejny-priestor-pri-vozovni-krasnany-prejde-rekonstrukciou-sluzit-bude-chodcom-cyklistom-aj-vodicom',
-        destination:
-          '/blog/zanedbany-verejny-priestor-pri-vozovni-krasnany-prejde-rekonstrukciou-sluzit-bude-chodcom-cyklistom-aj-vodicom',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/trolejbusom-zo-stanice-na-letisko-a-megatrolejbusom-do-vychodnej-casti-bratislavy-dopravny-podnik-podpisal-zmluvy-na-nakup-novych-hybridnych-vozidiel',
-        destination:
-          '/blog/trolejbusom-zo-stanice-na-letisko-a-megatrolejbusom-do-vychodnej-casti-bratislavy-dopravny-podnik-podpisal-zmluvy-na-nakup-novych-hybridnych-vozidiel',
-        permanent: true,
-      },
-      {
         source: '/vyberove-konanie-clen-predstavenstva-cfo-bvs',
         destination: '/mesto-bratislava/transparentne-mesto/vyberove-konania',
         permanent: true,
@@ -1762,18 +1502,6 @@ const nextConfig = {
         source: '/financny-mechanizmus-ehp-a-norska-2014-2021',
         destination:
           '/mesto-bratislava/projekty/eu-projekty/financny-mechanizmus-ehp-a-norska-2014-2021',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-bajkalska-8',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/bratislava-opat-podpori-pohybove-aktivity-a-neformalne-vzdelavanie-v-oblasti-prace-s-detmi-a-mladezou',
-        destination:
-          '/blog/bratislava-opat-podpori-pohybove-aktivity-a-neformalne-vzdelavanie-v-oblasti-prace-s-detmi-a-mladezou',
         permanent: true,
       },
       {
@@ -1794,91 +1522,8 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source:
-          '/sprava/dopravny-podnik-bratislava-predstavuje-verejnosti-flotilu-novych-autobusov-solaris-new-urbino-18',
-        destination:
-          '/blog/dopravny-podnik-bratislava-predstavuje-verejnosti-flotilu-novych-autobusov-solaris-new-urbino-18',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-kosicka-7',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/mesto-bratislava-a-neziskove-organizacie-podpisali-memorandum-o-spolupraci-v-ramci-projektu-dostupneho-byvania-so-socialnou-podporou',
-        destination:
-          '/blog/mesto-bratislava-a-neziskove-organizacie-podpisali-memorandum-o-spolupraci-v-ramci-projektu-dostupneho-byvania-so-socialnou-podporou',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/mestske-lesy-v-bratislave-vybudovali-naucny-chodnik-s-altankom-a-piknikovym-miestom-nad-liscim-udolim-v-karlovej-vsi',
-        destination:
-          '/blog/mestske-lesy-v-bratislave-vybudovali-naucny-chodnik-s-altankom-a-piknikovym-miestom-nad-liscim-udolim-v-karlovej-vsi',
-        permanent: true,
-      },
-      {
-        source:
-          '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-nabrezie-armadneho-generala-ludvika-svobodu-3',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
         source: '/o-com-je-zimna-udrzba',
         destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/zimna-udrzba',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-bajkalska-ulica-5',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source: '/dan-z-nehnutelnosti',
-        destination: '/mesto-bratislava/dane-a-poplatky/dan-z-nehnutelnosti',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/poslanci-mestskeho-zastupitelstva-schvalili-rozpocet-na-rok-2021-aj-uplny-zakaz-hazardu-na-uzemi-bratislavy',
-        destination:
-          '/blog/poslanci-mestskeho-zastupitelstva-schvalili-rozpocet-na-rok-2021-aj-uplny-zakaz-hazardu-na-uzemi-bratislavy',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-hodzovo-namestie-stefanikova',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-matusova-a-lovinskeho',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/uzavierka-landererovej-a-culenovej',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source: '/uzavery-d4-r7-a-mlynske-nivy',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/cakanie-na-spoj-bude-vyrazne-komfortnejsie-cestujuci-dostanu-vyse-dvesto-zastavkovych-pristreskov',
-        destination:
-          '/blog/cakanie-na-spoj-bude-vyrazne-komfortnejsie-cestujuci-dostanu-vyse-dvesto-zastavkovych-pristreskov',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/bratislava-podpisala-memorandum-chce-ziskat-dalsi-objekt-na-vybudovanie-mestskych-najomnych-bytov',
-        destination:
-          '/blog/bratislava-podpisala-memorandum-chce-ziskat-dalsi-objekt-na-vybudovanie-mestskych-najomnych-bytov',
         permanent: true,
       },
       {
@@ -1888,37 +1533,8 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-brnianska',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-slovnaftska-ulica-2',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/vyhlasujeme-architektonicku-sutaz-na-kulturne-stredisko-a-kniznicu-na-zarnovickej-ulici-v-raci',
-        destination:
-          '/blog/vyhlasujeme-architektonicku-sutaz-na-kulturne-stredisko-a-kniznicu-na-zarnovickej-ulici-v-raci',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-pristavna-5',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
         source: '/protikorupcne-minimum',
         destination: '/mesto-bratislava/transparentne-mesto/protikorupcne-standardy',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/mesto-dosiahlo-dohodu-vdaka-ktorej-znizia-statne-lesy-tazbu-v-lesoch-na-uzemi-bratislavy-o-polovicu-a-podporia-rekreaciu',
-        destination:
-          '/blog/mesto-dosiahlo-dohodu-vdaka-ktorej-znizia-statne-lesy-tazbu-v-lesoch-na-uzemi-bratislavy-o-polovicu-a-podporia-rekreaciu',
         permanent: true,
       },
       {
@@ -1928,78 +1544,14 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source:
-          '/sprava/komunitny-zivot-mesta-a-umelecke-stipendia-nadacia-mesta-bratislavy-zverejnila-projekty-podporene-sumou-takmer-150-000-eur',
-        destination:
-          '/blog/komunitny-zivot-mesta-a-umelecke-stipendia-nadacia-mesta-bratislavy-zverejnila-projekty-podporene-sumou-takmer-150-000-eur',
-        permanent: true,
-      },
-      {
-        source: '/najnovsie-rozkopavky-a-uzavierky',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/architekti-prinavratia-budove-byvaleho-nocneho-salona-dostojnost-buducu-gastroprevadzku-prepoja-s-parkom',
-        destination:
-          '/blog/architekti-prinavratia-budove-byvaleho-nocneho-salona-dostojnost-buducu-gastroprevadzku-prepoja-s-parkom',
-        permanent: true,
-      },
-      {
         source: '/ako-bude-horsky-park-vyuzivany-po-novom',
         destination:
           '/zivotne-prostredie-a-vystavba/zelen/udrzba-a-tvorba-zelene/parky-a-zahrady/horsky-park',
         permanent: true,
       },
       {
-        source:
-          '/sprava/buduca-podoba-bytoveho-objektu-v-zahorskej-bystrici-je-znama-napreduju-aj-dalsie-projekty-mestskeho-najomneho-byvania',
-        destination:
-          '/blog/buduca-podoba-bytoveho-objektu-v-zahorskej-bystrici-je-znama-napreduju-aj-dalsie-projekty-mestskeho-najomneho-byvania',
-        permanent: true,
-      },
-      {
         source: '/novinky',
         destination: '/mesto-bratislava/transparentne-mesto/aktuality',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/kaviaren-v-kostole-ci-dalsie-ufo-v-bratislave-aj-to-sa-dozviete-v-pokracovani-projektu-turistom-vo-vlastnom-meste',
-        destination:
-          '/blog/kaviaren-v-kostole-ci-dalsie-ufo-v-bratislave-aj-to-sa-dozviete-v-pokracovani-projektu-turistom-vo-vlastnom-meste',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/nezavisla-skupina-expertov-potvrdila-moznost-elektrickovej-trate-pri-snd-bez-negativnych-dopadov-na-budovu-divadla',
-        destination:
-          '/blog/nezavisla-skupina-expertov-potvrdila-moznost-elektrickovej-trate-pri-snd-bez-negativnych-dopadov-na-budovu-divadla',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-spitalska',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/bratislava-pracuje-na-programe-komplexnej-obnovy-svojich-zakladnych-umeleckych-skol-a-centier-volneho-casu',
-        destination:
-          '/blog/bratislava-pracuje-na-programe-komplexnej-obnovy-svojich-zakladnych-umeleckych-skol-a-centier-volneho-casu',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/bratislava-bude-ekologickejsia-cast-tepla-z-energetickeho-zhodnocovania-odpadov-bude-vyuzivat-na-vykurovanie',
-        destination:
-          '/blog/bratislava-bude-ekologickejsia-cast-tepla-z-energetickeho-zhodnocovania-odpadov-bude-vyuzivat-na-vykurovanie',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-landererova-a-kosicka',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
         permanent: true,
       },
       {
@@ -2013,33 +1565,14 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source:
-          '/sprava/hlavne-mesto-je-zapojene-do-medzinarodneho-projektu-arch-v-oblasti-klimatickej-adaptacie-miest',
-        destination:
-          '/blog/hlavne-mesto-je-zapojene-do-medzinarodneho-projektu-arch-v-oblasti-klimatickej-adaptacie-miest',
-        permanent: true,
-      },
-      {
         source: '/zakladne-umelecke-skoly',
         destination: '/vzdelavanie-a-volny-cas/skolstvo/zakladne-umelecke-skoly',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-kosicka-3',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
         permanent: true,
       },
       {
         source: '/ubytovna-fortuna/',
         destination:
           '/socialne-sluzby-a-byvanie/socialne-sluzby/nizkoprahova-socialna-sluzba-pre-deti-a-rodinu-fortunacik',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/bratislava-zintenzivnuje-monitoring-liahnisk-komarov-a-zavadza-vzdusnu-aplikaciu-biologickeho-prostriedku-dronmi-2',
-        destination:
-          '/blog/bratislava-zintenzivnuje-monitoring-liahnisk-komarov-a-zavadza-vzdusnu-aplikaciu-biologickeho-prostriedku-dronmi-2',
         permanent: true,
       },
       {
@@ -2059,18 +1592,6 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-namestie-snp',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/bratislavske-open-data-prvy-mesiac-prevadzky-priniesol-tisicky-navstevnikov-aj-viac-novych-dat',
-        destination:
-          '/blog/bratislavske-open-data-prvy-mesiac-prevadzky-priniesol-tisicky-navstevnikov-aj-viac-novych-dat',
-        permanent: true,
-      },
-      {
         source: '/územný-plán',
         destination:
           '/zivotne-prostredie-a-vystavba/rozvoj-mesta/uzemnoplanovacie-dokumenty/platna-uzemnoplanovacia-dokumentacia/uzemny-plan-mesta-a-jeho-zmeny-a-doplnky',
@@ -2082,70 +1603,8 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source:
-          '/sprava/bratislava-pokracuje-v-priprave-celomestskej-parkovacej-politiky-na-proces-inovativneho-verejneho-obstaravania-bude-dohliadat-externa-komisia',
-        destination:
-          '/blog/bratislava-pokracuje-v-priprave-celomestskej-parkovacej-politiky-na-proces-inovativneho-verejneho-obstaravania-bude-dohliadat-externa-komisia',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-kosicka-5',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/dopravny-podnik-obnovi-frekventovane-zastavky-na-racianskej-radiale-v-tychto-dnoch-spusta-realizaciu-programu-obnovy-a-doplnenia-pristreskov',
-        destination:
-          '/blog/dopravny-podnik-obnovi-frekventovane-zastavky-na-racianskej-radiale-v-tychto-dnoch-spusta-realizaciu-programu-obnovy-a-doplnenia-pristreskov',
-        permanent: true,
-      },
-      {
-        source: '/situacia-v-bratislave-od-15-2-2019',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/premena-komenskeho-namestia-na-parcik-je-dobrym-prikladom-premeny-verejneho-priestoru-vitazny-navrh-architektonickej-sutaze-predstavujeme-verejnosti-v-pavilone',
-        destination:
-          '/blog/premena-komenskeho-namestia-na-parcik-je-dobrym-prikladom-premeny-verejneho-priestoru-vitazny-navrh-architektonickej-sutaze-predstavujeme-verejnosti-v-pavilone',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/v-grosslingu-sa-zacalo-rekonstruovat-obnovuje-sa-aj-niekdajsia-dominanta-stareho-mesta-komin-z-roku-1914',
-        destination:
-          '/blog/v-grosslingu-sa-zacalo-rekonstruovat-obnovuje-sa-aj-niekdajsia-dominanta-stareho-mesta-komin-z-roku-1914',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/bratislava-zintenzivnuje-monitoring-liahnisk-komarov-a-zavadza-vzdusnu-aplikaciu-biologickeho-prostriedku-dronmi',
-        destination:
-          '/blog/bratislava-zintenzivnuje-monitoring-liahnisk-komarov-a-zavadza-vzdusnu-aplikaciu-biologickeho-prostriedku-dronmi',
-        permanent: true,
-      },
-      {
-        source: '/iframe/rozkopavky-a-uzavierky',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
         source: '/parky-a-parkovo-upravovane-plochy',
         destination: '/zivotne-prostredie-a-vystavba/zelen/udrzba-a-tvorba-zelene/parky-a-zahrady',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/bratislava-ma-v-otazke-umiestnovania-diel-vo-verejnom-priestore-jasny-nazor-naraza-vsak-na-legislativne-limity',
-        destination:
-          '/blog/bratislava-ma-v-otazke-umiestnovania-diel-vo-verejnom-priestore-jasny-nazor-naraza-vsak-na-legislativne-limity',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-lieskovska-cesta-2',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
         permanent: true,
       },
       {
@@ -2154,36 +1613,9 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-kosicka-4',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-namestie-1-maja-2',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/virtualna-realita-klimaticky-futurizmus-aj-hudba-ako-protest-festival-sensorium-beyond-the-sound-2021',
-        destination:
-          '/blog/virtualna-realita-klimaticky-futurizmus-aj-hudba-ako-protest-festival-sensorium-beyond-the-sound-2021',
-        permanent: true,
-      },
-      {
         source: '/archiv-mesta-bratislavy',
         destination:
           '/kultura-a-komunity/kulturne-sluzby/sluzby-badatelne-archivu-mesta-bratislavy',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-bosakova',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-pristavna-6',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
         permanent: true,
       },
       {
@@ -2194,84 +1626,8 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-namestie-1-maja',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-stara-vinarska',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-biskupicka-2',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/bezci-vybehali-pre-zdravotnicky-a-zdravotnikov-v-stom-rocniku-narodneho-behu-devin-bratislava-viac-ako-29-tisic-eur',
-        destination:
-          '/blog/bezci-vybehali-pre-zdravotnicky-a-zdravotnikov-v-stom-rocniku-narodneho-behu-devin-bratislava-viac-ako-29-tisic-eur',
-        permanent: true,
-      },
-      {
         source: '/zimna-udrzba-pridat-ruku-k-dielu-mozeme-vsetci',
         destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/zimna-udrzba',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-bulharska-a-slovinska',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-dostojevskeho-rad-2',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-drienova',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-radlinskeho-3',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/uplna-uzavierka-parickova',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-biskupicka',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-jelacicova',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/zaujemcovia-o-stanky-pre-neziskove-mimovladne-organizacie-na-vianocne-trhy-sa-uz-mozu-prihlasovat',
-        destination:
-          '/blog/zaujemcovia-o-stanky-pre-neziskove-mimovladne-organizacie-na-vianocne-trhy-sa-uz-mozu-prihlasovat',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/v-ramci-europskeho-tyzdna-mobility-zlacnujeme-rocny-predplatny-cestovny-listok-na-mhd-a-vsetky-typy-cestovnych-listkov-zakupenych-cez-mobilnu-aplikaciu-ids-bk',
-        destination:
-          '/blog/v-ramci-europskeho-tyzdna-mobility-zlacnujeme-rocny-predplatny-cestovny-listok-na-mhd-a-vsetky-typy-cestovnych-listkov-zakupenych-cez-mobilnu-aplikaciu-ids-bk',
         permanent: true,
       },
       {
@@ -2281,80 +1637,8 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-panonska-cesta-5',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-radlinskeho-ulica-4',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/vysledky-junovych-vyberovych-konani-na-riaditela-ku-pamiatkoveho-ustavu-nacelnika-mestskej-policie-a-riaditela-ku-zoo',
-        destination:
-          '/blog/vysledky-junovych-vyberovych-konani-na-riaditela-ku-pamiatkoveho-ustavu-nacelnika-mestskej-policie-a-riaditela-ku-zoo',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/vznikla-regionalna-rada-partnerstva-pre-efektivne-manazovanie-europskych-fondov-na-uzemi-bratislavskeho-kraja',
-        destination:
-          '/blog/vznikla-regionalna-rada-partnerstva-pre-efektivne-manazovanie-europskych-fondov-na-uzemi-bratislavskeho-kraja',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/bratislava-grantom-podpori-pohybove-aktivity-a-neformalne-vzdelavanie-v-oblasti-prace-s-detmi-a-mladezou',
-        destination:
-          '/blog/bratislava-grantom-podpori-pohybove-aktivity-a-neformalne-vzdelavanie-v-oblasti-prace-s-detmi-a-mladezou',
-        permanent: true,
-      },
-      {
-        source:
-          '/vseobecne-zavazne-nariadenie-hlavneho-mesta-slovenskej-republiky-bratislavy-c-12-2014/d-11045771/p1=11049947',
-        destination:
-          '/mesto-bratislava/sprava-mesta/legislativa-mesta/vseobecne-zavazne-nariadenia',
-        permanent: true,
-      },
-      {
         source: '/erb-bratislavy-jednofarebny',
         destination: '/mesto-bratislava/sprava-mesta/vizualna-identita/symboly-mesta',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-bocna',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/prispevkove-organizacie-bratislavy-v-oblasti-kultury-oboznamia-verejnost-s-vysledkami-svojej-prace',
-        destination:
-          '/blog/prispevkove-organizacie-bratislavy-v-oblasti-kultury-oboznamia-verejnost-s-vysledkami-svojej-prace',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/uplna-uzavierka-most-snp',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-prokopa-velkeho',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-hradska-4',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/dopravny-podnik-bratislava-oznamuje-novinky-po-otvoreni-dubravsko-karloveskej-radialy-a-trasy-liniek',
-        destination:
-          '/blog/dopravny-podnik-bratislava-oznamuje-novinky-po-otvoreni-dubravsko-karloveskej-radialy-a-trasy-liniek',
         permanent: true,
       },
       {
@@ -2363,65 +1647,9 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-hradska-2',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-pri-suchom-mlyne',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/hlavne-mesto-vyhlasilo-vyzvu-na-podporu-narodnych-a-medzinarodnych-sportovych-a-vzdelavacich-podujati',
-        destination:
-          '/blog/hlavne-mesto-vyhlasilo-vyzvu-na-podporu-narodnych-a-medzinarodnych-sportovych-a-vzdelavacich-podujati',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-kosicka-6',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-samorinska',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-edisonova',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-hradska-3',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
         source: '/bratislava-pre-vsetkych-grantovy-program-v-socialnej-oblasti',
         destination:
           '/socialne-sluzby-a-byvanie/financna-podpora/grantovy-program-v-socialnej-oblasti-bratislava-pre-vsetkych',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-kosicka-2',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/na-zrekonstruovanej-elektrickovej-trati-na-americkom-namesti-sme-odstranili-bilboardy-pribudnu-zelene-plochy',
-        destination:
-          '/blog/na-zrekonstruovanej-elektrickovej-trati-na-americkom-namesti-sme-odstranili-bilboardy-pribudnu-zelene-plochy',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/verejne-prerokovanie-konceptov-urbanistickej-studie-riesenie-centralnej-rozvojovej-osi-petrzalka',
-        destination:
-          '/blog/verejne-prerokovanie-konceptov-urbanistickej-studie-riesenie-centralnej-rozvojovej-osi-petrzalka',
         permanent: true,
       },
       {
@@ -2436,33 +1664,6 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-svatoplukova-6',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-ucitelska',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/vysledok-marcoveho-vyberoveho-konania-na-poziciu-riaditela-ky-metropolitneho-institutu-bratislavy',
-        destination:
-          '/blog/vysledok-marcoveho-vyberoveho-konania-na-poziciu-riaditela-ky-metropolitneho-institutu-bratislavy',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-a-g-l-svobodu',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/docasne-dopravne-obmedzenia-hranicna-gagarinova',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
         source: '/sekcia-zivotneho-prostredia',
         destination: '/zivotne-prostredie-a-vystavba/zivotne-prostredie',
         permanent: true,
@@ -2470,27 +1671,6 @@ const nextConfig = {
       {
         source: '/ubytovanie',
         destination: '/socialne-sluzby-a-byvanie/byvanie-a-ubytovanie',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-cesta-do-spalovne-3',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-dvojkrizna',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-parickova-3',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source: '/zavedenie-zberu-kuchynskeho-biologicky-rozlozitelneho-odpadu',
-        destination:
-          '/zivotne-prostredie-a-vystavba/zivotne-prostredie/odpady/triedeny-zber/zber-kuchynskeho-bioodpadu',
         permanent: true,
       },
       {
@@ -2505,65 +1685,9 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source: '/prugerka',
-        destination: '/zivotne-prostredie-a-vystavba/zelen/udrzba-a-tvorba-zelene/parky-a-zahrady',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/spolocne-stanovisko-primatorov-paktu-slobodnych-miest-za-spravodlive-a-udrzatelne-zotavenie-po-pandemii',
-        destination:
-          '/blog/spolocne-stanovisko-primatorov-paktu-slobodnych-miest-za-spravodlive-a-udrzatelne-zotavenie-po-pandemii',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/video-spolu-s-3d-prehliadkou-prevedie-sutaziacich-aj-divakov-kupelmi-grossling-od-kotolne-az-po-strechu',
-        destination:
-          '/blog/video-spolu-s-3d-prehliadkou-prevedie-sutaziacich-aj-divakov-kupelmi-grossling-od-kotolne-az-po-strechu',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/vodna-veza-v-bratislavskom-podhradi-prejde-citlivou-obnovou-investor-je-tesne-pred-vyhlasenim-architektonickej-sutaze',
-        destination:
-          '/blog/vodna-veza-v-bratislavskom-podhradi-prejde-citlivou-obnovou-investor-je-tesne-pred-vyhlasenim-architektonickej-sutaze',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/uplna-uzavierka-kadnarova',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/uplna-uzavierka-pristavna-3',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
         source: '/baum-2020-de',
         destination:
           '/mesto-bratislava/projekty/eu-projekty/interreg-v-a-slovenska-republika–rakusko',
-        permanent: true,
-      },
-      {
-        source: '/nadacia-mesta-bratislavy',
-        destination: '/kultura-a-komunity/kulturne-sluzby/nadacia-mesta-bratislavy',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-bosakova-a-sustekova',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-radnicna-ulica',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/uplna-uzavierka-mlynske-nivy-2',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
         permanent: true,
       },
       {
@@ -2573,78 +1697,9 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source:
-          '/sprava/olo-zacina-s-rozvozom-vriec-a-informacnych-letakov-pre-zvoz-triedeneho-odpadu-z-rodinnych-domov-v-ruzinove-novom-meste-a-raci',
-        destination:
-          '/blog/olo-zacina-s-rozvozom-vriec-a-informacnych-letakov-pre-zvoz-triedeneho-odpadu-z-rodinnych-domov-v-ruzinove-novom-meste-a-raci',
-        permanent: true,
-      },
-      {
-        source: '/zavedenie-zberu-kuchynskeho-biologicky-rozlozitelneho-odpadu',
-        destination:
-          '/zivotne-prostredie-a-vystavba/zivotne-prostredie/odpady/triedeny-zber/zber-kuchynskeho-bioodpadu',
-        permanent: true,
-      },
-      {
-        source: '/dan-z-nehnutelnosti',
-        destination: '/mesto-bratislava/dane-a-poplatky/dan-z-nehnutelnosti',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-kocankova',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-kosicka-8',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-misikova',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/grantova-schema-na-predkladanie-ziadosti-pre-podporu-malych-projektov-trvalo-udrzatelneho-hospodarenia-so-zrazkovou-vodou',
-        destination:
-          '/blog/grantova-schema-na-predkladanie-ziadosti-pre-podporu-malych-projektov-trvalo-udrzatelneho-hospodarenia-so-zrazkovou-vodou',
-        permanent: true,
-      },
-      {
-        source: '/dan-z-nehnutelnosti',
-        destination: '/mesto-bratislava/dane-a-poplatky/dan-z-nehnutelnosti',
-        permanent: true,
-      },
-      {
         source: '/financny-prispevok-na-hospodarenie-so-zrazkovou-vodou',
         destination:
           '/mesto-bratislava/transparentne-mesto/pridelovanie-dotacii/financny-prispevok-na-hospodarenie-so-zrazkovou-vodou',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-razusovo-nabrezie',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/bratislava-spusta-grantovy-program-na-podporu-investicii-do-sportovej-infrastruktury-v-hlavnom-meste',
-        destination:
-          '/blog/bratislava-spusta-grantovy-program-na-podporu-investicii-do-sportovej-infrastruktury-v-hlavnom-meste',
-        permanent: true,
-      },
-      {
-        source: '/uzemny-plan',
-        destination:
-          '/zivotne-prostredie-a-vystavba/rozvoj-mesta/uzemnoplanovacie-dokumenty/platna-uzemnoplanovacia-dokumentacia/uzemny-plan-mesta-a-jeho-zmeny-a-doplnky',
-        permanent: true,
-      },
-      {
-        source: '/zavedenie-zberu-kuchynskeho-biologicky-rozlozitelneho-odpadu',
-        destination:
-          '/zivotne-prostredie-a-vystavba/zivotne-prostredie/odpady/triedeny-zber/zber-kuchynskeho-bioodpadu',
         permanent: true,
       },
       {
@@ -2654,35 +1709,8 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source: '/rozkopavky-a-uzavierky/d-77246/p1=11049948',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/ciastocna-uzavierka-zahorska',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
-        permanent: true,
-      },
-      {
         source: '/sekcia-dopravy',
         destination: '/doprava-a-mapy',
-        permanent: true,
-      },
-      {
-        source:
-          '/sprava/druhy-hokejovy-sampionat-v-historii-slovenska-zacina-o-16-dni-organizatori-i-samospravy-finisuju-s-pripravami',
-        destination:
-          '/blog/druhy-hokejovy-sampionat-v-historii-slovenska-zacina-o-16-dni-organizatori-i-samospravy-finisuju-s-pripravami',
-        permanent: true,
-      },
-      {
-        source: '/dan-z-nehnutelnosti',
-        destination: '/mesto-bratislava/dane-a-poplatky/dan-z-nehnutelnosti',
-        permanent: true,
-      },
-      {
-        source: '/rozkopavka-alebo-uzavierka/uplna-uzavierka-bajkalska',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
         permanent: true,
       },
       {
@@ -2698,11 +1726,6 @@ const nextConfig = {
       {
         source: '/mesto-bratislava/projekty/kampane/sadni-si',
         destination: '/mesto-bratislava/projekty/sadni-si',
-        permanent: true,
-      },
-      {
-        source: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/rozkopavky-a-uzavery',
-        destination: '/doprava-a-mapy/sprava-a-udrzba-komunikacii/obmedzenia-a-poruchy',
         permanent: true,
       },
     ]

--- a/next/next.config.js
+++ b/next/next.config.js
@@ -31,6 +31,11 @@ const nextConfig = {
   async rewrites() {
     return {
       beforeFiles: [
+        // robots.txt https://medium.com/@rahulsharmaah/how-to-generate-robots-txt-in-next-js-8e0bccc96b8c
+        {
+          source: '/robots.txt',
+          destination: '/api/robots',
+        },
         // Graphql Proxy
         {
           source: '/graphql',
@@ -57,11 +62,6 @@ const nextConfig = {
   },
   async redirects() {
     return [
-      {
-        source: '/robots.txt',
-        destination: '/api/robots',
-        permanent: true,
-      },
       {
         source: '/sprava/:path*',
         destination: '/blog/:path*',

--- a/next/pages/api/robots.ts
+++ b/next/pages/api/robots.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 
 const handler = async (_req: NextApiRequest, res: NextApiResponse) => {
+  /* Disallow to crawl the website completely, if not in production */
   if (process.env.NEXT_PUBLIC_IS_STAGING === 'true') {
     return res.send(
       `
@@ -9,7 +10,14 @@ const handler = async (_req: NextApiRequest, res: NextApiResponse) => {
       `,
     )
   }
-  return res.send('')
+
+  /* In production, disallow to crawl /api endpoints */
+  return res.send(
+    `
+      User-Agent: *
+      Disallow: /api/
+      `,
+  )
 }
 
 export default handler


### PR DESCRIPTION
- remove all specific redirects of type `{ source; '/sprava/:slug', destination: '/blog/:slug' }` because they are matched by pattern matching 
- remove some duplicate redirects
- groups some related redirect just to have a better overview
- add robots.txt for production deployment