### PR TITLE
#1303 Remove legacy FileList section fields

### DIFF
--- a/next/services/graphql/index.ts
+++ b/next/services/graphql/index.ts
@@ -408,7 +408,6 @@ export type ComponentBlocksDocListExtensionsInput = {
 
 export type ComponentBlocksFile = {
   __typename?: 'ComponentBlocksFile'
-  category?: Maybe<Scalars['String']['output']>
   id: Scalars['ID']['output']
   media?: Maybe<UploadFileEntityResponse>
   title?: Maybe<Scalars['String']['output']>
@@ -416,7 +415,6 @@ export type ComponentBlocksFile = {
 
 export type ComponentBlocksFileFiltersInput = {
   and?: InputMaybe<Array<InputMaybe<ComponentBlocksFileFiltersInput>>>
-  category?: InputMaybe<StringFilterInput>
   not?: InputMaybe<ComponentBlocksFileFiltersInput>
   or?: InputMaybe<Array<InputMaybe<ComponentBlocksFileFiltersInput>>>
   title?: InputMaybe<StringFilterInput>
@@ -1171,22 +1169,13 @@ export type ComponentSectionsFeaturedBlogPosts = {
 export type ComponentSectionsFileList = {
   __typename?: 'ComponentSectionsFileList'
   fileList?: Maybe<Array<Maybe<ComponentBlocksFile>>>
-  files?: Maybe<Array<Maybe<ComponentBlocksFileItem>>>
-  hasBackground?: Maybe<Scalars['Boolean']['output']>
   id: Scalars['ID']['output']
   text?: Maybe<Scalars['String']['output']>
   title?: Maybe<Scalars['String']['output']>
-  variant?: Maybe<Enum_Componentsectionsfilelist_Variant>
 }
 
 export type ComponentSectionsFileListFileListArgs = {
   filters?: InputMaybe<ComponentBlocksFileFiltersInput>
-  pagination?: InputMaybe<PaginationArg>
-  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>
-}
-
-export type ComponentSectionsFileListFilesArgs = {
-  filters?: InputMaybe<ComponentBlocksFileItemFiltersInput>
   pagination?: InputMaybe<PaginationArg>
   sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>
 }
@@ -1729,11 +1718,6 @@ export enum Enum_Componentsectionsdivider_Style {
   Stromy_03FullWidth = 'stromy_03_full_width',
   Vystavba_03FullWidth = 'vystavba_03_full_width',
   Vzdelavanie = 'vzdelavanie',
-}
-
-export enum Enum_Componentsectionsfilelist_Variant {
-  Grid = 'grid',
-  Rows = 'rows',
 }
 
 export enum Enum_Componentsectionsiframe_Iframewidth {

--- a/strapi/schema.graphql
+++ b/strapi/schema.graphql
@@ -400,7 +400,6 @@ input ComponentBlocksDocListExtensionsInput {
 }
 
 type ComponentBlocksFile {
-  category: String
   id: ID!
   media: UploadFileEntityResponse
   title: String
@@ -408,14 +407,12 @@ type ComponentBlocksFile {
 
 input ComponentBlocksFileFiltersInput {
   and: [ComponentBlocksFileFiltersInput]
-  category: StringFilterInput
   not: ComponentBlocksFileFiltersInput
   or: [ComponentBlocksFileFiltersInput]
   title: StringFilterInput
 }
 
 input ComponentBlocksFileInput {
-  category: String
   id: ID
   media: ID
   title: String
@@ -1374,34 +1371,25 @@ input ComponentSectionsFeaturedBlogPostsInput {
 
 type ComponentSectionsFileList {
   fileList(filters: ComponentBlocksFileFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): [ComponentBlocksFile]
-  files(filters: ComponentBlocksFileItemFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): [ComponentBlocksFileItem]
-  hasBackground: Boolean
   id: ID!
   text: String
   title: String
-  variant: ENUM_COMPONENTSECTIONSFILELIST_VARIANT
 }
 
 input ComponentSectionsFileListFiltersInput {
   and: [ComponentSectionsFileListFiltersInput]
   fileList: ComponentBlocksFileFiltersInput
-  files: ComponentBlocksFileItemFiltersInput
-  hasBackground: BooleanFilterInput
   not: ComponentSectionsFileListFiltersInput
   or: [ComponentSectionsFileListFiltersInput]
   text: StringFilterInput
   title: StringFilterInput
-  variant: StringFilterInput
 }
 
 input ComponentSectionsFileListInput {
   fileList: [ComponentBlocksFileInput]
-  files: [ComponentBlocksFileItemInput]
-  hasBackground: Boolean
   id: ID
   text: String
   title: String
-  variant: ENUM_COMPONENTSECTIONSFILELIST_VARIANT
 }
 
 type ComponentSectionsGallery {
@@ -2201,11 +2189,6 @@ enum ENUM_COMPONENTSECTIONSDIVIDER_STYLE {
   stromy_03_full_width
   vystavba_03_full_width
   vzdelavanie
-}
-
-enum ENUM_COMPONENTSECTIONSFILELIST_VARIANT {
-  grid
-  rows
 }
 
 enum ENUM_COMPONENTSECTIONSIFRAME_IFRAMEWIDTH {

--- a/strapi/src/components/blocks/file.json
+++ b/strapi/src/components/blocks/file.json
@@ -10,9 +10,6 @@
     "title": {
       "type": "string"
     },
-    "category": {
-      "type": "string"
-    },
     "media": {
       "type": "media",
       "multiple": false,

--- a/strapi/src/components/sections/file-list.json
+++ b/strapi/src/components/sections/file-list.json
@@ -12,26 +12,10 @@
     "text": {
       "type": "text"
     },
-    "variant": {
-      "type": "enumeration",
-      "enum": [
-        "grid",
-        "rows"
-      ],
-      "default": "grid"
-    },
     "fileList": {
       "type": "component",
       "repeatable": true,
       "component": "blocks.file"
-    },
-    "hasBackground": {
-      "type": "boolean"
-    },
-    "files": {
-      "type": "component",
-      "repeatable": true,
-      "component": "blocks.file-item"
     }
   }
 }


### PR DESCRIPTION
### Description

Remove legacy fields from File list section in Strapi, run `yarn gen`.
These fields were not used anymore in FE.

### Testing

Open some page that contains File list section, e.g. "Uzemne generely" and check if you see all section and files.