### PR TITLE
#1332 Quickfix dividers and borders for file lists

### DIFF
--- a/next/src/components/common/Divider/HorizontalDivider.tsx
+++ b/next/src/components/common/Divider/HorizontalDivider.tsx
@@ -2,18 +2,23 @@ import React from 'react'
 
 import cn from '@/src/utils/cn'
 
-type HorizontalDividerProps = { categoryColor?: boolean; className?: string }
+type HorizontalDividerProps = {
+  categoryColor?: boolean
+  className?: string
+  asListItem?: boolean
+}
 
-const HorizontalDivider = ({ categoryColor, className }: HorizontalDividerProps) => {
-  return (
-    <div
-      role="separator"
-      className={cn(
-        'border-b-2',
-        { 'border-category-600': categoryColor, 'border-grey-200': !categoryColor },
-        className,
-      )}
-    />
+const HorizontalDivider = ({ categoryColor, className, asListItem }: HorizontalDividerProps) => {
+  const styles = cn(
+    'border-b-2',
+    { 'border-category-600': categoryColor, 'border-grey-200': !categoryColor },
+    className,
+  )
+
+  return asListItem ? (
+    <li role="separator" className={styles} />
+  ) : (
+    <div role="separator" className={styles} />
   )
 }
 

--- a/next/src/components/common/FileList/FileList.tsx
+++ b/next/src/components/common/FileList/FileList.tsx
@@ -1,4 +1,5 @@
 import { Typography } from '@bratislava/component-library'
+import { Fragment } from 'react'
 
 import FileRowCardWrapper from '@/src/components/cards/FileRowCardWrapper'
 import HorizontalDivider from '@/src/components/common/Divider/HorizontalDivider'
@@ -28,13 +29,12 @@ const FileList = ({ className, title, text, files }: FileListProps) => {
 
       <ul className="flex flex-col rounded-lg border-2 py-2">
         {files.map((file, index) => (
-          <>
-            {index > 0 ? <HorizontalDivider className="mx-4 lg:mx-6" /> : null}
-            {/* eslint-disable-next-line react/no-array-index-key */}
-            <li key={index} className="w-full">
+          <Fragment key={file.id}>
+            {index > 0 ? <HorizontalDivider asListItem className="mx-4 lg:mx-6" /> : null}
+            <li className="w-full">
               <FileRowCardWrapper fileItem={file} />
             </li>
-          </>
+          </Fragment>
         ))}
       </ul>
     </div>

--- a/next/src/components/page-contents/InbaReleasePageContent.tsx
+++ b/next/src/components/page-contents/InbaReleasePageContent.tsx
@@ -1,9 +1,10 @@
 import { Typography } from '@bratislava/component-library'
 import * as React from 'react'
-import { useMemo } from 'react'
+import { Fragment, useMemo } from 'react'
 
 import FileRowCard from '@/src/components/cards/FileRowCard'
 import { Breadcrumb } from '@/src/components/common/Breadcrumbs/Breadcrumbs'
+import HorizontalDivider from '@/src/components/common/Divider/HorizontalDivider'
 import ImagePlaceholder from '@/src/components/common/Image/ImagePlaceholder'
 import StrapiImage from '@/src/components/common/Image/StrapiImage'
 import NarrowText from '@/src/components/common/NarrowText/NarrowText'
@@ -79,22 +80,25 @@ const InbaReleasePageContent = ({ inbaRelease }: InbaReleasePageContentProps) =>
                 {t('InbaRelease.toDownload')}
               </Typography>
 
-              {/* TODO refactor, use FileList */}
-              {files?.filter(isDefined).map((file) => (
-                <FileRowCard
-                  key={file.media.data?.id}
-                  title={file.title ?? file.media.data?.attributes?.name ?? ''}
-                  downloadLink={file.media.data?.attributes?.url}
-                  format={formatFileExtension(file.media.data?.attributes?.ext) ?? undefined}
-                  size={
-                    file.media.data?.attributes?.size
-                      ? formatFileSize(file.media.data?.attributes?.size, locale)
-                      : undefined
-                  }
-                  // TODO download aria label
-                  // ariaLabel={getDownloadAriaLabel(file.media.data?.attributes)}
-                />
-              ))}
+              <ul className="flex flex-col rounded-lg border-2 py-2">
+                {files?.filter(isDefined).map((file, index) => (
+                  <Fragment key={file.media.data?.id}>
+                    {index > 0 ? <HorizontalDivider asListItem className="mx-4 lg:mx-6" /> : null}
+                    <li>
+                      <FileRowCard
+                        title={file.title ?? file.media.data?.attributes?.name ?? ''}
+                        downloadLink={file.media.data?.attributes?.url}
+                        format={formatFileExtension(file.media.data?.attributes?.ext) ?? undefined}
+                        size={
+                          file.media.data?.attributes?.size
+                            ? formatFileSize(file.media.data?.attributes?.size, locale)
+                            : undefined
+                        }
+                      />
+                    </li>
+                  </Fragment>
+                ))}
+              </ul>
             </div>
           </div>
         </div>

--- a/next/src/components/page-contents/OfficialBoardDocumentPageContent.tsx
+++ b/next/src/components/page-contents/OfficialBoardDocumentPageContent.tsx
@@ -2,10 +2,10 @@ import { Typography } from '@bratislava/component-library'
 import React, { Fragment, ReactNode } from 'react'
 
 import FileRowCard from '@/src/components/cards/FileRowCard'
+import HorizontalDivider from '@/src/components/common/Divider/HorizontalDivider'
 import PageHeader from '@/src/components/common/PageHeader/PageHeader'
 import SectionContainer from '@/src/components/common/SectionContainer/SectionContainer'
 import { ParsedOfficialBoardDocumentDetail } from '@/src/services/ginis/types'
-import cn from '@/src/utils/cn'
 import { formatDate } from '@/src/utils/formatDate'
 import { useLocale } from '@/src/utils/useLocale'
 import { useTranslation } from '@/src/utils/useTranslation'
@@ -65,24 +65,25 @@ const OfficialBoardDocumentPageContent = ({ document }: OfficialBoardDocumentPag
             <Typography type="h2" size="h4">
               {t('OfficialBoard.attachments')}
             </Typography>
-            <div className="flex flex-col rounded-lg border-2 px-4">
+            <ul className="flex flex-col rounded-lg border-2">
               {document.files.length > 0 ? (
                 document.files.map((file, index) => (
-                  <FileRowCard
-                    key={file.id}
-                    title={file.title}
-                    size={file.size}
-                    format="PDF"
-                    downloadLink={file.generatedUrl}
-                    className={cn('-mx-4 px-4', {
-                      '[&>*]:border-b-0': index === document.files.length - 1,
-                    })}
-                  />
+                  <Fragment key={file.id}>
+                    {index > 0 ? <HorizontalDivider asListItem className="mx-4 lg:mx-6" /> : null}
+                    <li>
+                      <FileRowCard
+                        title={file.title}
+                        size={file.size}
+                        format="PDF"
+                        downloadLink={file.generatedUrl}
+                      />
+                    </li>
+                  </Fragment>
                 ))
               ) : (
                 <Typography type="p">{t('OfficialBoard.noAttachmentsMessage')}</Typography>
               )}
-            </div>
+            </ul>
           </div>
 
           <div className="flex flex-col gap-6">

--- a/next/src/components/page-contents/RegulationPageContent.tsx
+++ b/next/src/components/page-contents/RegulationPageContent.tsx
@@ -96,28 +96,32 @@ const RegulationPageContent = ({ regulation }: RegulationPageContentProps) => {
 
               {/* TODO refactor to use standard component */}
               {attachmentFiles?.length ? (
-                <div className="rounded-lg border-2 py-2">
+                <ul className="rounded-lg border-2 py-2">
                   {attachmentFiles
-                    .map(({ media: attachementMedia, title: attachmentTitle }, index) => {
-                      if (!attachementMedia.data.attributes) return null
+                    .map(({ media: attachmentMedia, title: attachmentTitle }, index) => {
+                      if (!attachmentMedia.data.attributes) return null
 
                       return (
-                        <>
-                          {index > 0 ? <HorizontalDivider className="mx-4 lg:mx-6" /> : null}
-                          <FileRowCard
-                            key={attachementMedia.data.id}
-                            title={attachmentTitle ?? attachementMedia.data.attributes.name}
-                            size={formatFileSize(attachementMedia.data.attributes.size, locale)}
-                            format={
-                              formatFileExtension(attachementMedia.data.attributes.ext) ?? undefined
-                            }
-                            downloadLink={attachementMedia.data.attributes.url}
-                          />
-                        </>
+                        <Fragment key={attachmentMedia.data.id}>
+                          {index > 0 ? (
+                            <HorizontalDivider asListItem className="mx-4 lg:mx-6" />
+                          ) : null}
+                          <li>
+                            <FileRowCard
+                              title={attachmentTitle ?? attachmentMedia.data.attributes.name}
+                              size={formatFileSize(attachmentMedia.data.attributes.size, locale)}
+                              format={
+                                formatFileExtension(attachmentMedia.data.attributes.ext) ??
+                                undefined
+                              }
+                              downloadLink={attachmentMedia.data.attributes.url}
+                            />
+                          </li>
+                        </Fragment>
                       )
                     })
                     .filter(isDefined)}
-                </div>
+                </ul>
               ) : (
                 <Typography type="p">{t('Regulation.noAttachmentsMessage')}</Typography>
               )}

--- a/next/src/components/sections/SearchSection/SearchResultCard.tsx
+++ b/next/src/components/sections/SearchSection/SearchResultCard.tsx
@@ -16,17 +16,13 @@ import { isDefined } from '@/src/utils/isDefined'
 
 type SearchResultCardProps = {
   data: SearchResult
-  hideBottomDivider?: boolean
 }
 
-const SearchResultCard = ({ data, hideBottomDivider }: SearchResultCardProps) => {
+const SearchResultCard = ({ data }: SearchResultCardProps) => {
   return (
     <div className="px-5 lg:px-6">
       <div
-        className={cn(
-          'group relative flex flex-row items-stretch gap-4 overflow-hidden bg-white py-4',
-          { 'border-b-2': !hideBottomDivider },
-        )}
+        className="group relative flex flex-row items-stretch gap-4 overflow-hidden bg-white py-4"
         data-cy="search-result-card"
       >
         {data.coverImageSrc ? (

--- a/next/src/components/sections/SearchSection/SearchResults.tsx
+++ b/next/src/components/sections/SearchSection/SearchResults.tsx
@@ -1,7 +1,8 @@
 import { Typography } from '@bratislava/component-library'
-import React, { Dispatch, SetStateAction, useEffect } from 'react'
+import React, { Dispatch, Fragment, SetStateAction, useEffect } from 'react'
 import { Selection } from 'react-aria-components'
 
+import HorizontalDivider from '@/src/components/common/Divider/HorizontalDivider'
 import LoadingSpinner from '@/src/components/common/LoadingSpinner/LoadingSpinner'
 import Pagination from '@/src/components/common/Pagination/Pagination'
 import { SearchOption } from '@/src/components/sections/SearchSection/GlobalSearchSectionContent'
@@ -46,8 +47,6 @@ const SearchResults = ({
   const { searchResultsData, searchResultsCount } = data ?? { searchResultsCount: 0 }
 
   const GENERAL_RESULTS_COUNT = 5
-  const RESULTS_COUNT =
-    (searchResultsData?.length as number) < 5 ? searchResultsData?.length : GENERAL_RESULTS_COUNT // Logic based on TabPanelOfficialBoard.tsx
 
   useEffect(() => {
     onSetResultsCount(searchOption.id, searchResultsCount ?? 0)
@@ -82,20 +81,20 @@ const SearchResults = ({
           <ul className="flex flex-col rounded-lg border-2 py-2" data-cy="search-results">
             {searchResultsData
               .slice(0, variant === 'allResults' ? GENERAL_RESULTS_COUNT : undefined)
-              .map((item, index) => {
+              .map((searchResultsItem, index) => {
                 return (
-                  <li
+                  <Fragment
                     key={`item-${variant}-${searchOption.id}-${[
-                      item.uniqueId,
-                      item.title,
-                      ...(item?.metadata ?? []),
+                      searchResultsItem.uniqueId,
+                      searchResultsItem.title,
+                      ...(searchResultsItem?.metadata ?? []),
                     ].join('')}`}
                   >
-                    <SearchResultCard
-                      data={{ ...item }}
-                      hideBottomDivider={index === (RESULTS_COUNT as number) - 1}
-                    />
-                  </li>
+                    {index > 0 ? <HorizontalDivider className="mx-4 lg:mx-6" /> : null}
+                    <li>
+                      <SearchResultCard data={searchResultsItem} />
+                    </li>
+                  </Fragment>
                 )
               })}
           </ul>

--- a/next/src/components/sections/homepage-sections/HomepageTabs/TabPanelOfficialBoard.tsx
+++ b/next/src/components/sections/homepage-sections/HomepageTabs/TabPanelOfficialBoard.tsx
@@ -1,8 +1,10 @@
 import { Typography } from '@bratislava/component-library'
 import { useQuery } from '@tanstack/react-query'
+import { Fragment } from 'react'
 import { TabPanel } from 'react-aria-components'
 
 import Button from '@/src/components/common/Button/Button'
+import HorizontalDivider from '@/src/components/common/Divider/HorizontalDivider'
 import LoadingSpinner from '@/src/components/common/LoadingSpinner/LoadingSpinner'
 import { useHomepageContext } from '@/src/components/providers/HomepageContextProvider'
 import SearchResultCard from '@/src/components/sections/SearchSection/SearchResultCard'
@@ -73,12 +75,12 @@ const TabPanelOfficialBoard = () => {
             </li>
           ) : (
             documents.map((document, index) => (
-              <li key={document.uniqueId}>
-                <SearchResultCard
-                  data={{ ...document }}
-                  hideBottomDivider={index === documents.length - 1}
-                />
-              </li>
+              <Fragment key={document.uniqueId}>
+                {index > 0 ? <HorizontalDivider asListItem className="mx-4 lg:mx-6" /> : null}
+                <li>
+                  <SearchResultCard data={document} />
+                </li>
+              </Fragment>
             ))
           )}
         </ul>

--- a/next/src/services/graphql/index.ts
+++ b/next/src/services/graphql/index.ts
@@ -4839,6 +4839,7 @@ export type BlogPostBySlugQuery = {
               text?: string | null
               fileList?: Array<{
                 __typename?: 'ComponentBlocksFile'
+                id: string
                 title?: string | null
                 media?: {
                   __typename?: 'UploadFileEntityResponse'
@@ -5181,6 +5182,7 @@ export type LatestPostsByTagsQuery = {
               text?: string | null
               fileList?: Array<{
                 __typename?: 'ComponentBlocksFile'
+                id: string
                 title?: string | null
                 media?: {
                   __typename?: 'UploadFileEntityResponse'
@@ -5724,6 +5726,7 @@ export type BlogPostEntityFragment = {
           text?: string | null
           fileList?: Array<{
             __typename?: 'ComponentBlocksFile'
+            id: string
             title?: string | null
             media?: {
               __typename?: 'UploadFileEntityResponse'
@@ -8636,6 +8639,7 @@ export type PageBySlugQuery = {
                 } | null
                 fileList?: Array<{
                   __typename?: 'ComponentBlocksFileItem'
+                  id: string
                   title?: string | null
                   media: {
                     __typename?: 'UploadFileEntityResponse'
@@ -8896,6 +8900,7 @@ export type PageBySlugQuery = {
               text?: string | null
               fileList?: Array<{
                 __typename?: 'ComponentBlocksFile'
+                id: string
                 title?: string | null
                 media?: {
                   __typename?: 'UploadFileEntityResponse'
@@ -9561,6 +9566,7 @@ export type PageEntityFragment = {
             } | null
             fileList?: Array<{
               __typename?: 'ComponentBlocksFileItem'
+              id: string
               title?: string | null
               media: {
                 __typename?: 'UploadFileEntityResponse'
@@ -9817,6 +9823,7 @@ export type PageEntityFragment = {
           text?: string | null
           fileList?: Array<{
             __typename?: 'ComponentBlocksFile'
+            id: string
             title?: string | null
             media?: {
               __typename?: 'UploadFileEntityResponse'
@@ -11449,6 +11456,7 @@ export type IframeSectionFragment = {
 
 export type FileBlockFragment = {
   __typename?: 'ComponentBlocksFile'
+  id: string
   title?: string | null
   media?: {
     __typename?: 'UploadFileEntityResponse'
@@ -11474,6 +11482,7 @@ export type FileListSectionFragment = {
   text?: string | null
   fileList?: Array<{
     __typename?: 'ComponentBlocksFile'
+    id: string
     title?: string | null
     media?: {
       __typename?: 'UploadFileEntityResponse'
@@ -11496,6 +11505,7 @@ export type FileListSectionFragment = {
 
 export type FileItemBlockFragment = {
   __typename?: 'ComponentBlocksFileItem'
+  id: string
   title?: string | null
   media: {
     __typename?: 'UploadFileEntityResponse'
@@ -11604,6 +11614,7 @@ export type ComponentAccordionItemsFlatTextFragment = {
   } | null
   fileList?: Array<{
     __typename?: 'ComponentBlocksFileItem'
+    id: string
     title?: string | null
     media: {
       __typename?: 'UploadFileEntityResponse'
@@ -11672,6 +11683,7 @@ export type AccordionSectionFragment = {
     } | null
     fileList?: Array<{
       __typename?: 'ComponentBlocksFileItem'
+      id: string
       title?: string | null
       media: {
         __typename?: 'UploadFileEntityResponse'
@@ -12167,6 +12179,7 @@ type Sections_ComponentSectionsAccordion_Fragment = {
     } | null
     fileList?: Array<{
       __typename?: 'ComponentBlocksFileItem'
+      id: string
       title?: string | null
       media: {
         __typename?: 'UploadFileEntityResponse'
@@ -12410,6 +12423,7 @@ type Sections_ComponentSectionsFileList_Fragment = {
   text?: string | null
   fileList?: Array<{
     __typename?: 'ComponentBlocksFile'
+    id: string
     title?: string | null
     media?: {
       __typename?: 'UploadFileEntityResponse'
@@ -13033,6 +13047,7 @@ export const UploadFileEntityFragmentDoc = gql`
 `
 export const FileBlockFragmentDoc = gql`
   fragment FileBlock on ComponentBlocksFile {
+    id
     title
     media {
       data {
@@ -13108,6 +13123,7 @@ export const ComponentAccordionItemsInstitutionFragmentDoc = gql`
 `
 export const FileItemBlockFragmentDoc = gql`
   fragment FileItemBlock on ComponentBlocksFileItem {
+    id
     title
     media {
       data {

--- a/next/src/services/graphql/queries/Sections.graphql
+++ b/next/src/services/graphql/queries/Sections.graphql
@@ -116,6 +116,7 @@ fragment IframeSection on ComponentSectionsIframe {
 }
 
 fragment FileBlock on ComponentBlocksFile {
+  id
   title
   media {
     data {
@@ -133,6 +134,7 @@ fragment FileListSection on ComponentSectionsFileList {
 }
 
 fragment FileItemBlock on ComponentBlocksFileItem {
+  id
   title
   media {
     data {


### PR DESCRIPTION
Improve ui for file lists. I tried to implement a "ListBox" component, but ended in some problems, so I decides to only implement quickfix as small step for better filelists :D

All file lists should now have a box with border and dividers, and they should be in `<ul>`.

### Screenshots

FileList section, e.g. here https://bratislava.sk/zivotne-prostredie-a-vystavba/rozvoj-mesta/uzemnoplanovacie-dokumenty/prerokovane-uzemnoplanovacie-podklady/uzemne-generely

![image](https://github.com/user-attachments/assets/83f459eb-2db5-4696-9d85-f3dc4f02dbb9)

Search page https://bratislava.sk/vyhladavanie

![image](https://github.com/user-attachments/assets/218373df-28bb-4697-a1cd-010a41bfb844)

![image](https://github.com/user-attachments/assets/7766640f-3bac-4b64-b2a3-31cbfa9457c3)

Regulation detail page https://bratislava.sk/vzn/11-2023

![image](https://github.com/user-attachments/assets/36ee0737-1772-478d-8ac5-f95de46ff164)

Official board on homepage in tab https://bratislava.sk/

![image](https://github.com/user-attachments/assets/0c3358bd-5401-4550-b070-22b3812f867f)

Inba Release https://bratislava.sk/inba/archiv/in-ba-9-10-2023

![image](https://github.com/user-attachments/assets/407c9ddf-659a-4d55-ab5d-38bdb290f79c)

Official Board documents

![image](https://github.com/user-attachments/assets/6347316a-48da-4bba-917b-e44a14a467c9)

