### PR TITLE
#1486 Use required addedAt in BlogPosts instead of date_added

### DIFF
--- a/next/src/components/page-contents/BlogPostPageContent.tsx
+++ b/next/src/components/page-contents/BlogPostPageContent.tsx
@@ -55,14 +55,7 @@ const BlogPostPageContent = ({ blogPost }: BlogPostPageContentProps) => {
       <PageHeader
         title={blogPost.attributes?.title}
         breadcrumbs={breadcrumbs}
-        subtext={
-          blogPost &&
-          getNumericLocalDate(
-            blogPost.attributes?.date_added ||
-              blogPost.attributes?.publishedAt ||
-              blogPost.attributes?.createdAt,
-          )
-        }
+        subtext={getNumericLocalDate(blogPost.attributes?.addedAt)}
         tag={tag?.title}
         imageSrc={blogPost.attributes?.coverImage?.data?.attributes?.url}
       />

--- a/next/src/components/sections/ArticlesListSection/BlogPostsByCategory.tsx
+++ b/next/src/components/sections/ArticlesListSection/BlogPostsByCategory.tsx
@@ -79,14 +79,7 @@ const BlogPostsByTags = ({ section }: Props) => {
           if (!card.attributes) return null
 
           // TODO refactor sections that use BlogPostCard - it needs too much duplicate code while passing props
-          const {
-            title: blogPostTitle,
-            slug,
-            coverImage,
-            tag,
-            date_added,
-            publishedAt,
-          } = card.attributes
+          const { title: blogPostTitle, slug, coverImage, tag, addedAt } = card.attributes
           const tagColor = tag?.data?.attributes?.pageCategory?.data?.attributes?.color
           const tagTitle = tag?.data?.attributes?.title
 
@@ -94,7 +87,7 @@ const BlogPostsByTags = ({ section }: Props) => {
             <BlogPostCard
               key={slug}
               style={getCategoryColorLocalStyle({ color: tagColor })}
-              date={getNumericLocalDate(date_added ?? publishedAt)}
+              date={getNumericLocalDate(addedAt)}
               tag={tagTitle ?? undefined}
               title={blogPostTitle ?? ''}
               linkProps={{ children: t('readMore'), href: `/blog/${slug}` }}

--- a/next/src/components/sections/ArticlesListSection/BlogPostsList.tsx
+++ b/next/src/components/sections/ArticlesListSection/BlogPostsList.tsx
@@ -79,15 +79,7 @@ const BlogPostsByTags = ({ section }: Props) => {
           if (!card.attributes) return null
 
           // TODO refactor sections that use BlogPostCard - it needs too much duplicate code while passing props
-          const {
-            title: blogPostTitle,
-            slug,
-            coverImage,
-            tag,
-            date_added,
-            publishedAt,
-            excerpt,
-          } = card.attributes
+          const { title: blogPostTitle, slug, coverImage, tag, addedAt, excerpt } = card.attributes
           const tagColor = tag?.data?.attributes?.pageCategory?.data?.attributes?.color
           const tagTitle = tag?.data?.attributes?.title
 
@@ -95,7 +87,7 @@ const BlogPostsByTags = ({ section }: Props) => {
             <BlogPostCard
               key={slug}
               style={getCategoryColorLocalStyle({ color: tagColor })}
-              date={getNumericLocalDate(date_added ?? publishedAt)}
+              date={getNumericLocalDate(addedAt)}
               tag={tagTitle ?? undefined}
               title={blogPostTitle ?? ''}
               text={excerpt ?? undefined}

--- a/next/src/components/sections/RelatedBlogPostsSection.tsx
+++ b/next/src/components/sections/RelatedBlogPostsSection.tsx
@@ -52,7 +52,7 @@ const RelatedBlogPostsSection = ({ page, className }: Props) => {
             if (!card.attributes) return null
 
             // TODO refactor sections that use BlogPostCard - it needs too much duplicate code while passing props
-            const { title, slug, coverImage, tag, date_added, publishedAt } = card.attributes
+            const { title, slug, coverImage, tag, addedAt } = card.attributes
             const tagColor = tag?.data?.attributes?.pageCategory?.data?.attributes?.color
             const tagTitle = tag?.data?.attributes?.title
 
@@ -62,7 +62,7 @@ const RelatedBlogPostsSection = ({ page, className }: Props) => {
                 style={getCategoryColorLocalStyle({ color: tagColor })}
                 imgSrc={coverImage?.data?.attributes?.url}
                 imgSizes={imageSizes}
-                date={getNumericLocalDate(date_added ?? publishedAt)}
+                date={getNumericLocalDate(addedAt)}
                 title={title ?? ''}
                 tag={tagTitle ?? undefined}
                 linkProps={{

--- a/next/src/components/sections/SearchSection/useQueryBySearchOption.ts
+++ b/next/src/components/sections/SearchSection/useQueryBySearchOption.ts
@@ -107,7 +107,7 @@ export const useQueryBySearchOption = ({
               linkHref: `/blog/${blogPostData.attributes?.slug}`,
               metadata: [
                 blogPostData.attributes?.tag?.data?.attributes?.title,
-                formatDate(blogPostData.attributes?.publishedAt),
+                formatDate(blogPostData.attributes?.addedAt),
               ],
               coverImageSrc: blogPostData.attributes?.coverImage?.data?.attributes?.url,
             }

--- a/next/src/components/sections/homepage-sections/HomepageTabs/TabPanelLatestNews.tsx
+++ b/next/src/components/sections/homepage-sections/HomepageTabs/TabPanelLatestNews.tsx
@@ -38,8 +38,7 @@ const TabPanelLatestNews = () => {
       <ResponsiveCarousel
         className="lg:hidden"
         items={allPosts.map((blogPost) => {
-          const { title, slug, coverImage, date_added, publishedAt, tag } =
-            blogPost.attributes ?? {}
+          const { title, slug, coverImage, addedAt, tag } = blogPost.attributes ?? {}
           const tagColor = tag?.data?.attributes?.pageCategory?.data?.attributes?.color
           const tagTitle = tag?.data?.attributes?.title
 
@@ -48,7 +47,7 @@ const TabPanelLatestNews = () => {
               key={blogPost.id}
               style={getCategoryColorLocalStyle({ color: tagColor })}
               variant="no-border"
-              date={getNumericLocalDate(date_added ?? publishedAt)}
+              date={getNumericLocalDate(addedAt)}
               tag={tagTitle ?? undefined}
               title={title ?? ''}
               linkProps={{ children: t('HomepageTabs.readMore'), href: `/blog/${slug}` }}
@@ -61,8 +60,7 @@ const TabPanelLatestNews = () => {
       <div className="mt-14 hidden pb-8 lg:block">
         <div className="grid grid-cols-3 gap-x-8">
           {[leftNewsItem?.data, rightNewsItem?.data].filter(isDefined).map((blogPost) => {
-            const { title, slug, coverImage, date_added, publishedAt, tag, excerpt } =
-              blogPost.attributes ?? {}
+            const { title, slug, coverImage, addedAt, tag, excerpt } = blogPost.attributes ?? {}
             const tagColor = tag?.data?.attributes?.pageCategory?.data?.attributes?.color
             const tagTitle = tag?.data?.attributes?.title
 
@@ -71,7 +69,7 @@ const TabPanelLatestNews = () => {
                 key={blogPost.id}
                 style={getCategoryColorLocalStyle({ color: tagColor })}
                 variant="no-border"
-                date={getNumericLocalDate(date_added ?? publishedAt)}
+                date={getNumericLocalDate(addedAt)}
                 tag={tagTitle ?? undefined}
                 title={title ?? ''}
                 linkProps={{ children: t('HomepageTabs.readMore'), href: `/blog/${slug}` }}

--- a/next/src/pages/api/feed.ts
+++ b/next/src/pages/api/feed.ts
@@ -44,7 +44,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
         description: post.attributes.excerpt ?? '',
         // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         url: post.attributes.slug ? `${urlPrefix[language]}/${post.attributes.slug}` : '',
-        date: post.attributes.date_added ?? post.attributes.publishedAt,
+        date: post.attributes.addedAt,
         categories: [
           post.attributes.tag?.data?.attributes?.pageCategory?.data?.attributes?.title,
           post.attributes.tag?.data?.attributes?.title,

--- a/next/src/services/graphql/index.ts
+++ b/next/src/services/graphql/index.ts
@@ -86,7 +86,7 @@ export type AlertRelationResponseCollection = {
 
 export type BlogPost = {
   __typename?: 'BlogPost'
-  addedAt?: Maybe<Scalars['DateTime']['output']>
+  addedAt: Scalars['DateTime']['output']
   coverImage?: Maybe<UploadFileEntityResponse>
   createdAt?: Maybe<Scalars['DateTime']['output']>
   date_added?: Maybe<Scalars['DateTime']['output']>
@@ -4766,10 +4766,8 @@ export type BlogPostBySlugQuery = {
         slug: string
         excerpt?: string | null
         title: string
+        addedAt: any
         updatedAt?: any | null
-        publishedAt?: any | null
-        date_added?: any | null
-        createdAt?: any | null
         tag?: {
           __typename?: 'TagEntityResponse'
           data?: {
@@ -5105,10 +5103,8 @@ export type LatestPostsByTagsQuery = {
         slug: string
         excerpt?: string | null
         title: string
+        addedAt: any
         updatedAt?: any | null
-        publishedAt?: any | null
-        date_added?: any | null
-        createdAt?: any | null
         tag?: {
           __typename?: 'TagEntityResponse'
           data?: {
@@ -5454,8 +5450,7 @@ export type BlogPostsRssFeedQuery = {
         __typename?: 'BlogPost'
         slug: string
         title: string
-        publishedAt?: any | null
-        date_added?: any | null
+        addedAt: any
         excerpt?: string | null
         tag?: {
           __typename?: 'TagEntityResponse'
@@ -5513,8 +5508,7 @@ export type LatestBlogsWithTagsQuery = {
         slug: string
         title: string
         excerpt?: string | null
-        date_added?: any | null
-        publishedAt?: any | null
+        addedAt: any
         updatedAt?: any | null
         coverImage?: {
           __typename?: 'UploadFileEntityResponse'
@@ -5557,8 +5551,7 @@ export type LatestBlogPostEntityFragment = {
     slug: string
     title: string
     excerpt?: string | null
-    date_added?: any | null
-    publishedAt?: any | null
+    addedAt: any
     updatedAt?: any | null
     coverImage?: {
       __typename?: 'UploadFileEntityResponse'
@@ -5599,10 +5592,8 @@ export type BlogPostEntityFragment = {
     slug: string
     excerpt?: string | null
     title: string
+    addedAt: any
     updatedAt?: any | null
-    publishedAt?: any | null
-    date_added?: any | null
-    createdAt?: any | null
     tag?: {
       __typename?: 'TagEntityResponse'
       data?: {
@@ -6035,10 +6026,8 @@ export type Dev_AllBlogPostsQuery = {
         slug: string
         excerpt?: string | null
         title: string
+        addedAt: any
         updatedAt?: any | null
-        publishedAt?: any | null
-        date_added?: any | null
-        createdAt?: any | null
         tag?: {
           __typename?: 'TagEntityResponse'
           data?: {
@@ -7224,8 +7213,7 @@ export type HomepageEntityFragment = {
             slug: string
             title: string
             excerpt?: string | null
-            date_added?: any | null
-            publishedAt?: any | null
+            addedAt: any
             updatedAt?: any | null
             coverImage?: {
               __typename?: 'UploadFileEntityResponse'
@@ -7268,8 +7256,7 @@ export type HomepageEntityFragment = {
             slug: string
             title: string
             excerpt?: string | null
-            date_added?: any | null
-            publishedAt?: any | null
+            addedAt: any
             updatedAt?: any | null
             coverImage?: {
               __typename?: 'UploadFileEntityResponse'
@@ -7642,8 +7629,7 @@ export type HomepageQuery = {
                 slug: string
                 title: string
                 excerpt?: string | null
-                date_added?: any | null
-                publishedAt?: any | null
+                addedAt: any
                 updatedAt?: any | null
                 coverImage?: {
                   __typename?: 'UploadFileEntityResponse'
@@ -7686,8 +7672,7 @@ export type HomepageQuery = {
                 slug: string
                 title: string
                 excerpt?: string | null
-                date_added?: any | null
-                publishedAt?: any | null
+                addedAt: any
                 updatedAt?: any | null
                 coverImage?: {
                   __typename?: 'UploadFileEntityResponse'
@@ -8071,8 +8056,7 @@ export type HomepageTabsFragment = {
         slug: string
         title: string
         excerpt?: string | null
-        date_added?: any | null
-        publishedAt?: any | null
+        addedAt: any
         updatedAt?: any | null
         coverImage?: {
           __typename?: 'UploadFileEntityResponse'
@@ -8115,8 +8099,7 @@ export type HomepageTabsFragment = {
         slug: string
         title: string
         excerpt?: string | null
-        date_added?: any | null
-        publishedAt?: any | null
+        addedAt: any
         updatedAt?: any | null
         coverImage?: {
           __typename?: 'UploadFileEntityResponse'
@@ -13921,9 +13904,8 @@ export const BlogPostEntityFragmentDoc = gql`
       slug
       excerpt
       title
+      addedAt
       updatedAt
-      publishedAt
-      date_added
       tag {
         data {
           attributes {
@@ -13951,7 +13933,6 @@ export const BlogPostEntityFragmentDoc = gql`
       moreLink {
         ...BlogPostLink
       }
-      createdAt
       sections {
         ...Sections
       }
@@ -14195,8 +14176,7 @@ export const LatestBlogPostEntityFragmentDoc = gql`
           }
         }
       }
-      date_added
-      publishedAt
+      addedAt
       updatedAt
       tag {
         data {
@@ -14518,7 +14498,7 @@ export const LatestPostsByTagsDocument = gql`
       locale: $locale
       filters: { tag: { title: { in: $tags } } }
       pagination: { limit: $limit, start: $start }
-      sort: "publishedAt:desc"
+      sort: "addedAt:desc"
     ) {
       data {
         ...BlogPostEntity
@@ -14529,7 +14509,7 @@ export const LatestPostsByTagsDocument = gql`
 `
 export const BlogPostsStaticPathsDocument = gql`
   query BlogPostsStaticPaths {
-    blogPosts(locale: "all", sort: "publishedAt:desc") {
+    blogPosts(locale: "all", sort: "addedAt:desc") {
       data {
         id
         attributes {
@@ -14542,14 +14522,13 @@ export const BlogPostsStaticPathsDocument = gql`
 `
 export const BlogPostsRssFeedDocument = gql`
   query BlogPostsRssFeed($locale: I18NLocaleCode!) {
-    blogPosts(locale: $locale, sort: "publishedAt:desc") {
+    blogPosts(locale: $locale, sort: "addedAt:desc") {
       data {
         id
         attributes {
           slug
           title
-          publishedAt
-          date_added
+          addedAt
           excerpt
           tag {
             data {

--- a/next/src/services/graphql/queries/BlogPosts.graphql
+++ b/next/src/services/graphql/queries/BlogPosts.graphql
@@ -16,7 +16,7 @@ query LatestPostsByTags(
     locale: $locale
     filters: { tag: { title: { in: $tags } } }
     pagination: { limit: $limit, start: $start }
-    sort: "publishedAt:desc"
+    sort: "addedAt:desc"
   ) {
     data {
       ...BlogPostEntity
@@ -25,7 +25,7 @@ query LatestPostsByTags(
 }
 
 query BlogPostsStaticPaths {
-  blogPosts(locale: "all", sort: "publishedAt:desc") {
+  blogPosts(locale: "all", sort: "addedAt:desc") {
     data {
       id
       attributes {
@@ -37,14 +37,13 @@ query BlogPostsStaticPaths {
 }
 
 query BlogPostsRssFeed($locale: I18NLocaleCode!) {
-  blogPosts(locale: $locale, sort: "publishedAt:desc") {
+  blogPosts(locale: $locale, sort: "addedAt:desc") {
     data {
       id
       attributes {
         slug
         title
-        publishedAt
-        date_added
+        addedAt
         excerpt
         tag {
           data {
@@ -106,8 +105,7 @@ fragment LatestBlogPostEntity on BlogPostEntity {
         }
       }
     }
-    date_added
-    publishedAt
+    addedAt
     updatedAt
     tag {
       data {
@@ -133,9 +131,8 @@ fragment BlogPostEntity on BlogPostEntity {
     slug
     excerpt
     title
+    addedAt
     updatedAt
-    publishedAt
-    date_added
     tag {
       data {
         attributes {
@@ -163,7 +160,6 @@ fragment BlogPostEntity on BlogPostEntity {
     moreLink {
       ...BlogPostLink
     }
-    createdAt
     sections {
       ...Sections
     }

--- a/next/src/utils/dev/strapiHelper.ts
+++ b/next/src/utils/dev/strapiHelper.ts
@@ -22,25 +22,42 @@ export async function listBlogPosts() {
 
   const posts = blogPosts?.data ?? []
 
-  const filteredPosts = posts
-    .map((post) => post.attributes)
-    .filter(isDefined)
-    // .filter((post) => post.title?.trim().includes('\n'))
-    // .filter((post) => (post.title ?? '').length === 0)
-    // .filter((post) => (post.title ?? '').trim().length === 0)
-    // .filter((post) => (post.title ?? '').length > 255) // The most important
-    // .filter((post) => (post.slug ?? '').length === 0)
-    // .filter((post) => (post.slug ?? '').trim().length !== (post.slug ?? '').length)
-    // .filter((post) => (post.slug ?? '').match(/[^\da-z-]/g)) // checks other characters in slug thant low letters, numbers and dashes
-    // .filter((post) => post.author?.data?.attributes?.username.length)
-    .filter((post) => post.date_added != null)
+  const filteredPosts = posts.map((post) => post.attributes).filter(isDefined)
+  // .filter((post) => post.title?.trim().includes('\n'))
+  // .filter((post) => (post.title ?? '').length === 0)
+  // .filter((post) => (post.title ?? '').trim().length === 0)
+  // .filter((post) => (post.title ?? '').length > 255) // The most important
+  // .filter((post) => (post.slug ?? '').length === 0)
+  // .filter((post) => (post.slug ?? '').trim().length !== (post.slug ?? '').length)
+  // .filter((post) => (post.slug ?? '').match(/[^\da-z-]/g)) // checks other characters in slug thant low letters, numbers and dashes
+  // .filter((post) => post.author?.data?.attributes?.username.length)
+  // .filter((post) => post.date_added == null)
+  // .filter((post) => post.date_added != null && new Date(post.date_added).getHours() === 0)
+  // .filter(
+  //   (post) =>
+  //     new Date(post.publishedAt).setUTCHours(0, 0, 0, 0) !==
+  //     new Date(post.addedAt).setUTCHours(0, 0, 0, 0),
+  // )
 
   console.log('Number of all posts:', posts.length)
   console.log('Number of filteredPosts:', filteredPosts.length)
-  console.log(
-    'Filtered posts:',
-    filteredPosts.map((post) => post.slug),
-  )
+  // console.log(
+  //   'Filtered posts:',
+  //   filteredPosts.map((post) => {
+  //     const publishedAtDate = new Date(post.publishedAt)
+  //     const addedAtDate = new Date(post.addedAt)
+  //
+  //     const newPublishedAt = new Date(
+  //       publishedAtDate.setUTCFullYear(
+  //         addedAtDate.getUTCFullYear(),
+  //         addedAtDate.getUTCMonth(),
+  //         addedAtDate.getUTCDate(),
+  //       ),
+  //     ).toISOString()
+  //
+  //     return `${newPublishedAt} ${post.publishedAt} ${post.addedAt} ${post.createdAt} ${post.slug}`
+  //   }),
+  // )
 }
 
 // TODO simplify

--- a/strapi/config/plugins.meilisearch.config.ts
+++ b/strapi/config/plugins.meilisearch.config.ts
@@ -45,8 +45,7 @@ const searchIndexSettings = {
   sortableAttributes: [
     // Blog post
     'blog-post.title',
-    'blog-post.publishedAt', // TODO is it needed?
-    'blog-post.publishedAtTimestamp',
+    'blog-post.addedAtTimestamp',
     // Inba article
     'inba-article.title',
     'inba-article.publishedAtTimestamp',
@@ -86,7 +85,7 @@ const config = {
         ...entry,
         // Meilisearch doesn't support filtering dates as ISO strings, therefore we convert it to UNIX timestamp to
         // use (number) filters.
-        publishedAtTimestamp: entry.publishedAt ? new Date(entry.publishedAt).getTime() : undefined,
+        addedAtTimestamp: entry.addedAt ? new Date(entry.addedAt).getTime() : undefined,
       }),
   },
   'inba-article': {
@@ -98,20 +97,6 @@ const config = {
     settings: searchIndexSettings,
     transformEntry: ({ entry }) =>
       wrapSearchIndexEntry('inba-article', {
-        ...entry,
-        // Meilisearch doesn't support filtering dates as ISO strings, therefore we convert it to UNIX timestamp to
-        // use (number) filters.
-        publishedAtTimestamp: entry.publishedAt ? new Date(entry.publishedAt).getTime() : undefined,
-      }),
-  },
-  vzn: {
-    indexName: 'search_index',
-    entriesQuery: {
-      locale: 'all',
-    },
-    settings: searchIndexSettings,
-    transformEntry: ({ entry }) =>
-      wrapSearchIndexEntry('vzn', {
         ...entry,
         // Meilisearch doesn't support filtering dates as ISO strings, therefore we convert it to UNIX timestamp to
         // use (number) filters.

--- a/strapi/schema.graphql
+++ b/strapi/schema.graphql
@@ -44,7 +44,7 @@ type AlertRelationResponseCollection {
 }
 
 type BlogPost {
-  addedAt: DateTime
+  addedAt: DateTime!
   coverImage: UploadFileEntityResponse
   createdAt: DateTime
   date_added: DateTime

--- a/strapi/src/api/blog-post/content-types/blog-post/schema.json
+++ b/strapi/src/api/blog-post/content-types/blog-post/schema.json
@@ -102,7 +102,8 @@
           "localized": false
         }
       },
-      "type": "datetime"
+      "type": "datetime",
+      "required": true
     }
   }
 }

--- a/strapi/types/generated/contentTypes.d.ts
+++ b/strapi/types/generated/contentTypes.d.ts
@@ -351,6 +351,7 @@ export interface ApiBlogPostBlogPost extends Schema.CollectionType {
   }
   attributes: {
     addedAt: Attribute.DateTime &
+      Attribute.Required &
       Attribute.SetPluginOptions<{
         i18n: {
           localized: false


### PR DESCRIPTION
In BlogPosts:
- make `addedAt` required and use it everywhere (in meilisearch, sorting, cards...)
- remove `date_added`

Database is already updated on prod, where this was done:
- migrated `date_added` / `publishedAt` to addedAt
- updated `publishedAt` to reflect the manually entered date_added - this applies for blog posts that were oficially published before 2022 when new website was launged - therefore this needs to be done only once
- made sure that all blogposts have addedAt (so it can be made required)