### PR TITLE
#1486 Make BlogPost title required and short

### DIFF
--- a/next/src/components/common/Bookmarks_Deprecated/Bookmark_Deprecated.tsx
+++ b/next/src/components/common/Bookmarks_Deprecated/Bookmark_Deprecated.tsx
@@ -97,7 +97,8 @@ const Bookmark = ({
         </span>
       </Button>
 
-      <div className="flex py-5" aria-hidden={!isOpen} inert={!isOpen}>
+      {/* @ts-ignore */}
+      <div className="flex py-5" aria-hidden={!isOpen} inert={(!isOpen).toString()}>
         <div className="flex w-44 items-center justify-center">
           {icon ? (
             <div

--- a/next/src/services/graphql/index.ts
+++ b/next/src/services/graphql/index.ts
@@ -99,7 +99,7 @@ export type BlogPost = {
   sections?: Maybe<Array<Maybe<BlogPostSectionsDynamicZone>>>
   slug?: Maybe<Scalars['String']['output']>
   tag?: Maybe<TagEntityResponse>
-  title?: Maybe<Scalars['String']['output']>
+  title: Scalars['String']['output']
   updatedAt?: Maybe<Scalars['DateTime']['output']>
 }
 
@@ -4771,7 +4771,7 @@ export type BlogPostBySlugQuery = {
         __typename?: 'BlogPost'
         slug?: string | null
         excerpt?: string | null
-        title?: string | null
+        title: string
         updatedAt?: any | null
         publishedAt?: any | null
         date_added?: any | null
@@ -4815,11 +4815,7 @@ export type BlogPostBySlugQuery = {
             data?: {
               __typename?: 'BlogPostEntity'
               id?: string | null
-              attributes?: {
-                __typename?: 'BlogPost'
-                title?: string | null
-                slug?: string | null
-              } | null
+              attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
             } | null
           } | null
         } | null
@@ -5114,7 +5110,7 @@ export type LatestPostsByTagsQuery = {
         __typename?: 'BlogPost'
         slug?: string | null
         excerpt?: string | null
-        title?: string | null
+        title: string
         updatedAt?: any | null
         publishedAt?: any | null
         date_added?: any | null
@@ -5158,11 +5154,7 @@ export type LatestPostsByTagsQuery = {
             data?: {
               __typename?: 'BlogPostEntity'
               id?: string | null
-              attributes?: {
-                __typename?: 'BlogPost'
-                title?: string | null
-                slug?: string | null
-              } | null
+              attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
             } | null
           } | null
         } | null
@@ -5467,7 +5459,7 @@ export type BlogPostsRssFeedQuery = {
       attributes?: {
         __typename?: 'BlogPost'
         slug?: string | null
-        title?: string | null
+        title: string
         publishedAt?: any | null
         date_added?: any | null
         excerpt?: string | null
@@ -5525,7 +5517,7 @@ export type LatestBlogsWithTagsQuery = {
       attributes?: {
         __typename?: 'BlogPost'
         slug?: string | null
-        title?: string | null
+        title: string
         excerpt?: string | null
         date_added?: any | null
         publishedAt?: any | null
@@ -5569,7 +5561,7 @@ export type LatestBlogPostEntityFragment = {
   attributes?: {
     __typename?: 'BlogPost'
     slug?: string | null
-    title?: string | null
+    title: string
     excerpt?: string | null
     date_added?: any | null
     publishedAt?: any | null
@@ -5605,52 +5597,6 @@ export type LatestBlogPostEntityFragment = {
   } | null
 }
 
-export type TotalPostsCountQueryVariables = Exact<{
-  where?: InputMaybe<BlogPostFiltersInput>
-  limit?: InputMaybe<Scalars['Int']['input']>
-  locale?: InputMaybe<Scalars['I18NLocaleCode']['input']>
-}>
-
-export type TotalPostsCountQuery = {
-  __typename?: 'Query'
-  blogPosts?: {
-    __typename?: 'BlogPostEntityResponseCollection'
-    meta: {
-      __typename?: 'ResponseCollectionMeta'
-      pagination: { __typename?: 'Pagination'; total: number; pageCount: number }
-    }
-  } | null
-}
-
-export type RelatedTagsQueryVariables = Exact<{
-  where?: InputMaybe<TagFiltersInput>
-}>
-
-export type RelatedTagsQuery = {
-  __typename?: 'Query'
-  tags?: {
-    __typename?: 'TagEntityResponseCollection'
-    data: Array<{
-      __typename?: 'TagEntity'
-      attributes?: {
-        __typename?: 'Tag'
-        title?: string | null
-        pageCategory?: {
-          __typename?: 'PageCategoryEntityResponse'
-          data?: {
-            __typename?: 'PageCategoryEntity'
-            attributes?: {
-              __typename?: 'PageCategory'
-              title?: string | null
-              color?: Enum_Pagecategory_Color | null
-            } | null
-          } | null
-        } | null
-      } | null
-    }>
-  } | null
-}
-
 export type BlogPostEntityFragment = {
   __typename?: 'BlogPostEntity'
   id?: string | null
@@ -5658,7 +5604,7 @@ export type BlogPostEntityFragment = {
     __typename?: 'BlogPost'
     slug?: string | null
     excerpt?: string | null
-    title?: string | null
+    title: string
     updatedAt?: any | null
     publishedAt?: any | null
     date_added?: any | null
@@ -5702,11 +5648,7 @@ export type BlogPostEntityFragment = {
         data?: {
           __typename?: 'BlogPostEntity'
           id?: string | null
-          attributes?: {
-            __typename?: 'BlogPost'
-            title?: string | null
-            slug?: string | null
-          } | null
+          attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
         } | null
       } | null
     } | null
@@ -5990,7 +5932,7 @@ export type BlogPostLinkFragment = {
     data?: {
       __typename?: 'BlogPostEntity'
       id?: string | null
-      attributes?: { __typename?: 'BlogPost'; title?: string | null; slug?: string | null } | null
+      attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
     } | null
   } | null
 }
@@ -6077,6 +6019,348 @@ export type PageCategoryEntityFragment = {
   } | null
 }
 
+export type Dev_AllBlogPostsQueryVariables = Exact<{
+  sort?: InputMaybe<
+    Array<InputMaybe<Scalars['String']['input']>> | InputMaybe<Scalars['String']['input']>
+  >
+  limit?: InputMaybe<Scalars['Int']['input']>
+  start?: InputMaybe<Scalars['Int']['input']>
+  filters?: InputMaybe<BlogPostFiltersInput>
+  locale?: InputMaybe<Scalars['I18NLocaleCode']['input']>
+}>
+
+export type Dev_AllBlogPostsQuery = {
+  __typename?: 'Query'
+  blogPosts?: {
+    __typename?: 'BlogPostEntityResponseCollection'
+    data: Array<{
+      __typename?: 'BlogPostEntity'
+      id?: string | null
+      attributes?: {
+        __typename?: 'BlogPost'
+        slug?: string | null
+        excerpt?: string | null
+        title: string
+        updatedAt?: any | null
+        publishedAt?: any | null
+        date_added?: any | null
+        createdAt?: any | null
+        tag?: {
+          __typename?: 'TagEntityResponse'
+          data?: {
+            __typename?: 'TagEntity'
+            id?: string | null
+            attributes?: {
+              __typename?: 'Tag'
+              title?: string | null
+              pageCategory?: {
+                __typename?: 'PageCategoryEntityResponse'
+                data?: {
+                  __typename?: 'PageCategoryEntity'
+                  id?: string | null
+                  attributes?: {
+                    __typename?: 'PageCategory'
+                    title?: string | null
+                    color?: Enum_Pagecategory_Color | null
+                  } | null
+                } | null
+              } | null
+            } | null
+          } | null
+        } | null
+        coverImage?: {
+          __typename?: 'UploadFileEntityResponse'
+          data?: {
+            __typename?: 'UploadFileEntity'
+            attributes?: { __typename?: 'UploadFile'; url: string } | null
+          } | null
+        } | null
+        moreLink?: {
+          __typename?: 'ComponentBlocksBlogPostLink'
+          title?: string | null
+          url?: string | null
+          blogPost?: {
+            __typename?: 'BlogPostEntityResponse'
+            data?: {
+              __typename?: 'BlogPostEntity'
+              id?: string | null
+              attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
+            } | null
+          } | null
+        } | null
+        sections?: Array<
+          | {
+              __typename: 'ComponentSectionsColumnedText'
+              content?: string | null
+              contentAlignment?: Enum_Componentsectionscolumnedtext_Contentalignment | null
+            }
+          | {
+              __typename: 'ComponentSectionsDivider'
+              style?: Enum_Componentsectionsdivider_Style | null
+            }
+          | {
+              __typename: 'ComponentSectionsFileList'
+              title?: string | null
+              text?: string | null
+              fileList?: Array<{
+                __typename?: 'ComponentBlocksFile'
+                id: string
+                title?: string | null
+                media?: {
+                  __typename?: 'UploadFileEntityResponse'
+                  data?: {
+                    __typename?: 'UploadFileEntity'
+                    id?: string | null
+                    attributes?: {
+                      __typename?: 'UploadFile'
+                      url: string
+                      name: string
+                      ext?: string | null
+                      size: number
+                      createdAt?: any | null
+                      updatedAt?: any | null
+                    } | null
+                  } | null
+                } | null
+              } | null> | null
+            }
+          | {
+              __typename: 'ComponentSectionsGallery'
+              title?: string | null
+              text?: string | null
+              medias: {
+                __typename?: 'UploadFileRelationResponseCollection'
+                data: Array<{
+                  __typename?: 'UploadFileEntity'
+                  id?: string | null
+                  attributes?: {
+                    __typename?: 'UploadFile'
+                    url: string
+                    width?: number | null
+                    height?: number | null
+                    caption?: string | null
+                    alternativeText?: string | null
+                    name: string
+                  } | null
+                }>
+              }
+            }
+          | {
+              __typename: 'ComponentSectionsNarrowText'
+              content?: string | null
+              width?: Enum_Componentsectionsnarrowtext_Width | null
+              align?: Enum_Componentsectionsnarrowtext_Align | null
+            }
+          | {
+              __typename: 'ComponentSectionsNumericalList'
+              id: string
+              title?: string | null
+              variant?: Enum_Componentsectionsnumericallist_Variant | null
+              buttonText?: string | null
+              buttonLink?: string | null
+              items?: Array<{
+                __typename?: 'ComponentBlocksNumericalListItem'
+                text?: string | null
+              } | null> | null
+            }
+          | {
+              __typename: 'ComponentSectionsRegulations'
+              regulations?: {
+                __typename?: 'RegulationRelationResponseCollection'
+                data: Array<{
+                  __typename?: 'RegulationEntity'
+                  id?: string | null
+                  attributes?: {
+                    __typename?: 'Regulation'
+                    regNumber: string
+                    slug: string
+                    titleText?: string | null
+                    fullTitle: string
+                    effectiveFrom: any
+                    category: Enum_Regulation_Category
+                    isFullTextRegulation: boolean
+                    mainDocument: {
+                      __typename?: 'UploadFileEntityResponse'
+                      data?: {
+                        __typename?: 'UploadFileEntity'
+                        id?: string | null
+                        attributes?: {
+                          __typename?: 'UploadFile'
+                          url: string
+                          name: string
+                          ext?: string | null
+                          size: number
+                          createdAt?: any | null
+                          updatedAt?: any | null
+                        } | null
+                      } | null
+                    }
+                    attachments?: {
+                      __typename?: 'UploadFileRelationResponseCollection'
+                      data: Array<{
+                        __typename?: 'UploadFileEntity'
+                        id?: string | null
+                        attributes?: {
+                          __typename?: 'UploadFile'
+                          url: string
+                          name: string
+                          ext?: string | null
+                          size: number
+                          createdAt?: any | null
+                          updatedAt?: any | null
+                        } | null
+                      }>
+                    } | null
+                    amendments?: {
+                      __typename?: 'RegulationRelationResponseCollection'
+                      data: Array<{
+                        __typename?: 'RegulationEntity'
+                        id?: string | null
+                        attributes?: {
+                          __typename?: 'Regulation'
+                          regNumber: string
+                          slug: string
+                          effectiveFrom: any
+                          isFullTextRegulation: boolean
+                          attachments?: {
+                            __typename?: 'UploadFileRelationResponseCollection'
+                            data: Array<{
+                              __typename?: 'UploadFileEntity'
+                              id?: string | null
+                              attributes?: {
+                                __typename?: 'UploadFile'
+                                url: string
+                                name: string
+                                ext?: string | null
+                                size: number
+                                createdAt?: any | null
+                                updatedAt?: any | null
+                              } | null
+                            }>
+                          } | null
+                        } | null
+                      }>
+                    } | null
+                    amending?: {
+                      __typename?: 'RegulationRelationResponseCollection'
+                      data: Array<{
+                        __typename?: 'RegulationEntity'
+                        id?: string | null
+                        attributes?: {
+                          __typename?: 'Regulation'
+                          regNumber: string
+                          slug: string
+                          effectiveFrom: any
+                          cancellation?: {
+                            __typename?: 'RegulationEntityResponse'
+                            data?: {
+                              __typename?: 'RegulationEntity'
+                              id?: string | null
+                              attributes?: {
+                                __typename?: 'Regulation'
+                                regNumber: string
+                                slug: string
+                                effectiveFrom: any
+                              } | null
+                            } | null
+                          } | null
+                          amending?: {
+                            __typename?: 'RegulationRelationResponseCollection'
+                            data: Array<{
+                              __typename?: 'RegulationEntity'
+                              id?: string | null
+                              attributes?: {
+                                __typename?: 'Regulation'
+                                regNumber: string
+                                slug: string
+                                cancellation?: {
+                                  __typename?: 'RegulationEntityResponse'
+                                  data?: {
+                                    __typename?: 'RegulationEntity'
+                                    id?: string | null
+                                    attributes?: {
+                                      __typename?: 'Regulation'
+                                      regNumber: string
+                                      slug: string
+                                      effectiveFrom: any
+                                    } | null
+                                  } | null
+                                } | null
+                              } | null
+                            }>
+                          } | null
+                        } | null
+                      }>
+                    } | null
+                    cancellation?: {
+                      __typename?: 'RegulationEntityResponse'
+                      data?: {
+                        __typename?: 'RegulationEntity'
+                        id?: string | null
+                        attributes?: {
+                          __typename?: 'Regulation'
+                          regNumber: string
+                          slug: string
+                          effectiveFrom: any
+                        } | null
+                      } | null
+                    } | null
+                    cancelling?: {
+                      __typename?: 'RegulationRelationResponseCollection'
+                      data: Array<{
+                        __typename?: 'RegulationEntity'
+                        id?: string | null
+                        attributes?: {
+                          __typename?: 'Regulation'
+                          regNumber: string
+                          slug: string
+                          effectiveFrom: any
+                        } | null
+                      }>
+                    } | null
+                  } | null
+                }>
+              } | null
+            }
+          | {
+              __typename: 'ComponentSectionsTextWithImage'
+              content?: string | null
+              imagePosition?: Enum_Componentsectionstextwithimage_Imageposition | null
+              imageSrc?: {
+                __typename?: 'UploadFileEntityResponse'
+                data?: {
+                  __typename?: 'UploadFileEntity'
+                  attributes?: {
+                    __typename?: 'UploadFile'
+                    url: string
+                    alternativeText?: string | null
+                    width?: number | null
+                    height?: number | null
+                  } | null
+                } | null
+              } | null
+            }
+          | {
+              __typename: 'ComponentSectionsVideos'
+              id: string
+              title?: string | null
+              subtitle?: string | null
+              videos?: Array<{
+                __typename?: 'ComponentBlocksVideo'
+                id: string
+                title?: string | null
+                speaker?: string | null
+                url?: string | null
+              } | null> | null
+            }
+          | { __typename: 'Error' }
+          | null
+        > | null
+      } | null
+    }>
+  } | null
+}
+
 export type FaqCategoryEntityFragment = {
   __typename?: 'FaqCategoryEntity'
   id?: string | null
@@ -6153,7 +6437,7 @@ export type CommonLinkFragment = {
     data?: {
       __typename?: 'BlogPostEntity'
       id?: string | null
-      attributes?: { __typename?: 'BlogPost'; title?: string | null; slug?: string | null } | null
+      attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
     } | null
   } | null
 }
@@ -6179,7 +6463,7 @@ export type FooterColumnBlockFragment = {
       data?: {
         __typename?: 'BlogPostEntity'
         id?: string | null
-        attributes?: { __typename?: 'BlogPost'; title?: string | null; slug?: string | null } | null
+        attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
       } | null
     } | null
   } | null> | null
@@ -6211,11 +6495,7 @@ export type FooterFragment = {
         data?: {
           __typename?: 'BlogPostEntity'
           id?: string | null
-          attributes?: {
-            __typename?: 'BlogPost'
-            title?: string | null
-            slug?: string | null
-          } | null
+          attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
         } | null
       } | null
     } | null> | null
@@ -6238,7 +6518,7 @@ export type FooterFragment = {
       data?: {
         __typename?: 'BlogPostEntity'
         id?: string | null
-        attributes?: { __typename?: 'BlogPost'; title?: string | null; slug?: string | null } | null
+        attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
       } | null
     } | null
   } | null
@@ -6260,7 +6540,7 @@ export type FooterFragment = {
       data?: {
         __typename?: 'BlogPostEntity'
         id?: string | null
-        attributes?: { __typename?: 'BlogPost'; title?: string | null; slug?: string | null } | null
+        attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
       } | null
     } | null
   } | null
@@ -6420,11 +6700,7 @@ export type GeneralFragment = {
         data?: {
           __typename?: 'BlogPostEntity'
           id?: string | null
-          attributes?: {
-            __typename?: 'BlogPost'
-            title?: string | null
-            slug?: string | null
-          } | null
+          attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
         } | null
       } | null
     } | null
@@ -6590,11 +6866,7 @@ export type GeneralQuery = {
               data?: {
                 __typename?: 'BlogPostEntity'
                 id?: string | null
-                attributes?: {
-                  __typename?: 'BlogPost'
-                  title?: string | null
-                  slug?: string | null
-                } | null
+                attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
               } | null
             } | null
           } | null
@@ -6800,11 +7072,7 @@ export type GeneralQuery = {
               data?: {
                 __typename?: 'BlogPostEntity'
                 id?: string | null
-                attributes?: {
-                  __typename?: 'BlogPost'
-                  title?: string | null
-                  slug?: string | null
-                } | null
+                attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
               } | null
             } | null
           } | null> | null
@@ -6831,11 +7099,7 @@ export type GeneralQuery = {
             data?: {
               __typename?: 'BlogPostEntity'
               id?: string | null
-              attributes?: {
-                __typename?: 'BlogPost'
-                title?: string | null
-                slug?: string | null
-              } | null
+              attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
             } | null
           } | null
         } | null
