### PR TITLE
#1381 Add allow-forms into iframe sandbox

### DIFF
--- a/next/components/common/Iframe/Iframe.tsx
+++ b/next/components/common/Iframe/Iframe.tsx
@@ -65,7 +65,7 @@ const Iframe = ({
           // It may not work if the iframe needs some necessary cookies, or it may block some iframe to render at all.
           // But it seems to work for all of our iframes so far.
           // https://stackoverflow.com/questions/44837450/recommended-method-to-prevent-any-content-inside-iframe-from-setting-cookies
-          sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox allow-same-origin"
+          sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-forms"
         />
       </div>
     </div>


### PR DESCRIPTION
Strangely enough, we had to add `allow-forms` (not `allow-presentation`) into our iframe sandbox prop to make embedded PowerPoint presentations work.