### PR TITLE
Reduce the number of displayed news on homepage to prevent too much h…

### DIFF
--- a/next/components/sections/homepage-sections/HomepageTabs/TabPanelLatestNews.tsx
+++ b/next/components/sections/homepage-sections/HomepageTabs/TabPanelLatestNews.tsx
@@ -27,12 +27,12 @@ const TabPanelLatestNews = () => {
     blogPosts
       ?.filter(isDefined)
       .filter((post) => post.id !== leftNewsItem?.data?.id && post.id !== rightNewsItem?.data?.id)
-      .slice(0, 5) ?? []
+      .slice(0, 4) ?? []
 
   const allPosts =
     [leftNewsItem?.data, rightNewsItem?.data, ...latestPostsFiltered]
       .filter(isDefined)
-      .slice(0, 7) ?? []
+      .slice(0, 6) ?? []
 
   return (
     <TabPanel id="LatestNews">


### PR DESCRIPTION
…eight in cards

Change number of "additional" news from 5 to 4, to prevent large empty space in those two cards.


![image](https://github.com/bratislava/bratislava.sk/assets/19418224/52b05ae0-db5b-4e7a-9669-5d829e8b8aff)