@@ -6861,11 +7125,7 @@ export type GeneralQuery = {
             data?: {
               __typename?: 'BlogPostEntity'
               id?: string | null
-              attributes?: {
-                __typename?: 'BlogPost'
-                title?: string | null
-                slug?: string | null
-              } | null
+              attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
             } | null
           } | null
         } | null
@@ -6944,11 +7204,7 @@ export type HomepageEntityFragment = {
             data?: {
               __typename?: 'BlogPostEntity'
               id?: string | null
-              attributes?: {
-                __typename?: 'BlogPost'
-                title?: string | null
-                slug?: string | null
-              } | null
+              attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
             } | null
           } | null
         }
@@ -6972,7 +7228,7 @@ export type HomepageEntityFragment = {
           attributes?: {
             __typename?: 'BlogPost'
             slug?: string | null
-            title?: string | null
+            title: string
             excerpt?: string | null
             date_added?: any | null
             publishedAt?: any | null
@@ -7016,7 +7272,7 @@ export type HomepageEntityFragment = {
           attributes?: {
             __typename?: 'BlogPost'
             slug?: string | null
-            title?: string | null
+            title: string
             excerpt?: string | null
             date_added?: any | null
             publishedAt?: any | null
@@ -7070,11 +7326,7 @@ export type HomepageEntityFragment = {
           data?: {
             __typename?: 'BlogPostEntity'
             id?: string | null
-            attributes?: {
-              __typename?: 'BlogPost'
-              title?: string | null
-              slug?: string | null
-            } | null
+            attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
           } | null
         } | null
       } | null
@@ -7096,11 +7348,7 @@ export type HomepageEntityFragment = {
           data?: {
             __typename?: 'BlogPostEntity'
             id?: string | null
-            attributes?: {
-              __typename?: 'BlogPost'
-              title?: string | null
-              slug?: string | null
-            } | null
+            attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
           } | null
         } | null
       } | null
@@ -7122,11 +7370,7 @@ export type HomepageEntityFragment = {
           data?: {
             __typename?: 'BlogPostEntity'
             id?: string | null
-            attributes?: {
-              __typename?: 'BlogPost'
-              title?: string | null
-              slug?: string | null
-            } | null
+            attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
           } | null
         } | null
       } | null
@@ -7153,11 +7397,7 @@ export type HomepageEntityFragment = {
           data?: {
             __typename?: 'BlogPostEntity'
             id?: string | null
-            attributes?: {
-              __typename?: 'BlogPost'
-              title?: string | null
-              slug?: string | null
-            } | null
+            attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
           } | null
         } | null
       } | null
