### PR TITLE
#1502 Move "sekretariat" and "asistent" higher in org. structure lists

### DIFF
--- a/next/src/services/ms-graph/server/getGroupMembers.ts
+++ b/next/src/services/ms-graph/server/getGroupMembers.ts
@@ -36,7 +36,13 @@ export const roleOrderingScore = (role: string | null | undefined) => {
     score = 3
   } else if (role.startsWith('Zástup')) {
     score = 2
-  } else if (role.startsWith('Hovor')) {
+  } else if (
+    role.startsWith('Hovor') ||
+    role.includes('sekret') ||
+    role.includes('Sekret') ||
+    role.includes('asistent') ||
+    role.includes('Asistent')
+  ) {
     score = 1
   }
 


### PR DESCRIPTION
/mesto-bratislava/sprava-mesta/magistrat/organizacna-struktura

![image](https://github.com/user-attachments/assets/8a16cdec-4cde-471b-accf-af936730b250)
![image](https://github.com/user-attachments/assets/03a711bf-8efb-490c-b5b5-68039cb8afc7)
