### PR TITLE
#1514 Create and use `alias` field for pages and articles

### DIFF
--- a/next/src/components/common/Footer/DesktopFooter.tsx
+++ b/next/src/components/common/Footer/DesktopFooter.tsx
@@ -65,7 +65,7 @@ const DesktopFooter = () => {
           </div>
         </div>
         <HorizontalDivider />
-        <div className="text-default text-center">
+        <div className="text-component-default text-center">
           <FooterCopyright {...attributes} />
         </div>
       </footer>

--- a/next/src/components/page-contents/ArticlePageContent.tsx
+++ b/next/src/components/page-contents/ArticlePageContent.tsx
@@ -54,23 +54,24 @@ const ArticlePageContent = ({ article }: Props) => {
         // TODO some of these classes are duplicated in SectionContainer - ponder what to do with it
         className="mx-auto flex max-w-screen-xl gap-8 px-4 py-6 lg:px-8 lg:py-12"
       >
-        <div className="flex w-200 flex-col gap-18">
-          <div className="flex flex-col gap-6 lg:gap-8">
-            {perex ? (
-              <Typography type="p" size="p-large">
-                {perex}
-              </Typography>
-            ) : null}
-            <Markdown content={content} />
+        <div className="flex w-200 flex-col gap-4">
+          <div className="flex flex-col gap-18">
+            <div className="flex flex-col gap-6 lg:gap-8">
+              {perex ? (
+                <Typography type="p" size="p-large">
+                  {perex}
+                </Typography>
+              ) : null}
+              <Markdown content={content} />
+            </div>
+
+            {filteredGalleryImages.length > 0 ? <Gallery images={filteredGalleryImages} /> : null}
+
+            {filteredFiles.length > 0 ? <FileList files={filteredFiles} /> : null}
           </div>
-
-          {filteredGalleryImages.length > 0 ? <Gallery images={filteredGalleryImages} /> : null}
-
-          {filteredFiles.length > 0 ? <FileList files={filteredFiles} /> : null}
+          {alias ? <AliasInfoMessage alias={alias} variant="article" /> : null}
 
           <ShareButtons twitterTitle={title} />
-
-          {alias ? <AliasInfoMessage alias={alias} variant="article" /> : null}
         </div>
 
         {/* Empty sidebar */}

--- a/next/src/components/page-contents/GeneralPageContent.tsx
+++ b/next/src/components/page-contents/GeneralPageContent.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react'
 import { useMemo } from 'react'
 
+import AliasInfoMessage from '@/src/components/common/AliasInfoMessage/AliasInfoMessage'
 import PageHeader from '@/src/components/common/PageHeader/PageHeader'
+import SectionContainer from '@/src/components/common/SectionContainer/SectionContainer'
 import PageHeaderSections from '@/src/components/layouts/PageHeaderSections'
 import Sections from '@/src/components/layouts/Sections'
 import RelatedArticlesSection from '@/src/components/sections/RelatedArticlesSection'
@@ -41,6 +43,12 @@ const GeneralPageContent = ({ page }: GeneralPageProps) => {
           className="pt-10 md:pt-18"
         />
       </div>
+
+      {page.attributes?.alias ? (
+        <SectionContainer>
+          <AliasInfoMessage alias={page.attributes.alias} variant="page" />
+        </SectionContainer>
+      ) : null}
     </>
   )
 }

--- a/next/src/pages/[...slug].tsx
+++ b/next/src/pages/[...slug].tsx
@@ -89,7 +89,9 @@ export const getStaticProps: GetStaticProps<PageProps, StaticParams> = async ({
   if (redirectPath) {
     return {
       redirect: {
-        destination: redirectPath,
+        // For SK locale, prevent unnecessary redirects from `/sk/[redirectPath]` to `/[redirectPath]` - maybe it's not needed, but it's fewer redirects
+        // Other locales: /en/[alias] -> /en/[redirectPath]
+        destination: locale === 'sk' ? redirectPath : `/${locale}/${redirectPath}`,
         permanent: false,
       },
     }

--- a/next/src/pages/[...slug].tsx
+++ b/next/src/pages/[...slug].tsx
@@ -53,20 +53,47 @@ export const getStaticProps: GetStaticProps<PageProps, StaticParams> = async ({
   params,
 }) => {
   const slug = params?.slug
+  const slugJoined = slug?.join('/')
 
   // eslint-disable-next-line no-console
-  console.log(`Revalidating page ${locale === 'en' ? '/en' : ''}/${slug?.join('/')}`)
+  console.log(`Revalidating page ${locale === 'en' ? '/en' : ''}/${slugJoined}`)
 
-  if (!slug || !locale) return { notFound: true }
+  if (!slug || !slugJoined || !locale) return { notFound: true }
 
-  const [{ pages }, general, translations] = await Promise.all([
-    client.PageBySlug({
-      slug: slug.join('/'),
-      locale,
-    }),
-    client.General({ locale }),
-    serverSideTranslations(locale),
-  ])
+  const [{ pages }, { pages: aliasPages, articles: aliasArticles }, general, translations] =
+    await Promise.all([
+      client.PageBySlug({ slug: slugJoined, locale }),
+      client.PageRedirectByAlias({ alias: slugJoined, locale }),
+      client.General({ locale }),
+      serverSideTranslations(locale),
+    ])
+
+  let redirectPath = ''
+
+  // Check if an Article with this alias exists
+  const aliasArticleSlug = aliasArticles?.data[0]?.attributes?.slug
+  if (aliasArticleSlug) {
+    // Get the full path for the article
+    redirectPath = `/spravy/${aliasArticleSlug}`
+  }
+
+  // Check if a Page with this alias exists
+  const aliasPageSlug = aliasPages?.data[0]?.attributes?.slug
+  if (aliasPageSlug) {
+    // Get the full path for the page by its slug
+    redirectPath = `/${aliasPageSlug}`
+  }
+
+  // Note that alias in pages and articles are unique only within their own content type
+  // If there are both a page and an article with the same alias, the page will override the `redirectPath` as it's checked as last
+  if (redirectPath) {
+    return {
+      redirect: {
+        destination: redirectPath,
+        permanent: false,
+      },
+    }
+  }
 
   const page = pages?.data?.[0]
   if (!page) return { notFound: true }

--- a/next/src/services/graphql/index.ts
+++ b/next/src/services/graphql/index.ts
@@ -8002,6 +8002,904 @@ export type PageCategoriesQuery = {
   } | null
 }
 
+export type ParentPageFragment = {
+  __typename?: 'Page'
+  slug?: string | null
+  locale?: string | null
+  title?: string | null
+}
+
+export type PageParentPagesFragment = {
+  __typename?: 'PageEntity'
+  attributes?: {
+    __typename?: 'Page'
+    slug?: string | null
+    locale?: string | null
+    title?: string | null
+    parentPage?: {
+      __typename?: 'PageEntityResponse'
+      data?: {
+        __typename?: 'PageEntity'
+        attributes?: {
+          __typename?: 'Page'
+          slug?: string | null
+          locale?: string | null
+          title?: string | null
+          parentPage?: {
+            __typename?: 'PageEntityResponse'
+            data?: {
+              __typename?: 'PageEntity'
+              attributes?: {
+                __typename?: 'Page'
+                slug?: string | null
+                locale?: string | null
+                title?: string | null
+                parentPage?: {
+                  __typename?: 'PageEntityResponse'
+                  data?: {
+                    __typename?: 'PageEntity'
+                    attributes?: {
+                      __typename?: 'Page'
+                      slug?: string | null
+                      locale?: string | null
+                      title?: string | null
+                      parentPage?: {
+                        __typename?: 'PageEntityResponse'
+                        data?: {
+                          __typename?: 'PageEntity'
+                          attributes?: {
+                            __typename?: 'Page'
+                            slug?: string | null
+                            locale?: string | null
+                            title?: string | null
+                          } | null
+                        } | null
+                      } | null
+                    } | null
+                  } | null
+                } | null
+              } | null
+            } | null
+          } | null
+        } | null
+      } | null
+    } | null
+  } | null
+}
+
+export type LocalizationFragment = {
+  __typename?: 'PageRelationResponseCollection'
+  data: Array<{
+    __typename?: 'PageEntity'
+    attributes?: { __typename?: 'Page'; slug?: string | null; locale?: string | null } | null
+  }>
+}
+
+export type PageSlugEntityFragment = {
+  __typename?: 'PageEntity'
+  id?: string | null
+  attributes?: {
+    __typename?: 'Page'
+    slug?: string | null
+    title?: string | null
+    locale?: string | null
+  } | null
+}
+
+export type PageEntityFragment = {
+  __typename?: 'PageEntity'
+  id?: string | null
+  attributes?: {
+    __typename?: 'Page'
+    alias?: string | null
+    subtext?: string | null
+    pageColor?: Enum_Page_Pagecolor | null
+    metaDiscription?: string | null
+    keywords?: string | null
+    slug?: string | null
+    title?: string | null
+    locale?: string | null
+    pageBackgroundImage?: {
+      __typename?: 'UploadFileEntityResponse'
+      data?: {
+        __typename?: 'UploadFileEntity'
+        id?: string | null
+        attributes?: { __typename?: 'UploadFile'; url: string } | null
+      } | null
+    } | null
+    headerLinks?: Array<{
+      __typename?: 'ComponentBlocksCommonLink'
+      label: string
+      url?: string | null
+      analyticsId?: string | null
+      page?: {
+        __typename?: 'PageEntityResponse'
+        data?: {
+          __typename?: 'PageEntity'
+          id?: string | null
+          attributes?: { __typename?: 'Page'; title?: string | null; slug?: string | null } | null
+        } | null
+      } | null
+      article?: {
+        __typename?: 'ArticleEntityResponse'
+        data?: {
+          __typename: 'ArticleEntity'
+          id?: string | null
+          attributes?: {
+            __typename?: 'Article'
+            slug: string
+            title: string
+            locale?: string | null
+          } | null
+        } | null
+      } | null
+    } | null> | null
+    sections?: Array<
+      | {
+          __typename: 'ComponentSectionsAccordion'
+          title?: string | null
+          institutions?: Array<{
+            __typename?: 'ComponentAccordionItemsInstitution'
+            title?: string | null
+            subtitle?: string | null
+            category?: string | null
+            firstColumn?: string | null
+            secondColumn?: string | null
+            thirdColumn?: string | null
+            url?: string | null
+            urlLabel?: string | null
+          } | null> | null
+          flatText?: Array<{
+            __typename?: 'ComponentAccordionItemsFlatText'
+            category?: string | null
+            content?: string | null
+            width?: Enum_Componentaccordionitemsflattext_Width | null
+            align?: Enum_Componentaccordionitemsflattext_Align | null
+            moreLinkTitle?: string | null
+            moreLinkUrl?: string | null
+            moreLinkPage?: {
+              __typename?: 'PageEntityResponse'
+              data?: {
+                __typename?: 'PageEntity'
+                attributes?: {
+                  __typename?: 'Page'
+                  slug?: string | null
+                  title?: string | null
+                  locale?: string | null
+                } | null
+              } | null
+            } | null
+            fileList?: Array<{
+              __typename?: 'ComponentBlocksFileItem'
+              id: string
+              title?: string | null
+              media: {
+                __typename?: 'UploadFileEntityResponse'
+                data?: {
+                  __typename?: 'UploadFileEntity'
+                  id?: string | null
+                  attributes?: {
+                    __typename?: 'UploadFile'
+                    url: string
+                    name: string
+                    ext?: string | null
+                    size: number
+                    createdAt?: any | null
+                    updatedAt?: any | null
+                  } | null
+                } | null
+              }
+            } | null> | null
+          } | null> | null
+          institutionsNarrow?: Array<{
+            __typename?: 'ComponentAccordionItemsInstitutionNarrow'
+            title?: string | null
+            subtitle?: string | null
+            category?: string | null
+            url?: string | null
+            urlLabel?: string | null
+          } | null> | null
+        }
+      | {
+          __typename: 'ComponentSectionsArticles'
+          title?: string | null
+          text?: string | null
+          showAll?: boolean | null
+          category?: {
+            __typename?: 'PageCategoryEntityResponse'
+            data?: {
+              __typename?: 'PageCategoryEntity'
+              id?: string | null
+              attributes?: {
+                __typename?: 'PageCategory'
+                title?: string | null
+                color?: Enum_Pagecategory_Color | null
+              } | null
+            } | null
+          } | null
+        }
+      | {
+          __typename: 'ComponentSectionsBanner'
+          content?: string | null
+          contentPosition: Enum_Componentsectionsbanner_Contentposition
+          bannerTitle: string
+          bannerVariant: Enum_Componentsectionsbanner_Variant
+          media: {
+            __typename?: 'UploadFileEntityResponse'
+            data?: {
+              __typename?: 'UploadFileEntity'
+              attributes?: { __typename?: 'UploadFile'; url: string } | null
+            } | null
+          }
+          primaryLink?: {
+            __typename?: 'ComponentBlocksCommonLink'
+            label: string
+            url?: string | null
+            analyticsId?: string | null
+            page?: {
+              __typename?: 'PageEntityResponse'
+              data?: {
+                __typename?: 'PageEntity'
+                id?: string | null
+                attributes?: {
+                  __typename?: 'Page'
+                  title?: string | null
+                  slug?: string | null
+                } | null
+              } | null
+            } | null
+            article?: {
+              __typename?: 'ArticleEntityResponse'
+              data?: {
+                __typename: 'ArticleEntity'
+                id?: string | null
+                attributes?: {
+                  __typename?: 'Article'
+                  slug: string
+                  title: string
+                  locale?: string | null
+                } | null
+              } | null
+            } | null
+          } | null
+          secondaryLink?: {
+            __typename?: 'ComponentBlocksCommonLink'
+            label: string
+            url?: string | null
+            analyticsId?: string | null
+            page?: {
+              __typename?: 'PageEntityResponse'
+              data?: {
+                __typename?: 'PageEntity'
+                id?: string | null
+                attributes?: {
+                  __typename?: 'Page'
+                  title?: string | null
+                  slug?: string | null
+                } | null
+              } | null
+            } | null
+            article?: {
+              __typename?: 'ArticleEntityResponse'
+              data?: {
+                __typename: 'ArticleEntity'
+                id?: string | null
+                attributes?: {
+                  __typename?: 'Article'
+                  slug: string
+                  title: string
+                  locale?: string | null
+                } | null
+              } | null
+            } | null
+          } | null
+          tertiaryLink?: {
+            __typename?: 'ComponentBlocksCommonLink'
+            label: string
+            url?: string | null
+            analyticsId?: string | null
+            page?: {
+              __typename?: 'PageEntityResponse'
+              data?: {
+                __typename?: 'PageEntity'
+                id?: string | null
+                attributes?: {
+                  __typename?: 'Page'
+                  title?: string | null
+                  slug?: string | null
+                } | null
+              } | null
+            } | null
+            article?: {
+              __typename?: 'ArticleEntityResponse'
+              data?: {
+                __typename: 'ArticleEntity'
+                id?: string | null
+                attributes?: {
+                  __typename?: 'Article'
+                  slug: string
+                  title: string
+                  locale?: string | null
+                } | null
+              } | null
+            } | null
+          } | null
+        }
+      | {
+          __typename: 'ComponentSectionsCalculator'
+          hasBackground?: boolean | null
+          single_adult_value?: number | null
+          another_adult_value?: number | null
+          child_value?: number | null
+        }
+      | {
+          __typename: 'ComponentSectionsColumnedText'
+          content?: string | null
+          contentAlignment?: Enum_Componentsectionscolumnedtext_Contentalignment | null
+        }
+      | {
+          __typename: 'ComponentSectionsComparisonSection'
+          title?: string | null
+          text?: string | null
+          textAlignComparison: Enum_Componentsectionscomparisonsection_Textalign
+          cards: Array<{
+            __typename?: 'ComponentBlocksComparisonCard'
+            title: string
+            items: Array<{ __typename?: 'ComponentBlocksComparisonItem'; label: string } | null>
+            iconMedia?: {
+              __typename?: 'UploadFileEntityResponse'
+              data?: {
+                __typename?: 'UploadFileEntity'
+                attributes?: { __typename?: 'UploadFile'; url: string } | null
+              } | null
+            } | null
+          } | null>
+        }
+      | {
+          __typename: 'ComponentSectionsContactsSection'
+          id: string
+          title?: string | null
+          description?: string | null
+          hasBackground?: boolean | null
+          type: Enum_Componentsectionscontactssection_Type
+          addressContacts?: Array<{
+            __typename?: 'ComponentBlocksContactCard'
+            overrideLabel?: string | null
+            value: string
+          } | null> | null
+          emailContacts?: Array<{
+            __typename?: 'ComponentBlocksContactCard'
+            overrideLabel?: string | null
+            value: string
+          } | null> | null
+          phoneContacts?: Array<{
+            __typename?: 'ComponentBlocksContactCard'
+            overrideLabel?: string | null
+            value: string
+          } | null> | null
+          webContacts?: Array<{
+            __typename?: 'ComponentBlocksContactCard'
+            overrideLabel?: string | null
+            value: string
+          } | null> | null
+        }
+      | {
+          __typename: 'ComponentSectionsDivider'
+          style?: Enum_Componentsectionsdivider_Style | null
+        }
+      | {
+          __typename: 'ComponentSectionsFaqCategories'
+          title?: string | null
+          text?: string | null
+          faqCategories?: {
+            __typename?: 'FaqCategoryRelationResponseCollection'
+            data: Array<{
+              __typename?: 'FaqCategoryEntity'
+              id?: string | null
+              attributes?: {
+                __typename?: 'FaqCategory'
+                title: string
+                slug: string
+                faqs?: {
+                  __typename?: 'FaqRelationResponseCollection'
+                  data: Array<{
+                    __typename?: 'FaqEntity'
+                    id?: string | null
+                    attributes?: { __typename?: 'Faq'; title: string; body?: string | null } | null
+                  }>
+                } | null
+              } | null
+            }>
+          } | null
+        }
+      | {
+          __typename: 'ComponentSectionsFaqs'
+          title?: string | null
+          text?: string | null
+          faqs?: {
+            __typename?: 'FaqRelationResponseCollection'
+            data: Array<{
+              __typename?: 'FaqEntity'
+              id?: string | null
+              attributes?: { __typename?: 'Faq'; title: string; body?: string | null } | null
+            }>
+          } | null
+        }
+      | {
+          __typename: 'ComponentSectionsFileList'
+          title?: string | null
+          text?: string | null
+          fileList?: Array<{
+            __typename?: 'ComponentBlocksFile'
+            id: string
+            title?: string | null
+            media?: {
+              __typename?: 'UploadFileEntityResponse'
+              data?: {
+                __typename?: 'UploadFileEntity'
+                id?: string | null
+                attributes?: {
+                  __typename?: 'UploadFile'
+                  url: string
+                  name: string
+                  ext?: string | null
+                  size: number
+                  createdAt?: any | null
+                  updatedAt?: any | null
+                } | null
+              } | null
+            } | null
+          } | null> | null
+        }
+      | {
+          __typename: 'ComponentSectionsGallery'
+          title?: string | null
+          text?: string | null
+          medias: {
+            __typename?: 'UploadFileRelationResponseCollection'
+            data: Array<{
+              __typename?: 'UploadFileEntity'
+              id?: string | null
+              attributes?: {
+                __typename?: 'UploadFile'
+                url: string
+                width?: number | null
+                height?: number | null
+                caption?: string | null
+                alternativeText?: string | null
+                name: string
+              } | null
+            }>
+          }
+        }
+      | {
+          __typename: 'ComponentSectionsIconTitleDesc'
+          title?: string | null
+          list?: Array<{
+            __typename?: 'ComponentBlocksIconWithTitleAndDescription'
+            title?: string | null
+            desc?: string | null
+            disableIconBackground?: boolean | null
+            icon?: {
+              __typename?: 'UploadFileEntityResponse'
+              data?: {
+                __typename?: 'UploadFileEntity'
+                id?: string | null
+                attributes?: { __typename?: 'UploadFile'; url: string } | null
+              } | null
+            } | null
+          } | null> | null
+        }
+      | {
+          __typename: 'ComponentSectionsIframe'
+          url: string
+          iframeWidth: Enum_Componentsectionsiframe_Iframewidth
+          iframeHeight: string
+          fullHeight: boolean
+          allowFullscreen: boolean
+          css?: string | null
+          allowGeolocation?: boolean | null
+        }
+      | {
+          __typename: 'ComponentSectionsInbaArticlesList'
+          title?: string | null
+          text?: string | null
+        }
+      | { __typename: 'ComponentSectionsInbaReleases'; title?: string | null; text?: string | null }
+      | {
+          __typename: 'ComponentSectionsLinks'
+          title?: string | null
+          pageLinks?: Array<{
+            __typename?: 'ComponentBlocksPageLink'
+            title?: string | null
+            url?: string | null
+            page?: {
+              __typename?: 'PageEntityResponse'
+              data?: {
+                __typename?: 'PageEntity'
+                attributes?: {
+                  __typename?: 'Page'
+                  title?: string | null
+                  slug?: string | null
+                  locale?: string | null
+                } | null
+              } | null
+            } | null
+          } | null> | null
+        }
+      | {
+          __typename: 'ComponentSectionsNarrowText'
+          content?: string | null
+          width?: Enum_Componentsectionsnarrowtext_Width | null
+          align?: Enum_Componentsectionsnarrowtext_Align | null
+        }
+      | {
+          __typename: 'ComponentSectionsNumericalList'
+          id: string
+          title?: string | null
+          variant?: Enum_Componentsectionsnumericallist_Variant | null
+          buttonText?: string | null
+          buttonLink?: string | null
+          items?: Array<{
+            __typename?: 'ComponentBlocksNumericalListItem'
+            text?: string | null
+          } | null> | null
+        }
+      | { __typename: 'ComponentSectionsOfficialBoard' }
+      | { __typename: 'ComponentSectionsOrganizationalStructure'; title?: string | null }
+      | {
+          __typename: 'ComponentSectionsProsAndConsSection'
+          title?: string | null
+          text?: string | null
+          textAlignProsAndCons: Enum_Componentsectionsprosandconssection_Textalign
+          pros: {
+            __typename?: 'ComponentBlocksProsAndConsCard'
+            title: string
+            items: Array<{ __typename?: 'ComponentBlocksComparisonItem'; label: string } | null>
+          }
+          cons: {
+            __typename?: 'ComponentBlocksProsAndConsCard'
+            title: string
+            items: Array<{ __typename?: 'ComponentBlocksComparisonItem'; label: string } | null>
+          }
+        }
+      | {
+          __typename: 'ComponentSectionsRegulations'
+          regulations?: {
+            __typename?: 'RegulationRelationResponseCollection'
+            data: Array<{
+              __typename?: 'RegulationEntity'
+              id?: string | null
+              attributes?: {
+                __typename?: 'Regulation'
+                regNumber: string
+                slug: string
+                titleText?: string | null
+                fullTitle: string
+                effectiveFrom: any
+                category: Enum_Regulation_Category
+                isFullTextRegulation: boolean
+                mainDocument: {
+                  __typename?: 'UploadFileEntityResponse'
+                  data?: {
+                    __typename?: 'UploadFileEntity'
+                    id?: string | null
+                    attributes?: {
+                      __typename?: 'UploadFile'
+                      url: string
+                      name: string
+                      ext?: string | null
+                      size: number
+                      createdAt?: any | null
+                      updatedAt?: any | null
+                    } | null
+                  } | null
+                }
+                attachments?: {
+                  __typename?: 'UploadFileRelationResponseCollection'
+                  data: Array<{
+                    __typename?: 'UploadFileEntity'
+                    id?: string | null
+                    attributes?: {
+                      __typename?: 'UploadFile'
+                      url: string
+                      name: string
+                      ext?: string | null
+                      size: number
+                      createdAt?: any | null
+                      updatedAt?: any | null
+                    } | null
+                  }>
+                } | null
+                amendments?: {
+                  __typename?: 'RegulationRelationResponseCollection'
+                  data: Array<{
+                    __typename?: 'RegulationEntity'
+                    id?: string | null
+                    attributes?: {
+                      __typename?: 'Regulation'
+                      regNumber: string
+                      slug: string
+                      effectiveFrom: any
+                      isFullTextRegulation: boolean
+                      attachments?: {
+                        __typename?: 'UploadFileRelationResponseCollection'
+                        data: Array<{
+                          __typename?: 'UploadFileEntity'
+                          id?: string | null
+                          attributes?: {
+                            __typename?: 'UploadFile'
+                            url: string
+                            name: string
+                            ext?: string | null
+                            size: number
+                            createdAt?: any | null
+                            updatedAt?: any | null
+                          } | null
+                        }>
+                      } | null
+                    } | null
+                  }>
+                } | null
+                amending?: {
+                  __typename?: 'RegulationRelationResponseCollection'
+                  data: Array<{
+                    __typename?: 'RegulationEntity'
+                    id?: string | null
+                    attributes?: {
+                      __typename?: 'Regulation'
+                      regNumber: string
+                      slug: string
+                      effectiveFrom: any
+                      cancellation?: {
+                        __typename?: 'RegulationEntityResponse'
+                        data?: {
+                          __typename?: 'RegulationEntity'
+                          id?: string | null
+                          attributes?: {
+                            __typename?: 'Regulation'
+                            regNumber: string
+                            slug: string
+                            effectiveFrom: any
+                          } | null
+                        } | null
+                      } | null
+                      amending?: {
+                        __typename?: 'RegulationRelationResponseCollection'
+                        data: Array<{
+                          __typename?: 'RegulationEntity'
+                          id?: string | null
+                          attributes?: {
+                            __typename?: 'Regulation'
+                            regNumber: string
+                            slug: string
+                            cancellation?: {
+                              __typename?: 'RegulationEntityResponse'
+                              data?: {
+                                __typename?: 'RegulationEntity'
+                                id?: string | null
+                                attributes?: {
+                                  __typename?: 'Regulation'
+                                  regNumber: string
+                                  slug: string
+                                  effectiveFrom: any
+                                } | null
+                              } | null
+                            } | null
+                          } | null
+                        }>
+                      } | null
+                    } | null
+                  }>
+                } | null
+                cancellation?: {
+                  __typename?: 'RegulationEntityResponse'
+                  data?: {
+                    __typename?: 'RegulationEntity'
+                    id?: string | null
+                    attributes?: {
+                      __typename?: 'Regulation'
+                      regNumber: string
+                      slug: string
+                      effectiveFrom: any
+                    } | null
+                  } | null
+                } | null
+                cancelling?: {
+                  __typename?: 'RegulationRelationResponseCollection'
+                  data: Array<{
+                    __typename?: 'RegulationEntity'
+                    id?: string | null
+                    attributes?: {
+                      __typename?: 'Regulation'
+                      regNumber: string
+                      slug: string
+                      effectiveFrom: any
+                    } | null
+                  }>
+                } | null
+              } | null
+            }>
+          } | null
+        }
+      | { __typename: 'ComponentSectionsRegulationsList' }
+      | {
+          __typename: 'ComponentSectionsTestimonials'
+          title?: string | null
+          text?: string | null
+          hasBackground?: boolean | null
+          testimonials: Array<{
+            __typename?: 'ComponentBlocksTestimonialItem'
+            id: string
+            name: string
+            quote: string
+          } | null>
+        }
+      | {
+          __typename: 'ComponentSectionsTextWithImage'
+          content?: string | null
+          imagePosition?: Enum_Componentsectionstextwithimage_Imageposition | null
+          imageSrc?: {
+            __typename?: 'UploadFileEntityResponse'
+            data?: {
+              __typename?: 'UploadFileEntity'
+              attributes?: {
+                __typename?: 'UploadFile'
+                url: string
+                alternativeText?: string | null
+                width?: number | null
+                height?: number | null
+              } | null
+            } | null
+          } | null
+        }
+      | {
+          __typename: 'ComponentSectionsTimeline'
+          timelineItems?: Array<{
+            __typename?: 'ComponentBlocksTimelineItem'
+            id: string
+            title?: string | null
+            content?: string | null
+          } | null> | null
+        }
+      | {
+          __typename: 'ComponentSectionsVideos'
+          id: string
+          title?: string | null
+          subtitle?: string | null
+          videos?: Array<{
+            __typename?: 'ComponentBlocksVideo'
+            id: string
+            title?: string | null
+            speaker?: string | null
+            url?: string | null
+          } | null> | null
+        }
+      | {
+          __typename: 'ComponentSectionsWaves'
+          position?: Enum_Componentsectionswaves_Position | null
+        }
+      | { __typename: 'Error' }
+      | null
+    > | null
+    localizations?: {
+      __typename?: 'PageRelationResponseCollection'
+      data: Array<{
+        __typename?: 'PageEntity'
+        attributes?: { __typename?: 'Page'; slug?: string | null; locale?: string | null } | null
+      }>
+    } | null
+    pageHeaderSections?: Array<
+      | {
+          __typename: 'ComponentSectionsSubpageList'
+          id: string
+          subpageList?: Array<{
+            __typename?: 'ComponentBlocksPageLink'
+            title?: string | null
+            url?: string | null
+            page?: {
+              __typename?: 'PageEntityResponse'
+              data?: {
+                __typename?: 'PageEntity'
+                attributes?: {
+                  __typename?: 'Page'
+                  title?: string | null
+                  slug?: string | null
+                  locale?: string | null
+                } | null
+              } | null
+            } | null
+          } | null> | null
+        }
+      | { __typename: 'Error' }
+      | null
+    > | null
+    pageCategory?: {
+      __typename?: 'PageCategoryEntityResponse'
+      data?: {
+        __typename?: 'PageCategoryEntity'
+        id?: string | null
+        attributes?: {
+          __typename?: 'PageCategory'
+          title?: string | null
+          color?: Enum_Pagecategory_Color | null
+        } | null
+      } | null
+    } | null
+    relatedContents?: {
+      __typename?: 'TagRelationResponseCollection'
+      data: Array<{
+        __typename?: 'TagEntity'
+        id?: string | null
+        attributes?: {
+          __typename?: 'Tag'
+          title?: string | null
+          pageCategory?: {
+            __typename?: 'PageCategoryEntityResponse'
+            data?: {
+              __typename?: 'PageCategoryEntity'
+              id?: string | null
+              attributes?: {
+                __typename?: 'PageCategory'
+                title?: string | null
+                color?: Enum_Pagecategory_Color | null
+              } | null
+            } | null
+          } | null
+        } | null
+      }>
+    } | null
+    parentPage?: {
+      __typename?: 'PageEntityResponse'
+      data?: {
+        __typename?: 'PageEntity'
+        attributes?: {
+          __typename?: 'Page'
+          slug?: string | null
+          locale?: string | null
+          title?: string | null
+          parentPage?: {
+            __typename?: 'PageEntityResponse'
+            data?: {
+              __typename?: 'PageEntity'
+              attributes?: {
+                __typename?: 'Page'
+                slug?: string | null
+                locale?: string | null
+                title?: string | null
+                parentPage?: {
+                  __typename?: 'PageEntityResponse'
+                  data?: {
+                    __typename?: 'PageEntity'
+                    attributes?: {
+                      __typename?: 'Page'
+                      slug?: string | null
+                      locale?: string | null
+                      title?: string | null
+                      parentPage?: {
+                        __typename?: 'PageEntityResponse'
+                        data?: {
+                          __typename?: 'PageEntity'
+                          attributes?: {
+                            __typename?: 'Page'
+                            slug?: string | null
+                            locale?: string | null
+                            title?: string | null
+                          } | null
+                        } | null
+                      } | null
+                    } | null
+                  } | null
+                } | null
+              } | null
+            } | null
+          } | null
+        } | null
+      } | null
+    } | null
+  } | null
+}
+
 export type PagesStaticPathsQueryVariables = Exact<{ [key: string]: never }>
 
 export type PagesStaticPathsQuery = {
@@ -8030,12 +8928,13 @@ export type PageBySlugQuery = {
       id?: string | null
       attributes?: {
         __typename?: 'Page'
-        slug?: string | null
-        title?: string | null
+        alias?: string | null
         subtext?: string | null
         pageColor?: Enum_Page_Pagecolor | null
         metaDiscription?: string | null
         keywords?: string | null
+        slug?: string | null
+        title?: string | null
         locale?: string | null
         pageBackgroundImage?: {
           __typename?: 'UploadFileEntityResponse'
@@ -8856,890 +9755,39 @@ export type PageBySlugQuery = {
   } | null
 }
 
-export type PageParentPagesFragment = {
-  __typename?: 'PageEntity'
-  attributes?: {
-    __typename?: 'Page'
-    slug?: string | null
-    locale?: string | null
-    title?: string | null
-    parentPage?: {
-      __typename?: 'PageEntityResponse'
-      data?: {
-        __typename?: 'PageEntity'
-        attributes?: {
-          __typename?: 'Page'
-          slug?: string | null
-          locale?: string | null
-          title?: string | null
-          parentPage?: {
-            __typename?: 'PageEntityResponse'
-            data?: {
-              __typename?: 'PageEntity'
-              attributes?: {
-                __typename?: 'Page'
-                slug?: string | null
-                locale?: string | null
-                title?: string | null
-                parentPage?: {
-                  __typename?: 'PageEntityResponse'
-                  data?: {
-                    __typename?: 'PageEntity'
-                    attributes?: {
-                      __typename?: 'Page'
-                      slug?: string | null
-                      locale?: string | null
-                      title?: string | null
-                      parentPage?: {
-                        __typename?: 'PageEntityResponse'
-                        data?: {
-                          __typename?: 'PageEntity'
-                          attributes?: {
-                            __typename?: 'Page'
-                            slug?: string | null
-                            locale?: string | null
-                            title?: string | null
-                          } | null
-                        } | null
-                      } | null
-                    } | null
-                  } | null
-                } | null
-              } | null
-            } | null
-          } | null
-        } | null
+export type PageRedirectByAliasQueryVariables = Exact<{
+  alias: Scalars['String']['input']
+  locale: Scalars['I18NLocaleCode']['input']
+}>
+
+export type PageRedirectByAliasQuery = {
+  __typename?: 'Query'
+  pages?: {
+    __typename?: 'PageEntityResponseCollection'
+    data: Array<{
+      __typename?: 'PageEntity'
+      id?: string | null
+      attributes?: {
+        __typename?: 'Page'
+        slug?: string | null
+        title?: string | null
+        locale?: string | null
       } | null
-    } | null
+    }>
   } | null
-}
-
-export type PageEntityFragment = {
-  __typename?: 'PageEntity'
-  id?: string | null
-  attributes?: {
-    __typename?: 'Page'
-    slug?: string | null
-    title?: string | null
-    subtext?: string | null
-    pageColor?: Enum_Page_Pagecolor | null
-    metaDiscription?: string | null
-    keywords?: string | null
-    locale?: string | null
-    pageBackgroundImage?: {
-      __typename?: 'UploadFileEntityResponse'
-      data?: {
-        __typename?: 'UploadFileEntity'
-        id?: string | null
-        attributes?: { __typename?: 'UploadFile'; url: string } | null
+  articles?: {
+    __typename?: 'ArticleEntityResponseCollection'
+    data: Array<{
+      __typename: 'ArticleEntity'
+      id?: string | null
+      attributes?: {
+        __typename?: 'Article'
+        slug: string
+        title: string
+        locale?: string | null
       } | null
-    } | null
-    headerLinks?: Array<{
-      __typename?: 'ComponentBlocksCommonLink'
-      label: string
-      url?: string | null
-      analyticsId?: string | null
-      page?: {
-        __typename?: 'PageEntityResponse'
-        data?: {
-          __typename?: 'PageEntity'
-          id?: string | null
-          attributes?: { __typename?: 'Page'; title?: string | null; slug?: string | null } | null
-        } | null
-      } | null
-      article?: {
-        __typename?: 'ArticleEntityResponse'
-        data?: {
-          __typename: 'ArticleEntity'
-          id?: string | null
-          attributes?: {
-            __typename?: 'Article'
-            slug: string
-            title: string
-            locale?: string | null
-          } | null
-        } | null
-      } | null
-    } | null> | null
-    sections?: Array<
-      | {
-          __typename: 'ComponentSectionsAccordion'
-          title?: string | null
-          institutions?: Array<{
-            __typename?: 'ComponentAccordionItemsInstitution'
-            title?: string | null
-            subtitle?: string | null
-            category?: string | null
-            firstColumn?: string | null
-            secondColumn?: string | null
-            thirdColumn?: string | null
-            url?: string | null
-            urlLabel?: string | null
-          } | null> | null
-          flatText?: Array<{
-            __typename?: 'ComponentAccordionItemsFlatText'
-            category?: string | null
-            content?: string | null
-            width?: Enum_Componentaccordionitemsflattext_Width | null
-            align?: Enum_Componentaccordionitemsflattext_Align | null
-            moreLinkTitle?: string | null
-            moreLinkUrl?: string | null
-            moreLinkPage?: {
-              __typename?: 'PageEntityResponse'
-              data?: {
-                __typename?: 'PageEntity'
-                attributes?: {
-                  __typename?: 'Page'
-                  slug?: string | null
-                  title?: string | null
-                  locale?: string | null
-                } | null
-              } | null
-            } | null
-            fileList?: Array<{
-              __typename?: 'ComponentBlocksFileItem'
-              id: string
-              title?: string | null
-              media: {
-                __typename?: 'UploadFileEntityResponse'
-                data?: {
-                  __typename?: 'UploadFileEntity'
-                  id?: string | null
-                  attributes?: {
-                    __typename?: 'UploadFile'
-                    url: string
-                    name: string
-                    ext?: string | null
-                    size: number
-                    createdAt?: any | null
-                    updatedAt?: any | null
-                  } | null
-                } | null
-              }
-            } | null> | null
-          } | null> | null
-          institutionsNarrow?: Array<{
-            __typename?: 'ComponentAccordionItemsInstitutionNarrow'
-            title?: string | null
-            subtitle?: string | null
-            category?: string | null
-            url?: string | null
-            urlLabel?: string | null
-          } | null> | null
-        }
-      | {
-          __typename: 'ComponentSectionsArticles'
-          title?: string | null
-          text?: string | null
-          showAll?: boolean | null
-          category?: {
-            __typename?: 'PageCategoryEntityResponse'
-            data?: {
-              __typename?: 'PageCategoryEntity'
-              id?: string | null
-              attributes?: {
-                __typename?: 'PageCategory'
-                title?: string | null
-                color?: Enum_Pagecategory_Color | null
-              } | null
-            } | null
-          } | null
-        }
-      | {
-          __typename: 'ComponentSectionsBanner'
-          content?: string | null
-          contentPosition: Enum_Componentsectionsbanner_Contentposition
-          bannerTitle: string
-          bannerVariant: Enum_Componentsectionsbanner_Variant
-          media: {
-            __typename?: 'UploadFileEntityResponse'
-            data?: {
-              __typename?: 'UploadFileEntity'
-              attributes?: { __typename?: 'UploadFile'; url: string } | null
-            } | null
-          }
-          primaryLink?: {
-            __typename?: 'ComponentBlocksCommonLink'
-            label: string
-            url?: string | null
-            analyticsId?: string | null
-            page?: {
-              __typename?: 'PageEntityResponse'
-              data?: {
-                __typename?: 'PageEntity'
-                id?: string | null
-                attributes?: {
-                  __typename?: 'Page'
-                  title?: string | null
-                  slug?: string | null
-                } | null
-              } | null
-            } | null
-            article?: {
-              __typename?: 'ArticleEntityResponse'
-              data?: {
-                __typename: 'ArticleEntity'
-                id?: string | null
-                attributes?: {
-                  __typename?: 'Article'
-                  slug: string
-                  title: string
-                  locale?: string | null
-                } | null
-              } | null
-            } | null
-          } | null
-          secondaryLink?: {
-            __typename?: 'ComponentBlocksCommonLink'
-            label: string
-            url?: string | null
-            analyticsId?: string | null
-            page?: {
-              __typename?: 'PageEntityResponse'
-              data?: {
-                __typename?: 'PageEntity'
-                id?: string | null
-                attributes?: {
-                  __typename?: 'Page'
-                  title?: string | null
-                  slug?: string | null
-                } | null
-              } | null
-            } | null
-            article?: {
-              __typename?: 'ArticleEntityResponse'
-              data?: {
-                __typename: 'ArticleEntity'
-                id?: string | null
-                attributes?: {
-                  __typename?: 'Article'
-                  slug: string
-                  title: string
-                  locale?: string | null
-                } | null
-              } | null
-            } | null
-          } | null
-          tertiaryLink?: {
-            __typename?: 'ComponentBlocksCommonLink'
-            label: string
-            url?: string | null
-            analyticsId?: string | null
-            page?: {
-              __typename?: 'PageEntityResponse'
-              data?: {
-                __typename?: 'PageEntity'
-                id?: string | null
-                attributes?: {
-                  __typename?: 'Page'
-                  title?: string | null
-                  slug?: string | null
-                } | null
-              } | null
-            } | null
-            article?: {
-              __typename?: 'ArticleEntityResponse'
-              data?: {
-                __typename: 'ArticleEntity'
-                id?: string | null
-                attributes?: {
-                  __typename?: 'Article'
-                  slug: string
-                  title: string
-                  locale?: string | null
-                } | null
-              } | null
-            } | null
-          } | null
-        }
-      | {
-          __typename: 'ComponentSectionsCalculator'
-          hasBackground?: boolean | null
-          single_adult_value?: number | null
-          another_adult_value?: number | null
-          child_value?: number | null
-        }
-      | {
-          __typename: 'ComponentSectionsColumnedText'
-          content?: string | null
-          contentAlignment?: Enum_Componentsectionscolumnedtext_Contentalignment | null
-        }
-      | {
-          __typename: 'ComponentSectionsComparisonSection'
-          title?: string | null
-          text?: string | null
-          textAlignComparison: Enum_Componentsectionscomparisonsection_Textalign
-          cards: Array<{
-            __typename?: 'ComponentBlocksComparisonCard'
-            title: string
-            items: Array<{ __typename?: 'ComponentBlocksComparisonItem'; label: string } | null>
-            iconMedia?: {
-              __typename?: 'UploadFileEntityResponse'
-              data?: {
-                __typename?: 'UploadFileEntity'
-                attributes?: { __typename?: 'UploadFile'; url: string } | null
-              } | null
-            } | null
-          } | null>
-        }
-      | {
-          __typename: 'ComponentSectionsContactsSection'
-          id: string
-          title?: string | null
-          description?: string | null
-          hasBackground?: boolean | null
-          type: Enum_Componentsectionscontactssection_Type
-          addressContacts?: Array<{
-            __typename?: 'ComponentBlocksContactCard'
-            overrideLabel?: string | null
-            value: string
-          } | null> | null
-          emailContacts?: Array<{
-            __typename?: 'ComponentBlocksContactCard'
-            overrideLabel?: string | null
-            value: string
-          } | null> | null
-          phoneContacts?: Array<{
-            __typename?: 'ComponentBlocksContactCard'
-            overrideLabel?: string | null
-            value: string
-          } | null> | null
-          webContacts?: Array<{
-            __typename?: 'ComponentBlocksContactCard'
-            overrideLabel?: string | null
-            value: string
-          } | null> | null
-        }
-      | {
-          __typename: 'ComponentSectionsDivider'
-          style?: Enum_Componentsectionsdivider_Style | null
-        }
-      | {
-          __typename: 'ComponentSectionsFaqCategories'
-          title?: string | null
-          text?: string | null
-          faqCategories?: {
-            __typename?: 'FaqCategoryRelationResponseCollection'
-            data: Array<{
-              __typename?: 'FaqCategoryEntity'
-              id?: string | null
-              attributes?: {
-                __typename?: 'FaqCategory'
-                title: string
-                slug: string
-                faqs?: {
-                  __typename?: 'FaqRelationResponseCollection'
-                  data: Array<{
-                    __typename?: 'FaqEntity'
-                    id?: string | null
-                    attributes?: { __typename?: 'Faq'; title: string; body?: string | null } | null
-                  }>
-                } | null
-              } | null
-            }>
-          } | null
-        }
-      | {
-          __typename: 'ComponentSectionsFaqs'
-          title?: string | null
-          text?: string | null
-          faqs?: {
-            __typename?: 'FaqRelationResponseCollection'
-            data: Array<{
-              __typename?: 'FaqEntity'
-              id?: string | null
-              attributes?: { __typename?: 'Faq'; title: string; body?: string | null } | null
-            }>
-          } | null
-        }
-      | {
-          __typename: 'ComponentSectionsFileList'
-          title?: string | null
-          text?: string | null
-          fileList?: Array<{
-            __typename?: 'ComponentBlocksFile'
-            id: string
-            title?: string | null
-            media?: {
-              __typename?: 'UploadFileEntityResponse'
-              data?: {
-                __typename?: 'UploadFileEntity'
-                id?: string | null
-                attributes?: {
-                  __typename?: 'UploadFile'
-                  url: string
-                  name: string
-                  ext?: string | null
-                  size: number
-                  createdAt?: any | null
-                  updatedAt?: any | null
-                } | null
-              } | null
-            } | null
-          } | null> | null
-        }
-      | {
-          __typename: 'ComponentSectionsGallery'
-          title?: string | null
-          text?: string | null
-          medias: {
-            __typename?: 'UploadFileRelationResponseCollection'
-            data: Array<{
-              __typename?: 'UploadFileEntity'
-              id?: string | null
-              attributes?: {
-                __typename?: 'UploadFile'
-                url: string
-                width?: number | null
-                height?: number | null
-                caption?: string | null
-                alternativeText?: string | null
-                name: string
-              } | null
-            }>
-          }
-        }
-      | {
-          __typename: 'ComponentSectionsIconTitleDesc'
-          title?: string | null
-          list?: Array<{
-            __typename?: 'ComponentBlocksIconWithTitleAndDescription'
-            title?: string | null
-            desc?: string | null
-            disableIconBackground?: boolean | null
-            icon?: {
-              __typename?: 'UploadFileEntityResponse'
-              data?: {
-                __typename?: 'UploadFileEntity'
-                id?: string | null
-                attributes?: { __typename?: 'UploadFile'; url: string } | null
-              } | null
-            } | null
-          } | null> | null
-        }
-      | {
-          __typename: 'ComponentSectionsIframe'
-          url: string
-          iframeWidth: Enum_Componentsectionsiframe_Iframewidth
-          iframeHeight: string
-          fullHeight: boolean
-          allowFullscreen: boolean
-          css?: string | null
-          allowGeolocation?: boolean | null
-        }
-      | {
-          __typename: 'ComponentSectionsInbaArticlesList'
-          title?: string | null
-          text?: string | null
-        }
-      | { __typename: 'ComponentSectionsInbaReleases'; title?: string | null; text?: string | null }
-      | {
-          __typename: 'ComponentSectionsLinks'
-          title?: string | null
-          pageLinks?: Array<{
-            __typename?: 'ComponentBlocksPageLink'
-            title?: string | null
-            url?: string | null
-            page?: {
-              __typename?: 'PageEntityResponse'
-              data?: {
-                __typename?: 'PageEntity'
-                attributes?: {
-                  __typename?: 'Page'
-                  title?: string | null
-                  slug?: string | null
-                  locale?: string | null
-                } | null
-              } | null
-            } | null
-          } | null> | null
-        }
-      | {
-          __typename: 'ComponentSectionsNarrowText'
-          content?: string | null
-          width?: Enum_Componentsectionsnarrowtext_Width | null
-          align?: Enum_Componentsectionsnarrowtext_Align | null
-        }
-      | {
-          __typename: 'ComponentSectionsNumericalList'
-          id: string
-          title?: string | null
-          variant?: Enum_Componentsectionsnumericallist_Variant | null
-          buttonText?: string | null
-          buttonLink?: string | null
-          items?: Array<{
-            __typename?: 'ComponentBlocksNumericalListItem'
-            text?: string | null
-          } | null> | null
-        }
-      | { __typename: 'ComponentSectionsOfficialBoard' }
-      | { __typename: 'ComponentSectionsOrganizationalStructure'; title?: string | null }
-      | {
-          __typename: 'ComponentSectionsProsAndConsSection'
-          title?: string | null
-          text?: string | null
-          textAlignProsAndCons: Enum_Componentsectionsprosandconssection_Textalign
-          pros: {
-            __typename?: 'ComponentBlocksProsAndConsCard'
-            title: string
-            items: Array<{ __typename?: 'ComponentBlocksComparisonItem'; label: string } | null>
-          }
-          cons: {
-            __typename?: 'ComponentBlocksProsAndConsCard'
-            title: string
-            items: Array<{ __typename?: 'ComponentBlocksComparisonItem'; label: string } | null>
-          }
-        }
-      | {
-          __typename: 'ComponentSectionsRegulations'
-          regulations?: {
-            __typename?: 'RegulationRelationResponseCollection'
-            data: Array<{
-              __typename?: 'RegulationEntity'
-              id?: string | null
-              attributes?: {
-                __typename?: 'Regulation'
-                regNumber: string
-                slug: string
-                titleText?: string | null
-                fullTitle: string
-                effectiveFrom: any
-                category: Enum_Regulation_Category
-                isFullTextRegulation: boolean
-                mainDocument: {
-                  __typename?: 'UploadFileEntityResponse'
-                  data?: {
-                    __typename?: 'UploadFileEntity'
-                    id?: string | null
-                    attributes?: {
-                      __typename?: 'UploadFile'
-                      url: string
-                      name: string
-                      ext?: string | null
-                      size: number
-                      createdAt?: any | null
-                      updatedAt?: any | null
-                    } | null
-                  } | null
-                }
-                attachments?: {
-                  __typename?: 'UploadFileRelationResponseCollection'
-                  data: Array<{
-                    __typename?: 'UploadFileEntity'
-                    id?: string | null
-                    attributes?: {
-                      __typename?: 'UploadFile'
-                      url: string
-                      name: string
-                      ext?: string | null
-                      size: number
-                      createdAt?: any | null
-                      updatedAt?: any | null
-                    } | null
-                  }>
-                } | null
-                amendments?: {
-                  __typename?: 'RegulationRelationResponseCollection'
-                  data: Array<{
-                    __typename?: 'RegulationEntity'
-                    id?: string | null
-                    attributes?: {
-                      __typename?: 'Regulation'
-                      regNumber: string
-                      slug: string
-                      effectiveFrom: any
-                      isFullTextRegulation: boolean
-                      attachments?: {
-                        __typename?: 'UploadFileRelationResponseCollection'
-                        data: Array<{
-                          __typename?: 'UploadFileEntity'
-                          id?: string | null
-                          attributes?: {
-                            __typename?: 'UploadFile'
-                            url: string
-                            name: string
-                            ext?: string | null
-                            size: number
-                            createdAt?: any | null
-                            updatedAt?: any | null
-                          } | null
-                        }>
-                      } | null
-                    } | null
-                  }>
-                } | null
-                amending?: {
-                  __typename?: 'RegulationRelationResponseCollection'
-                  data: Array<{
-                    __typename?: 'RegulationEntity'
-                    id?: string | null
-                    attributes?: {
-                      __typename?: 'Regulation'
-                      regNumber: string
-                      slug: string
-                      effectiveFrom: any
-                      cancellation?: {
-                        __typename?: 'RegulationEntityResponse'
-                        data?: {
-                          __typename?: 'RegulationEntity'
-                          id?: string | null
-                          attributes?: {
-                            __typename?: 'Regulation'
-                            regNumber: string
-                            slug: string
-                            effectiveFrom: any
-                          } | null
-                        } | null
-                      } | null
-                      amending?: {
-                        __typename?: 'RegulationRelationResponseCollection'
-                        data: Array<{
-                          __typename?: 'RegulationEntity'
-                          id?: string | null
-                          attributes?: {
-                            __typename?: 'Regulation'
-                            regNumber: string
-                            slug: string
-                            cancellation?: {
-                              __typename?: 'RegulationEntityResponse'
-                              data?: {
-                                __typename?: 'RegulationEntity'
-                                id?: string | null
-                                attributes?: {
-                                  __typename?: 'Regulation'
-                                  regNumber: string
-                                  slug: string
-                                  effectiveFrom: any
-                                } | null
-                              } | null
-                            } | null
-                          } | null
-                        }>
-                      } | null
-                    } | null
-                  }>
-                } | null
-                cancellation?: {
-                  __typename?: 'RegulationEntityResponse'
-                  data?: {
-                    __typename?: 'RegulationEntity'
-                    id?: string | null
-                    attributes?: {
-                      __typename?: 'Regulation'
-                      regNumber: string
-                      slug: string
-                      effectiveFrom: any
-                    } | null
-                  } | null
-                } | null
-                cancelling?: {
-                  __typename?: 'RegulationRelationResponseCollection'
-                  data: Array<{
-                    __typename?: 'RegulationEntity'
-                    id?: string | null
-                    attributes?: {
-                      __typename?: 'Regulation'
-                      regNumber: string
-                      slug: string
-                      effectiveFrom: any
-                    } | null
-                  }>
-                } | null
-              } | null
-            }>
-          } | null
-        }
-      | { __typename: 'ComponentSectionsRegulationsList' }
-      | {
-          __typename: 'ComponentSectionsTestimonials'
-          title?: string | null
-          text?: string | null
-          hasBackground?: boolean | null
-          testimonials: Array<{
-            __typename?: 'ComponentBlocksTestimonialItem'
-            id: string
-            name: string
-            quote: string
-          } | null>
-        }
-      | {
-          __typename: 'ComponentSectionsTextWithImage'
-          content?: string | null
-          imagePosition?: Enum_Componentsectionstextwithimage_Imageposition | null
-          imageSrc?: {
-            __typename?: 'UploadFileEntityResponse'
-            data?: {
-              __typename?: 'UploadFileEntity'
-              attributes?: {
-                __typename?: 'UploadFile'
-                url: string
-                alternativeText?: string | null
-                width?: number | null
-                height?: number | null
-              } | null
-            } | null
-          } | null
-        }
-      | {
-          __typename: 'ComponentSectionsTimeline'
-          timelineItems?: Array<{
-            __typename?: 'ComponentBlocksTimelineItem'
-            id: string
-            title?: string | null
-            content?: string | null
-          } | null> | null
-        }
-      | {
-          __typename: 'ComponentSectionsVideos'
-          id: string
-          title?: string | null
-          subtitle?: string | null
-          videos?: Array<{
-            __typename?: 'ComponentBlocksVideo'
-            id: string
-            title?: string | null
-            speaker?: string | null
-            url?: string | null
-          } | null> | null
-        }
-      | {
-          __typename: 'ComponentSectionsWaves'
-          position?: Enum_Componentsectionswaves_Position | null
-        }
-      | { __typename: 'Error' }
-      | null
-    > | null
-    localizations?: {
-      __typename?: 'PageRelationResponseCollection'
-      data: Array<{
-        __typename?: 'PageEntity'
-        attributes?: { __typename?: 'Page'; slug?: string | null; locale?: string | null } | null
-      }>
-    } | null
-    pageHeaderSections?: Array<
-      | {
-          __typename: 'ComponentSectionsSubpageList'
-          id: string
-          subpageList?: Array<{
-            __typename?: 'ComponentBlocksPageLink'
-            title?: string | null
-            url?: string | null
-            page?: {
-              __typename?: 'PageEntityResponse'
-              data?: {
-                __typename?: 'PageEntity'
-                attributes?: {
-                  __typename?: 'Page'
-                  title?: string | null
-                  slug?: string | null
-                  locale?: string | null
-                } | null
-              } | null
-            } | null
-          } | null> | null
-        }
-      | { __typename: 'Error' }
-      | null
-    > | null
-    pageCategory?: {
-      __typename?: 'PageCategoryEntityResponse'
-      data?: {
-        __typename?: 'PageCategoryEntity'
-        id?: string | null
-        attributes?: {
-          __typename?: 'PageCategory'
-          title?: string | null
-          color?: Enum_Pagecategory_Color | null
-        } | null
-      } | null
-    } | null
-    relatedContents?: {
-      __typename?: 'TagRelationResponseCollection'
-      data: Array<{
-        __typename?: 'TagEntity'
-        id?: string | null
-        attributes?: {
-          __typename?: 'Tag'
-          title?: string | null
-          pageCategory?: {
-            __typename?: 'PageCategoryEntityResponse'
-            data?: {
-              __typename?: 'PageCategoryEntity'
-              id?: string | null
-              attributes?: {
-                __typename?: 'PageCategory'
-                title?: string | null
-                color?: Enum_Pagecategory_Color | null
-              } | null
-            } | null
-          } | null
-        } | null
-      }>
-    } | null
-    parentPage?: {
-      __typename?: 'PageEntityResponse'
-      data?: {
-        __typename?: 'PageEntity'
-        attributes?: {
-          __typename?: 'Page'
-          slug?: string | null
-          locale?: string | null
-          title?: string | null
-          parentPage?: {
-            __typename?: 'PageEntityResponse'
-            data?: {
-              __typename?: 'PageEntity'
-              attributes?: {
-                __typename?: 'Page'
-                slug?: string | null
-                locale?: string | null
-                title?: string | null
-                parentPage?: {
-                  __typename?: 'PageEntityResponse'
-                  data?: {
-                    __typename?: 'PageEntity'
-                    attributes?: {
-                      __typename?: 'Page'
-                      slug?: string | null
-                      locale?: string | null
-                      title?: string | null
-                      parentPage?: {
-                        __typename?: 'PageEntityResponse'
-                        data?: {
-                          __typename?: 'PageEntity'
-                          attributes?: {
-                            __typename?: 'Page'
-                            slug?: string | null
-                            locale?: string | null
-                            title?: string | null
-                          } | null
-                        } | null
-                      } | null
-                    } | null
-                  } | null
-                } | null
-              } | null
-            } | null
-          } | null
-        } | null
-      } | null
-    } | null
+    }>
   } | null
-}
-
-export type ParentPageFragment = {
-  __typename?: 'Page'
-  slug?: string | null
-  locale?: string | null
-  title?: string | null
-}
-
-export type LocalizationFragment = {
-  __typename?: 'PageRelationResponseCollection'
-  data: Array<{
-    __typename?: 'PageEntity'
-    attributes?: { __typename?: 'Page'; slug?: string | null; locale?: string | null } | null
-  }>
 }
 
 export type AllRegulationsQueryVariables = Exact<{ [key: string]: never }>
@@ -12907,6 +12955,16 @@ export const InbaReleaseEntityFragmentDoc = gql`
   ${UploadImageEntityFragmentDoc}
   ${UploadFileEntityFragmentDoc}
 `
+export const PageSlugEntityFragmentDoc = gql`
+  fragment PageSlugEntity on PageEntity {
+    id
+    attributes {
+      slug
+      title
+      locale
+    }
+  }
+`
 export const IconTitleDescriptionBlockFragmentDoc = gql`
   fragment IconTitleDescriptionBlock on ComponentBlocksIconWithTitleAndDescription {
     title
@@ -13608,10 +13666,9 @@ export const PageHeaderSectionsFragmentDoc = gql`
 `
 export const PageEntityFragmentDoc = gql`
   fragment PageEntity on PageEntity {
-    id
+    ...PageSlugEntity
     attributes {
-      slug
-      title
+      alias
       subtext
       pageColor
       metaDiscription
@@ -13627,7 +13684,6 @@ export const PageEntityFragmentDoc = gql`
       sections {
         ...Sections
       }
-      locale
       localizations {
         ...Localization
       }
@@ -13651,6 +13707,7 @@ export const PageEntityFragmentDoc = gql`
     }
     ...PageParentPages
   }
+  ${PageSlugEntityFragmentDoc}
   ${UploadImageSrcEntityFragmentDoc}
   ${CommonLinkFragmentDoc}
   ${SectionsFragmentDoc}
@@ -13965,6 +14022,22 @@ export const PageBySlugDocument = gql`
     }
   }
   ${PageEntityFragmentDoc}
+`
+export const PageRedirectByAliasDocument = gql`
+  query PageRedirectByAlias($alias: String!, $locale: I18NLocaleCode!) {
+    pages(filters: { alias: { eq: $alias } }, locale: $locale) {
+      data {
+        ...PageSlugEntity
+      }
+    }
+    articles(filters: { alias: { eq: $alias } }, locale: $locale) {
+      data {
+        ...ArticleSlugEntity
+      }
+    }
+  }
+  ${PageSlugEntityFragmentDoc}
+  ${ArticleSlugEntityFragmentDoc}
 `
 export const AllRegulationsDocument = gql`
   query allRegulations {
@@ -14392,6 +14465,21 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
             ...wrappedRequestHeaders,
           }),
         'PageBySlug',
+        'query',
+        variables,
+      )
+    },
+    PageRedirectByAlias(
+      variables: PageRedirectByAliasQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<PageRedirectByAliasQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<PageRedirectByAliasQuery>(PageRedirectByAliasDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'PageRedirectByAlias',
         'query',
         variables,
       )

--- a/next/src/services/graphql/index.ts
+++ b/next/src/services/graphql/index.ts
@@ -3667,6 +3667,7 @@ export type MutationUploadArgs = {
 
 export type Page = {
   __typename?: 'Page'
+  alias?: Maybe<Scalars['String']['output']>
   childPages?: Maybe<PageRelationResponseCollection>
   createdAt?: Maybe<Scalars['DateTime']['output']>
   headerLinks?: Maybe<Array<Maybe<ComponentBlocksCommonLink>>>
@@ -3808,6 +3809,7 @@ export type PageEntityResponseCollection = {
 }
 
 export type PageFiltersInput = {
+  alias?: InputMaybe<StringFilterInput>
   and?: InputMaybe<Array<InputMaybe<PageFiltersInput>>>
   childPages?: InputMaybe<PageFiltersInput>
   createdAt?: InputMaybe<DateTimeFilterInput>
@@ -3831,6 +3833,7 @@ export type PageFiltersInput = {
 }
 
 export type PageInput = {
+  alias?: InputMaybe<Scalars['String']['input']>
   childPages?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>
   headerLinks?: InputMaybe<Array<InputMaybe<ComponentBlocksCommonLinkInput>>>
   keywords?: InputMaybe<Scalars['String']['input']>

--- a/next/src/services/graphql/queries/Pages.graphql
+++ b/next/src/services/graphql/queries/Pages.graphql
@@ -1,20 +1,7 @@
-query PagesStaticPaths {
-  pages(pagination: { limit: -1 }) {
-    data {
-      id
-      attributes {
-        slug
-      }
-    }
-  }
-}
-
-query PageBySlug($slug: String!, $locale: I18NLocaleCode!) {
-  pages(filters: { slug: { eq: $slug } }, locale: $locale) {
-    data {
-      ...PageEntity
-    }
-  }
+fragment ParentPage on Page {
+  slug
+  locale
+  title
 }
 
 fragment PageParentPages on PageEntity {
@@ -51,11 +38,28 @@ fragment PageParentPages on PageEntity {
   }
 }
 
-fragment PageEntity on PageEntity {
+fragment Localization on PageRelationResponseCollection {
+  data {
+    attributes {
+      slug
+      locale
+    }
+  }
+}
+
+fragment PageSlugEntity on PageEntity {
   id
   attributes {
     slug
     title
+    locale
+  }
+}
+
+fragment PageEntity on PageEntity {
+  ...PageSlugEntity
+  attributes {
+    alias
     subtext
     pageColor
     metaDiscription
@@ -71,7 +75,6 @@ fragment PageEntity on PageEntity {
     sections {
       ...Sections
     }
-    locale
     localizations {
       ...Localization
     }
@@ -96,17 +99,35 @@ fragment PageEntity on PageEntity {
   ...PageParentPages
 }
 
-fragment ParentPage on Page {
-  slug
-  locale
-  title
+query PagesStaticPaths {
+  pages(pagination: { limit: -1 }) {
+    data {
+      id
+      attributes {
+        slug
+      }
+    }
+  }
 }
 
-fragment Localization on PageRelationResponseCollection {
-  data {
-    attributes {
-      slug
-      locale
+query PageBySlug($slug: String!, $locale: I18NLocaleCode!) {
+  pages(filters: { slug: { eq: $slug } }, locale: $locale) {
+    data {
+      ...PageEntity
+    }
+  }
+}
+
+# Based on OLO: https://github.com/bratislava/olo.sk/blob/master/next/src/services/graphql/queries/pages.gql
+query PageRedirectByAlias($alias: String!, $locale: I18NLocaleCode!) {
+  pages(filters: { alias: { eq: $alias } }, locale: $locale) {
+    data {
+      ...PageSlugEntity
+    }
+  }
+  articles(filters: { alias: { eq: $alias } }, locale: $locale) {
+    data {
+      ...ArticleSlugEntity
     }
   }
 }

--- a/strapi/config/sync/admin-role.strapi-super-admin.json
+++ b/strapi/config/sync/admin-role.strapi-super-admin.json
@@ -1323,6 +1323,7 @@
         "fields": [
           "title",
           "slug",
+          "alias",
           "subtext",
           "metaDiscription",
           "keywords",
@@ -1379,6 +1380,7 @@
         "fields": [
           "title",
           "slug",
+          "alias",
           "subtext",
           "metaDiscription",
           "keywords",
@@ -1411,6 +1413,7 @@
         "fields": [
           "title",
           "slug",
+          "alias",
           "subtext",
           "metaDiscription",
           "keywords",

--- a/strapi/config/sync/core-store.plugin_content_manager_configuration_content_types##api##page.page.json
+++ b/strapi/config/sync/core-store.plugin_content_manager_configuration_content_types##api##page.page.json
@@ -48,6 +48,20 @@
           "sortable": true
         }
       },
+      "alias": {
+        "edit": {
+          "label": "Alias",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "alias",
+          "searchable": true,
+          "sortable": true
+        }
+      },
       "subtext": {
         "edit": {
           "label": "Text v hlavičke",
@@ -280,12 +294,6 @@
       }
     },
     "layouts": {
-      "list": [
-        "slug",
-        "title",
-        "updatedAt",
-        "parentPage"
-      ],
       "edit": [
         [
           {
@@ -366,7 +374,19 @@
             "name": "relatedContents",
             "size": 12
           }
+        ],
+        [
+          {
+            "name": "alias",
+            "size": 6
+          }
         ]
+      ],
+      "list": [
+        "slug",
+        "title",
+        "updatedAt",
+        "parentPage"
       ]
     }
   },

--- a/strapi/schema.graphql
+++ b/strapi/schema.graphql
@@ -2757,6 +2757,7 @@ type Mutation {
 }
 
 type Page {
+  alias: String
   childPages(filters: PageFiltersInput, pagination: PaginationArg = {}, publicationState: PublicationState = LIVE, sort: [String] = []): PageRelationResponseCollection
   createdAt: DateTime
   headerLinks(filters: ComponentBlocksCommonLinkFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): [ComponentBlocksCommonLink]
@@ -2850,6 +2851,7 @@ type PageEntityResponseCollection {
 }
 
 input PageFiltersInput {
+  alias: StringFilterInput
   and: [PageFiltersInput]
   childPages: PageFiltersInput
   createdAt: DateTimeFilterInput
@@ -2873,6 +2875,7 @@ input PageFiltersInput {
 }
 
 input PageInput {
+  alias: String
   childPages: [ID]
   headerLinks: [ComponentBlocksCommonLinkInput]
   keywords: String

--- a/strapi/src/api/page/content-types/page/schema.json
+++ b/strapi/src/api/page/content-types/page/schema.json
@@ -32,6 +32,14 @@
       },
       "type": "string"
     },
+    "alias": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "uid"
+    },
     "subtext": {
       "pluginOptions": {
         "i18n": {
@@ -69,25 +77,13 @@
         }
       },
       "type": "enumeration",
-      "enum": [
-        "red",
-        "blue",
-        "green",
-        "yellow",
-        "purple",
-        "brown"
-      ]
+      "enum": ["red", "blue", "green", "yellow", "purple", "brown"]
     },
     "pageBackgroundImage": {
       "type": "media",
       "multiple": false,
       "required": false,
-      "allowedTypes": [
-        "images",
-        "files",
-        "videos",
-        "audios"
-      ],
+      "allowedTypes": ["images", "files", "videos", "audios"],
       "pluginOptions": {
         "i18n": {
           "localized": true
@@ -111,9 +107,7 @@
         }
       },
       "type": "dynamiczone",
-      "components": [
-        "sections.subpage-list"
-      ]
+      "components": ["sections.subpage-list"]
     },
     "sections": {
       "pluginOptions": {

--- a/strapi/types/generated/contentTypes.d.ts
+++ b/strapi/types/generated/contentTypes.d.ts
@@ -1116,6 +1116,12 @@ export interface ApiPagePage extends Schema.CollectionType {
     }
   }
   attributes: {
+    alias: Attribute.UID &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }>
     childPages: Attribute.Relation<'api::page.page', 'oneToMany', 'api::page.page'>
     createdAt: Attribute.DateTime
     createdBy: Attribute.Relation<'api::page.page', 'oneToOne', 'admin::user'> & Attribute.Private


### PR DESCRIPTION
- add `alias` field for Pages (Articles already had it, but not used)
- implement redirects with same approach as in OLO
- show info message when page/article has an alias (this was inspired by hel.fi website, also used on OLO)
  - improve paddings on article page
- fix footer text size

This is a nice solution how to add an option for short urls, usually needed for sharing or campaigns, while keeping real urls inlined with sitemap nesting. 

Note that `alias` field is only visible for super admins for now, until properly tested.

Screenshots from localhost (no alias are set on production/staging):

![image](https://github.com/user-attachments/assets/7670bfa8-668b-47b7-bb94-1ee8c94d6ec4)

![image](https://github.com/user-attachments/assets/746abc85-5f87-465a-b87f-f178a5957c01)
