### PR TITLE
#1156 Exclude groups from contacts search from AD

### DIFF
--- a/next/src/services/ms-graph/server/searchInOrgStructure.ts
+++ b/next/src/services/ms-graph/server/searchInOrgStructure.ts
@@ -24,7 +24,7 @@ export const searchInOrgStructure = async (query: string, accessToken: string) =
   /* Letters with diacritics causes request to fail (it needs investigation why, but slugify helps) */
   const sanitizedQuery = slugify(query, { separator: ' ', customReplacements: [['ä', 'a']] }).trim()
 
-  const url = `https://graph.microsoft.com/v1.0/groups/${MS_GRAPH_GROUP_ID}/transitiveMembers?${[
+  const url = `https://graph.microsoft.com/v1.0/groups/${MS_GRAPH_GROUP_ID}/transitiveMembers/microsoft.graph.user?${[
     `$select=${PARAMS_FROM_MS_GRAPH_API.join(',')}`,
     `$search="displayName:${sanitizedQuery}" OR "jobTitle:${sanitizedQuery}" OR "mail:${sanitizedQuery}"`,
     // TODO add support for searching in businessPhones and mobilePhone


### PR DESCRIPTION
Inspiration taken from docs here: https://learn.microsoft.com/en-us/graph/api/group-list-transitivemembers?view=graph-rest-1.0&tabs=http#example-4-use-odata-cast-and-search-to-get-membership-in-groups-with-display-names-that-contain-the-letters-tier-including-a-count-of-returned-objects

![image](https://github.com/user-attachments/assets/fa455416-5f96-4725-8333-16ca1a3d681a)