@@ -7179,11 +7419,7 @@ export type HomepageEntityFragment = {
           data?: {
             __typename?: 'BlogPostEntity'
             id?: string | null
-            attributes?: {
-              __typename?: 'BlogPost'
-              title?: string | null
-              slug?: string | null
-            } | null
+            attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
           } | null
         } | null
       } | null
@@ -7210,11 +7446,7 @@ export type HomepageEntityFragment = {
           data?: {
             __typename?: 'BlogPostEntity'
             id?: string | null
-            attributes?: {
-              __typename?: 'BlogPost'
-              title?: string | null
-              slug?: string | null
-            } | null
+            attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
           } | null
         } | null
       } | null
@@ -7247,11 +7479,7 @@ export type HomepageEntityFragment = {
             data?: {
               __typename?: 'BlogPostEntity'
               id?: string | null
-              attributes?: {
-                __typename?: 'BlogPost'
-                title?: string | null
-                slug?: string | null
-              } | null
+              attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
             } | null
           } | null
         }
@@ -7396,7 +7624,7 @@ export type HomepageQuery = {
                   id?: string | null
                   attributes?: {
                     __typename?: 'BlogPost'
-                    title?: string | null
+                    title: string
                     slug?: string | null
                   } | null
                 } | null
@@ -7422,7 +7650,7 @@ export type HomepageQuery = {
               attributes?: {
                 __typename?: 'BlogPost'
                 slug?: string | null
-                title?: string | null
+                title: string
                 excerpt?: string | null
                 date_added?: any | null
                 publishedAt?: any | null
@@ -7466,7 +7694,7 @@ export type HomepageQuery = {
               attributes?: {
                 __typename?: 'BlogPost'
                 slug?: string | null
-                title?: string | null
+                title: string
                 excerpt?: string | null
                 date_added?: any | null
                 publishedAt?: any | null
@@ -7524,11 +7752,7 @@ export type HomepageQuery = {
               data?: {
                 __typename?: 'BlogPostEntity'
                 id?: string | null
-                attributes?: {
-                  __typename?: 'BlogPost'
-                  title?: string | null
-                  slug?: string | null
-                } | null
+                attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
               } | null
             } | null
           } | null
@@ -7554,11 +7778,7 @@ export type HomepageQuery = {
               data?: {
                 __typename?: 'BlogPostEntity'
                 id?: string | null
-                attributes?: {
-                  __typename?: 'BlogPost'
-                  title?: string | null
-                  slug?: string | null
-                } | null
+                attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
               } | null
             } | null
           } | null
@@ -7584,11 +7804,7 @@ export type HomepageQuery = {
               data?: {
                 __typename?: 'BlogPostEntity'
                 id?: string | null
-                attributes?: {
-                  __typename?: 'BlogPost'
-                  title?: string | null
-                  slug?: string | null
-                } | null
+                attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
               } | null
             } | null
           } | null
@@ -7619,11 +7835,7 @@ export type HomepageQuery = {
               data?: {
                 __typename?: 'BlogPostEntity'
                 id?: string | null
-                attributes?: {
-                  __typename?: 'BlogPost'
-                  title?: string | null
-                  slug?: string | null
-                } | null
+                attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
               } | null
             } | null
           } | null
