### PR TITLE
#1337 Change FileList item title from text to string

### DIFF
--- a/next/services/graphql/index.ts
+++ b/next/services/graphql/index.ts
@@ -4290,6 +4290,8 @@ export type BlogPostBySlugQuery = {
             }
           | {
               __typename: 'ComponentSectionsFileList'
+              title?: string | null
+              text?: string | null
               hasBackground?: boolean | null
               variantFileList?: Enum_Componentsectionsfilelist_Variant | null
               fileList?: Array<{
@@ -4660,6 +4662,8 @@ export type LatestPostsByTagsQuery = {
             }
           | {
               __typename: 'ComponentSectionsFileList'
+              title?: string | null
+              text?: string | null
               hasBackground?: boolean | null
               variantFileList?: Enum_Componentsectionsfilelist_Variant | null
               fileList?: Array<{
@@ -5231,6 +5235,8 @@ export type BlogPostEntityFragment = {
         }
       | {
           __typename: 'ComponentSectionsFileList'
+          title?: string | null
+          text?: string | null
           hasBackground?: boolean | null
           variantFileList?: Enum_Componentsectionsfilelist_Variant | null
           fileList?: Array<{
@@ -8530,6 +8536,8 @@ export type PageBySlugQuery = {
             }
           | {
               __typename: 'ComponentSectionsFileList'
+              title?: string | null
+              text?: string | null
               hasBackground?: boolean | null
               variantFileList?: Enum_Componentsectionsfilelist_Variant | null
               fileList?: Array<{
@@ -9592,6 +9600,8 @@ export type PageEntityFragment = {
         }
       | {
           __typename: 'ComponentSectionsFileList'
+          title?: string | null
+          text?: string | null
           hasBackground?: boolean | null
           variantFileList?: Enum_Componentsectionsfilelist_Variant | null
           fileList?: Array<{
@@ -11337,6 +11347,8 @@ export type FileBlockFragment = {
 
 export type FileListSectionFragment = {
   __typename?: 'ComponentSectionsFileList'
+  title?: string | null
+  text?: string | null
   hasBackground?: boolean | null
   variantFileList?: Enum_Componentsectionsfilelist_Variant | null
   fileList?: Array<{
@@ -12488,6 +12500,8 @@ type Sections_ComponentSectionsFeaturedBlogPosts_Fragment = {
 
 type Sections_ComponentSectionsFileList_Fragment = {
   __typename: 'ComponentSectionsFileList'
+  title?: string | null
+  text?: string | null
   hasBackground?: boolean | null
   variantFileList?: Enum_Componentsectionsfilelist_Variant | null
   fileList?: Array<{
@@ -13266,9 +13280,11 @@ export const FileBlockFragmentDoc = gql`
 `
 export const FileListSectionFragmentDoc = gql`
   fragment FileListSection on ComponentSectionsFileList {
+    title
+    text
     hasBackground
     variantFileList: variant
-    fileList(pagination: { limit: 500 }) {
+    fileList(pagination: { limit: -1 }) {
       ...FileBlock
     }
   }

--- a/next/services/graphql/queries/Sections.graphql
+++ b/next/services/graphql/queries/Sections.graphql
@@ -161,10 +161,12 @@ fragment FileBlock on ComponentBlocksFile {
 }
 
 fragment FileListSection on ComponentSectionsFileList {
+  title # TODO not used yet
+  text # TODO not used yet
+  # files # TODO not used yet
   hasBackground
   variantFileList: variant
-  # TODO consider limit -1
-  fileList(pagination: { limit: 500 }) {
+  fileList(pagination: { limit: -1 }) {
     ...FileBlock
   }
 }

--- a/strapi/src/components/blocks/file.json
+++ b/strapi/src/components/blocks/file.json
@@ -2,20 +2,27 @@
   "collectionName": "components_blocks_files",
   "info": {
     "displayName": "file",
-    "icon": "archive"
+    "icon": "archive",
+    "description": ""
   },
   "options": {},
   "attributes": {
     "title": {
-      "type": "text"
+      "type": "string"
     },
     "category": {
       "type": "string"
     },
     "media": {
-      "allowedTypes": ["images", "files", "videos", "audios"],
       "type": "media",
-      "multiple": false
+      "multiple": false,
+      "required": false,
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ]
     }
   }
 }


### PR DESCRIPTION
- change wrongly set title from "long" to "short" (from text to string)

Notes:
- I checked if some of the titles are not longer that 256 characters - this would cause a problem in database when changing type of the field from text to string (string allows max 256 chars)
- I tested it deployed on dev with current production DB - it works nicely