### PR TITLE
#1384 #1391 Improve markdown margins and tables

### DIFF
--- a/next/src/components/formatting/Markdown/Markdown.module.scss
+++ b/next/src/components/formatting/Markdown/Markdown.module.scss
@@ -1,4 +1,55 @@
 .markdown {
+  // Nested list styles
+  & > ul {
+    list-style-type: disc;
+
+    & li > ul {
+      list-style-type: circle;
+
+      & li > ul {
+        list-style-type: square;
+
+        & li > ul {
+          list-style-type: disc;
+
+          & li > ul {
+            list-style-type: circle;
+
+            & li > ul {
+              list-style-type: square;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  & > ol {
+    list-style-type: decimal;
+
+    & li > ol {
+      list-style-type: lower-latin;
+
+      & li > ol {
+        list-style-type: lower-roman;
+
+        & li > ol {
+          list-style-type: decimal;
+
+          & li > ol {
+            list-style-type: lower-latin;
+
+            & li > ol {
+              list-style-type: lower-roman;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // margins
+
   & > *:first-child {
     @apply mt-0;
   }
@@ -16,40 +67,34 @@
     @apply mb-4 mt-10;
   }
 
-  & > ul,
-  & > ol {
-    @apply mb-8 mt-4;
+  & > blockquote {
+    @apply my-10;
   }
 
-  & > *:not(h1):not(h2):not(h3):not(h4):not(h5):not(h6):not(ul):not(ol) {
-    @apply my-4;
+  & > figure {
+    @apply my-10;
   }
 
-  ol {
+  // Select paragraphs that have an adjacent ol or ul
+  & > p:has(+ ol),
+  & > p:has(+ ul) {
+    @apply mb-3;
+  }
+
+  // Adjust the margin of list items
+
+  & > ol,
+  & > ul {
     & > li {
-      @apply my-4;
-
-      &:first-child {
-        @apply mt-0;
-      }
-
-      &:last-child {
-        @apply mt-0;
-      }
+      @apply my-3;
     }
   }
-
-  ul {
-    & > li {
-      @apply my-1;
-
-      &:first-child {
-        @apply mt-0;
-      }
-
-      &:last-child {
-        @apply mt-0;
-      }
-    }
+  // TODO write the css the way we don't have to list all the elements again with :not (?)
+  // Set margin for all other elements
+  &
+    > *:not(h1):not(h2):not(h3):not(h4):not(h5):not(h6):not(ul):not(ol):not(blockquote):not(
+      figure
+    ):not(p:has(+ ol)):not(p:has(+ ul)) {
+    @apply my-6;
   }
 }

--- a/next/src/components/formatting/Markdown/Markdown.tsx
+++ b/next/src/components/formatting/Markdown/Markdown.tsx
@@ -127,24 +127,31 @@ const Markdown = ({ content, variant = 'default', className }: MarkdownProps) =>
           // Remark-gfm components: del, input, table, tbody, td, th, thead, and tr
           // FIXME tables need revisit - align, spacing, etc.
           table: ({ children, node, ...props }) => (
-            <div className="overflow-x-auto" {...props}>
+            <div className="overflow-x-auto rounded-lg border" {...props}>
               <table className="w-full table-auto">{children}</table>
             </div>
           ),
           thead: ({ children, node, ...props }) => <thead {...props}>{children}</thead>,
-          tbody: ({ children, node, ...props }) => <tbody {...props}>{children}</tbody>,
+          tbody: ({ children, node, ...props }) => (
+            <tbody {...props} className="border-t">
+              {children}
+            </tbody>
+          ),
           tr: ({ children, node, ...props }) => (
-            <tr className={cn('h-14')} {...props}>
+            <tr className={cn('h-14 not-first:border-t')} {...props}>
               {children}
             </tr>
           ),
           td: ({ children, node, ...props }) => (
-            <td className="border px-5 py-1" {...props}>
+            <td className="px-5 py-1 not-first:border-l" {...props}>
               {children}
             </td>
           ),
           th: ({ children, node, ...props }) => (
-            <th className="border bg-background-secondary px-5 py-1 font-bold" {...props}>
+            <th
+              className="bg-background-secondary px-5 py-1 font-bold not-first:border-l"
+              {...props}
+            >
               {children}
             </th>
           ),

--- a/next/src/components/formatting/Markdown/Markdown.tsx
+++ b/next/src/components/formatting/Markdown/Markdown.tsx
@@ -3,6 +3,7 @@ import { Typography } from '@bratislava/component-library'
 import ReactMarkdown, { defaultUrlTransform } from 'react-markdown'
 import rehypeRaw from 'rehype-raw'
 import remarkGfm from 'remark-gfm'
+import supersub from 'remark-supersub'
 import remarkUnwrapImages from 'remark-unwrap-images'
 
 import MLink from '@/src/components/common/MLink/MLink'
@@ -13,6 +14,7 @@ import styles from './Markdown.module.scss'
 export type MarkdownProps = {
   content: string | null | undefined
   variant?: 'default' | 'small' | 'small-no-respo' | 'accordion'
+  className?: string
 }
 
 /**
@@ -20,6 +22,7 @@ export type MarkdownProps = {
  *
  * @param className
  * @param content
+ * @param variant
  * @constructor
  *
  * This is the closest design we have:
@@ -27,18 +30,33 @@ export type MarkdownProps = {
  */
 
 // FIXME Typography. Convert to Typography. Headers and p.
-const Markdown = ({ content, variant = 'default' }: MarkdownProps) => {
+const Markdown = ({ content, variant = 'default', className }: MarkdownProps) => {
   return (
     <div
-      className={cn(styles.markdown, {
-        'text-large-respo': variant === 'default' || variant === 'accordion',
-        'text-default-respo': variant === 'small',
-        'text-default': variant === 'small-no-respo',
-      })}
+      className={cn(
+        styles.markdown,
+        {
+          'text-large-respo': variant === 'default' || variant === 'accordion',
+          'text-default-respo': variant === 'small',
+          'text-default': variant === 'small-no-respo',
+        },
+        className,
+      )}
     >
       <ReactMarkdown
-        // fix nonfunctioning phone links - more at https://github.com/orgs/remarkjs/discussions/1329
+        // Fixes non-functioning phone links - more at https://github.com/orgs/remarkjs/discussions/1329
         urlTransform={(url) => (url.startsWith('tel:') ? url : defaultUrlTransform(url))}
+        remarkPlugins={[
+          remarkUnwrapImages,
+          [
+            remarkGfm,
+            // singleTilde is disabled to enable subscript: https://stackoverflow.com/a/78076200
+            { singleTilde: false },
+          ],
+          supersub,
+        ]}
+        // TODO remove rehypeRaw
+        rehypePlugins={[rehypeRaw]}
         components={{
           // Standard components: a, blockquote, br, code, em, h1, h2, h3, h4, h5, h6, hr, img, li, ol, p, pre, strong, and ul
 
@@ -108,27 +126,29 @@ const Markdown = ({ content, variant = 'default' }: MarkdownProps) => {
 
           // Remark-gfm components: del, input, table, tbody, td, th, thead, and tr
           // FIXME tables need revisit - align, spacing, etc.
-          table: ({ node, children }) => (
-            <div className="overflow-x-auto">
+          table: ({ children, node, ...props }) => (
+            <div className="overflow-x-auto" {...props}>
               <table className="w-full table-auto">{children}</table>
             </div>
           ),
-          tr: ({ node, children }) => (
-            <tr className="mb-4 table w-full md:mb-0 md:table-row">{children}</tr>
+          thead: ({ children, node, ...props }) => <thead {...props}>{children}</thead>,
+          tbody: ({ children, node, ...props }) => <tbody {...props}>{children}</tbody>,
+          tr: ({ children, node, ...props }) => (
+            <tr className={cn('h-14')} {...props}>
+              {children}
+            </tr>
           ),
-          tbody: ({ node, children }) => <tbody>{children}</tbody>,
-          thead: () => <thead />,
-          td: ({ node, children }) => (
-            <td className="text-large-respo table-row md:table-cell">
-              <div className="mb-1 flex items-center pr-4 text-left md:mb-0 md:py-1">
-                {children}
-              </div>
+          td: ({ children, node, ...props }) => (
+            <td className="border px-5 py-1" {...props}>
+              {children}
             </td>
           ),
-          // th: ...
+          th: ({ children, node, ...props }) => (
+            <th className="border bg-background-secondary px-5 py-1 font-bold" {...props}>
+              {children}
+            </th>
+          ),
         }}
-        remarkPlugins={[remarkGfm, remarkUnwrapImages]}
-        rehypePlugins={[rehypeRaw]}
       >
         {content ?? ''}
       </ReactMarkdown>


### PR DESCRIPTION
- use styles for Markdown from OLO (it's mostly about mostly spacing)
- improve tables in markdown, based on OLO

Notes to tables:
- no scroll fade - TODO

Tables are on these pages:
`/mesto-bratislava/dane-a-poplatky`
`/zivotne-prostredie-a-vystavba/rozvoj-mesta/spoluucast-developerov-na-rozvoji-mesta`
`/doprava-a-mapy/doprava/dopravne-povolenia`    (v akordeone "Povolenie vjazdu..." a "Vyhradene parkovanie")
`/socialne-sluzby-a-byvanie/financna-podpora/financovanie-neverejnych-poskytovatelov-socialnych-sluzieb/socialne-sluzby-krizovej-intervencie`     (v akordeone)

Desktop

![image](https://github.com/user-attachments/assets/9df44212-2c46-4d1e-80e9-58fa11767e1a)

Mobile
(Note that there are non breaking spaces used in IBANs in Strapi)

![image](https://github.com/user-attachments/assets/b4c0903b-b94f-469f-b612-8fab6748aac1)