@@ -7649,11 +7861,7 @@ export type HomepageQuery = {
               data?: {
                 __typename?: 'BlogPostEntity'
                 id?: string | null
-                attributes?: {
-                  __typename?: 'BlogPost'
-                  title?: string | null
-                  slug?: string | null
-                } | null
+                attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
               } | null
             } | null
           } | null
@@ -7684,11 +7892,7 @@ export type HomepageQuery = {
               data?: {
                 __typename?: 'BlogPostEntity'
                 id?: string | null
-                attributes?: {
-                  __typename?: 'BlogPost'
-                  title?: string | null
-                  slug?: string | null
-                } | null
+                attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
               } | null
             } | null
           } | null
@@ -7723,7 +7927,7 @@ export type HomepageQuery = {
                   id?: string | null
                   attributes?: {
                     __typename?: 'BlogPost'
-                    title?: string | null
+                    title: string
                     slug?: string | null
                   } | null
                 } | null
@@ -7855,7 +8059,7 @@ export type HomepageHighlightsItemFragment = {
       data?: {
         __typename?: 'BlogPostEntity'
         id?: string | null
-        attributes?: { __typename?: 'BlogPost'; title?: string | null; slug?: string | null } | null
+        attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
       } | null
     } | null
   }
@@ -7879,7 +8083,7 @@ export type HomepageTabsFragment = {
       attributes?: {
         __typename?: 'BlogPost'
         slug?: string | null
-        title?: string | null
+        title: string
         excerpt?: string | null
         date_added?: any | null
         publishedAt?: any | null
@@ -7923,7 +8127,7 @@ export type HomepageTabsFragment = {
       attributes?: {
         __typename?: 'BlogPost'
         slug?: string | null
-        title?: string | null
+        title: string
         excerpt?: string | null
         date_added?: any | null
         publishedAt?: any | null
@@ -7977,7 +8181,7 @@ export type HomepageTabsFragment = {
       data?: {
         __typename?: 'BlogPostEntity'
         id?: string | null
-        attributes?: { __typename?: 'BlogPost'; title?: string | null; slug?: string | null } | null
+        attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
       } | null
     } | null
   } | null
@@ -7999,7 +8203,7 @@ export type HomepageTabsFragment = {
       data?: {
         __typename?: 'BlogPostEntity'
         id?: string | null
-        attributes?: { __typename?: 'BlogPost'; title?: string | null; slug?: string | null } | null
+        attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
       } | null
     } | null
   } | null
@@ -8021,7 +8225,7 @@ export type HomepageTabsFragment = {
       data?: {
         __typename?: 'BlogPostEntity'
         id?: string | null
-        attributes?: { __typename?: 'BlogPost'; title?: string | null; slug?: string | null } | null
+        attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
       } | null
     } | null
   } | null
@@ -8049,7 +8253,7 @@ export type HomepageMayorAndCouncilFragment = {
       data?: {
         __typename?: 'BlogPostEntity'
         id?: string | null
-        attributes?: { __typename?: 'BlogPost'; title?: string | null; slug?: string | null } | null
+        attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
       } | null
     } | null
   } | null
