### PR TITLE
Fix typo in quantity suffix for staging resources

### DIFF
--- a/next/kubernetes/envs/Staging/config.json
+++ b/next/kubernetes/envs/Staging/config.json
@@ -1,7 +1,7 @@
 {
   "envs": {
     "NEXT_CPU_REQUESTS": "10m",
-    "NEXT_MEMORY_REQUESTS": "128mi",
+    "NEXT_MEMORY_REQUESTS": "128Mi",
     "NEXT_CPU_LIMITS": "500m",
     "NEXT_MEMORY_LIMITS": "1Gi"
   }


### PR DESCRIPTION
* Fix typo in suffix of Next memory limit from `mi` to `Mi`