@@ -8071,7 +8275,7 @@ export type HomepageMayorAndCouncilFragment = {
       data?: {
         __typename?: 'BlogPostEntity'
         id?: string | null
-        attributes?: { __typename?: 'BlogPost'; title?: string | null; slug?: string | null } | null
+        attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
       } | null
     } | null
   } | null
@@ -8098,7 +8302,7 @@ export type TopServicesItemFragment = {
       data?: {
         __typename?: 'BlogPostEntity'
         id?: string | null
-        attributes?: { __typename?: 'BlogPost'; title?: string | null; slug?: string | null } | null
+        attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
       } | null
     } | null
   }
@@ -8594,11 +8798,7 @@ export type PageBySlugQuery = {
             data?: {
               __typename?: 'BlogPostEntity'
               id?: string | null
-              attributes?: {
-                __typename?: 'BlogPost'
-                title?: string | null
-                slug?: string | null
-              } | null
+              attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
             } | null
           } | null
         } | null> | null
@@ -8705,7 +8905,7 @@ export type PageBySlugQuery = {
                     id?: string | null
                     attributes?: {
                       __typename?: 'BlogPost'
-                      title?: string | null
+                      title: string
                       slug?: string | null
                     } | null
                   } | null
@@ -8735,7 +8935,7 @@ export type PageBySlugQuery = {
                     id?: string | null
                     attributes?: {
                       __typename?: 'BlogPost'
-                      title?: string | null
+                      title: string
                       slug?: string | null
                     } | null
                   } | null
@@ -8765,7 +8965,7 @@ export type PageBySlugQuery = {
                     id?: string | null
                     attributes?: {
                       __typename?: 'BlogPost'
-                      title?: string | null
+                      title: string
                       slug?: string | null
                     } | null
                   } | null
@@ -9521,11 +9721,7 @@ export type PageEntityFragment = {
         data?: {
           __typename?: 'BlogPostEntity'
           id?: string | null
-          attributes?: {
-            __typename?: 'BlogPost'
-            title?: string | null
-            slug?: string | null
-          } | null
+          attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
         } | null
       } | null
     } | null> | null
@@ -9630,11 +9826,7 @@ export type PageEntityFragment = {
               data?: {
                 __typename?: 'BlogPostEntity'
                 id?: string | null
-                attributes?: {
-                  __typename?: 'BlogPost'
-                  title?: string | null
-                  slug?: string | null
-                } | null
+                attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
               } | null
             } | null
           } | null
@@ -9660,11 +9852,7 @@ export type PageEntityFragment = {
               data?: {
                 __typename?: 'BlogPostEntity'
                 id?: string | null
-                attributes?: {
-                  __typename?: 'BlogPost'
-                  title?: string | null
-                  slug?: string | null
-                } | null
+                attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
               } | null
             } | null
           } | null
@@ -9690,11 +9878,7 @@ export type PageEntityFragment = {
               data?: {
                 __typename?: 'BlogPostEntity'
                 id?: string | null
-                attributes?: {
-                  __typename?: 'BlogPost'
-                  title?: string | null
-                  slug?: string | null
-                } | null
+                attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
               } | null
             } | null
           } | null
@@ -11852,7 +12036,7 @@ export type BannerSectionFragment = {
       data?: {
         __typename?: 'BlogPostEntity'
         id?: string | null
-        attributes?: { __typename?: 'BlogPost'; title?: string | null; slug?: string | null } | null
+        attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
       } | null
     } | null
   } | null
@@ -11874,7 +12058,7 @@ export type BannerSectionFragment = {
       data?: {
         __typename?: 'BlogPostEntity'
         id?: string | null
-        attributes?: { __typename?: 'BlogPost'; title?: string | null; slug?: string | null } | null
+        attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
       } | null
     } | null
   } | null
@@ -11896,7 +12080,7 @@ export type BannerSectionFragment = {
       data?: {
         __typename?: 'BlogPostEntity'
         id?: string | null
-        attributes?: { __typename?: 'BlogPost'; title?: string | null; slug?: string | null } | null
+        attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
       } | null
     } | null
   } | null
@@ -12240,7 +12424,7 @@ type Sections_ComponentSectionsBanner_Fragment = {
       data?: {
         __typename?: 'BlogPostEntity'
         id?: string | null
-        attributes?: { __typename?: 'BlogPost'; title?: string | null; slug?: string | null } | null
+        attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
       } | null
     } | null
   } | null
@@ -12262,7 +12446,7 @@ type Sections_ComponentSectionsBanner_Fragment = {
       data?: {
         __typename?: 'BlogPostEntity'
         id?: string | null
-        attributes?: { __typename?: 'BlogPost'; title?: string | null; slug?: string | null } | null
+        attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
       } | null
     } | null
   } | null
@@ -12284,7 +12468,7 @@ type Sections_ComponentSectionsBanner_Fragment = {
       data?: {
         __typename?: 'BlogPostEntity'
         id?: string | null
-        attributes?: { __typename?: 'BlogPost'; title?: string | null; slug?: string | null } | null
+        attributes?: { __typename?: 'BlogPost'; title: string; slug?: string | null } | null
       } | null
     } | null
   } | null
@@ -14442,37 +14626,6 @@ export const LatestBlogsWithTagsDocument = gql`
   }
   ${LatestBlogPostEntityFragmentDoc}
 `
-export const TotalPostsCountDocument = gql`
-  query TotalPostsCount($where: BlogPostFiltersInput, $limit: Int, $locale: I18NLocaleCode) {
-    blogPosts(filters: $where, pagination: { limit: $limit }, locale: $locale) {
-      meta {
-        pagination {
-          total
-          pageCount
-        }
-      }
-    }
-  }
-`
-export const RelatedTagsDocument = gql`
-  query RelatedTags($where: TagFiltersInput) {
-    tags(pagination: { limit: -1 }, filters: $where) {
-      data {
-        attributes {
-          title
-          pageCategory {
-            data {
-              attributes {
-                title
-                color
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-`
 export const PageCategoriesDocument = gql`
   query pageCategories($locale: I18NLocaleCode) {
     pageCategories(pagination: { limit: -1 }, locale: $locale) {
@@ -14492,6 +14645,27 @@ export const BlogPostsTagsDocument = gql`
     }
   }
   ${TagEntityFragmentDoc}
+`
+export const Dev_AllBlogPostsDocument = gql`
+  query Dev_AllBlogPosts(
+    $sort: [String]
+    $limit: Int
+    $start: Int
+    $filters: BlogPostFiltersInput
+    $locale: I18NLocaleCode
+  ) {
+    blogPosts(
+      sort: $sort
+      pagination: { limit: $limit, start: $start }
+      filters: $filters
+      locale: $locale
+    ) {
+      data {
+        ...BlogPostEntity
+      }
+    }
+  }
+  ${BlogPostEntityFragmentDoc}
 `
 export const GeneralDocument = gql`
   query General($locale: I18NLocaleCode!) {
@@ -14903,36 +15077,6 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
         variables,
       )
     },
-    TotalPostsCount(
-      variables?: TotalPostsCountQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<TotalPostsCountQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<TotalPostsCountQuery>(TotalPostsCountDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'TotalPostsCount',
-        'query',
-        variables,
-      )
-    },
-    RelatedTags(
-      variables?: RelatedTagsQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<RelatedTagsQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<RelatedTagsQuery>(RelatedTagsDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'RelatedTags',
-        'query',
-        variables,
-      )
-    },
     pageCategories(
       variables?: PageCategoriesQueryVariables,
       requestHeaders?: GraphQLClientRequestHeaders,
@@ -14959,6 +15103,21 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
             ...wrappedRequestHeaders,
           }),
         'blogPostsTags',
+        'query',
+        variables,
+      )
+    },
+    Dev_AllBlogPosts(
+      variables?: Dev_AllBlogPostsQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<Dev_AllBlogPostsQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<Dev_AllBlogPostsQuery>(Dev_AllBlogPostsDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'Dev_AllBlogPosts',
         'query',
         variables,
       )

--- a/next/src/services/graphql/queries/BlogPosts.graphql
+++ b/next/src/services/graphql/queries/BlogPosts.graphql
@@ -127,35 +127,6 @@ fragment LatestBlogPostEntity on BlogPostEntity {
   }
 }
 
-query TotalPostsCount($where: BlogPostFiltersInput, $limit: Int, $locale: I18NLocaleCode) {
-  blogPosts(filters: $where, pagination: { limit: $limit }, locale: $locale) {
-    meta {
-      pagination {
-        total
-        pageCount
-      }
-    }
-  }
-}
-
-query RelatedTags($where: TagFiltersInput) {
-  tags(pagination: { limit: -1 }, filters: $where) {
-    data {
-      attributes {
-        title
-        pageCategory {
-          data {
-            attributes {
-              title
-              color
-            }
-          }
-        }
-      }
-    }
-  }
-}
-
 fragment BlogPostEntity on BlogPostEntity {
   id
   attributes {
@@ -246,5 +217,24 @@ fragment PageCategoryEntity on PageCategoryEntity {
   attributes {
     title
     color
+  }
+}
+
+query Dev_AllBlogPosts(
+  $sort: [String]
+  $limit: Int
+  $start: Int
+  $filters: BlogPostFiltersInput
+  $locale: I18NLocaleCode
+) {
+  blogPosts(
+    sort: $sort
+    pagination: { limit: $limit, start: $start }
+    filters: $filters
+    locale: $locale
+  ) {
+    data {
+      ...BlogPostEntity
+    }
   }
 }

--- a/next/src/utils/dev/strapiHelper.ts
+++ b/next/src/utils/dev/strapiHelper.ts
@@ -1,0 +1,143 @@
+/* eslint-disable no-console */
+
+import { client } from '@/src/services/graphql/gql'
+import { isDefined } from '@/src/utils/isDefined'
+
+const CONSOLE_BLUE = '\u001B[34m'
+const CONSOLE_YELLOW = '\u001B[33m'
+const CONSOLE_GREEN = '\u001B[32m'
+const CONSOLE_WHITE = '\u001B[0m'
+const CONSOLE_GREY = '\u001B[90m'
+
+// Based on strapi graphql helper: https://github.com/bratislava/strapi-graphql-migration-helper
+
+//  Usage example - put this inside index.tsx, inside getStaticProps:
+//   await logAllSectionsByType({
+//     entityType: 'page',
+//     sectionName: 'ComponentSectionsBanner',
+//   })
+
+export async function listBlogPosts() {
+  const { blogPosts } = await client.Dev_AllBlogPosts({ locale: 'all', limit: -1 })
+
+  const posts = blogPosts?.data ?? []
+
+  const filteredPosts = posts
+    .map((post) => post.attributes)
+    .filter(isDefined)
+    .filter((post) => post.title?.trim().includes('\n'))
+
+  console.log('Number of all posts:', posts.length)
+  console.log('Number of filteredPosts:', filteredPosts.length)
+  console.log(
+    'Filtered posts:',
+    filteredPosts.map((post) => post.slug),
+  )
+}
+
+// TODO simplify
+// eslint-disable-next-line sonarjs/cognitive-complexity
+// export async function logAllSectionsByType({
+//   entityType,
+//   sectionName,
+//   locale,
+//   showExtendedInfo = false,
+// }: {
+//   entityType: 'page' | 'workshop' | 'service'
+//   sectionName: SectionName
+//   locale?: string
+//   showExtendedInfo?: boolean
+// }) {
+//   const LOCALE_DEFAULT = 'sk'
+//
+//   let data
+//   let entities
+//
+//   const foundEntities: { count: number; [key: string]: number } = { count: 0 }
+//   let foundSectionsCount = 0
+//
+//   switch (entityType) {
+//     case 'page':
+//       data = await client.Pages({ locale: locale ?? LOCALE_DEFAULT })
+//       entities = data.pages?.data
+//       break
+//
+//     case 'workshop':
+//       data = await client.Workshops()
+//       entities = data.workshops?.data
+//       break
+//
+//     case 'service':
+//       data = await client.Services({ locale: locale ?? LOCALE_DEFAULT })
+//       entities = data.services?.data
+//       break
+//
+//     default:
+//       break
+//   }
+//   if (!entities) {
+//     return
+//   }
+//
+//   console.log('\n')
+//
+//   console.log(
+//     `Searching through ${CONSOLE_BLUE}${process.env.NEXT_PUBLIC_STRAPI_URL}${CONSOLE_WHITE}`,
+//   )
+//   console.log(
+//     `For all entities of type ${CONSOLE_BLUE}${entityType}${CONSOLE_WHITE}, logging all sections with __typename ${CONSOLE_BLUE}${sectionName}${CONSOLE_WHITE}`,
+//   )
+//   console.log('\n')
+//
+//   entities.forEach((entity) => {
+//     const strapiEntityLink = `${process.env.NEXT_PUBLIC_STRAPI_URL}/admin/content-manager/collection-types/api::${entityType}.${entityType}/${entity.id}`
+//
+//     const entityLog: { __typename: SectionName; title: string | undefined }[] = []
+//
+//     entity.attributes?.sections?.forEach((section) => {
+//       if (section?.__typename === sectionName) {
+//         entityLog.push({
+//           __typename: sectionName,
+//           title: entity.attributes?.title,
+//         })
+//
+//         foundSectionsCount += 1
+//         if (entity.id && !foundEntities[entity.id]) {
+//           foundEntities.count += 1
+//         }
+//       }
+//     })
+//
+//     const entityLogMessage = entityLog
+//       .map(
+//         (sectionLog) =>
+//           `- ${CONSOLE_GREEN}${sectionLog.title}${CONSOLE_WHITE} ${CONSOLE_GREY}${sectionLog.__typename}${CONSOLE_WHITE}`,
+//       )
+//       .join('\n')
+//
+//     if (entityLog.length === 0) return
+//
+//     if (showExtendedInfo) {
+//       console.log(`[${entityType}] ${entity.attributes?.title}`)
+//       console.log(`${strapiEntityLink}`)
+//       console.log(entityLogMessage)
+//       console.log('\n')
+//     } else {
+//       console.log(
+//         `${entityLog.length}x ${sectionName?.replace('ComponentSections', '')} found at ${entity.attributes?.title} ${CONSOLE_GREY}${strapiEntityLink}${CONSOLE_WHITE}`,
+//       )
+//     }
+//   })
+//
+//   console.log('\n')
+//   console.log(
+//     `${CONSOLE_YELLOW}Finished searching through ${CONSOLE_BLUE}${process.env.NEXT_PUBLIC_STRAPI_URL}${CONSOLE_GREY} (to search other Strapi instances, change your .env.local)`,
+//   )
+//   console.log(
+//     `${CONSOLE_YELLOW}Found ${CONSOLE_BLUE}${foundSectionsCount}${CONSOLE_YELLOW} sections with __typename ${CONSOLE_BLUE}${sectionName}${CONSOLE_YELLOW} within \u001B[34m${foundEntities.count} ${CONSOLE_YELLOW}entities of type ${CONSOLE_BLUE}${entityType}\u001B[0m `,
+//   )
+//   console.log(
+//     '_______________________________________________________________________________________________________________',
+//     '\n',
+//   )
+// }

--- a/strapi/config/sync/admin-role.admin-clanky-lmg395y8.json
+++ b/strapi/config/sync/admin-role.admin-clanky-lmg395y8.json
@@ -1,5 +1,5 @@
 {
-  "name": "Admin: Články + Media Library",
+  "name": "Admin: Články + Media Library + Homepage",
   "code": "admin-clanky-lmg395y8",
   "description": "Plná správa Článkov\n\n\nCreated September 12th, 2023",
   "permissions": [

--- a/strapi/config/sync/admin-role.admin-in-ba-lmg3a62g.json
+++ b/strapi/config/sync/admin-role.admin-in-ba-lmg3a62g.json
@@ -8,11 +8,14 @@
       "subject": "api::homepage.homepage",
       "properties": {
         "fields": [
+          "metaTitle",
+          "metaDescription",
+          "welcomeHeadline",
+          "welcomeMedia",
           "inba.title",
           "inba.content",
           "inbaFrontImage",
-          "inbaRearImage",
-          "inbaUrl"
+          "inbaRearImage"
         ],
         "locales": []
       },
@@ -24,16 +27,16 @@
       "subject": "api::homepage.homepage",
       "properties": {
         "fields": [
+          "metaTitle",
+          "metaDescription",
+          "welcomeHeadline",
+          "welcomeMedia",
           "inba.title",
           "inba.content",
           "inbaFrontImage",
-          "inbaRearImage",
-          "inbaUrl"
+          "inbaRearImage"
         ],
-        "locales": [
-          "en",
-          "sk"
-        ]
+        "locales": []
       },
       "conditions": [],
       "actionParameters": {}
@@ -47,7 +50,10 @@
           "inba.content",
           "inbaFrontImage",
           "inbaRearImage",
-          "inbaUrl"
+          "metaTitle",
+          "metaDescription",
+          "welcomeHeadline",
+          "welcomeMedia"
         ],
         "locales": []
       },

--- a/strapi/schema.graphql
+++ b/strapi/schema.graphql
@@ -57,7 +57,7 @@ type BlogPost {
   sections: [BlogPostSectionsDynamicZone]
   slug: String
   tag: TagEntityResponse
-  title: String
+  title: String!
   updatedAt: DateTime
 }
 

--- a/strapi/src/api/blog-post/content-types/blog-post/schema.json
+++ b/strapi/src/api/blog-post/content-types/blog-post/schema.json
@@ -17,12 +17,13 @@
   },
   "attributes": {
     "title": {
-      "type": "text",
+      "type": "string",
       "pluginOptions": {
         "i18n": {
           "localized": true
         }
-      }
+      },
+      "required": true
     },
     "excerpt": {
       "type": "text",

--- a/strapi/types/generated/contentTypes.d.ts
+++ b/strapi/types/generated/contentTypes.d.ts
@@ -415,7 +415,8 @@ export interface ApiBlogPostBlogPost extends Schema.CollectionType {
       }>
     slug: Attribute.UID<'api::blog-post.blog-post', 'title'>
     tag: Attribute.Relation<'api::blog-post.blog-post', 'oneToOne', 'api::tag.tag'>
-    title: Attribute.Text &
+    title: Attribute.String &
+      Attribute.Required &
       Attribute.SetPluginOptions<{
         i18n: {
           localized: true


### PR DESCRIPTION
commit by commit

Note:
Using the strapiHelper, I checked if in all blogposts
- the title is shorter than 255 characters - to be able to make it short
- the title doesn't contain newlines (4 blogposts did, so I updated them) (some titles contain newline at the end, that is not a problem)
- the title is not empty/undefined/null - to be able to make it required
I check botch sk and en locales.


Note that `inert` is probably wrongly types. Using string worked before, using boolean doesn't work on prod (you can "tab" into the bookmark - this is not wanted)

Now on prod:
![image](https://github.com/user-attachments/assets/c86309a0-1b92-4c05-aa25-52fbe56bc359)
