### PR TITLE
Fix cypress tests after CookieBot was introduced

### DIFF
--- a/tests/cypress/e2e/404Page.cy.ts
+++ b/tests/cypress/e2e/404Page.cy.ts
@@ -9,6 +9,7 @@ describe('Page 404', { testIsolation: false }, () => {
       context(device, Cypress.env('resolution')[`${device}`], () => {
         before(() => {
           cy.visit('/93dfcaf3d923ec47edb8580667473987', { failOnStatusCode: false })
+          cy.setCookie('CookieConsent', 'false') // Set CookieBot cookies to something to prevent cookie banner to show up
         })
 
         it('1. Check if the 404 page is displayed.', () => {

--- a/tests/cypress/e2e/accountButton.cy.ts
+++ b/tests/cypress/e2e/accountButton.cy.ts
@@ -9,6 +9,7 @@ describe('Account button', { testIsolation: false }, () => {
       context(device, Cypress.env('resolution')[`${device}`], () => {
         before(() => {
           cy.visit('/')
+          cy.setCookie('CookieConsent', 'false') // Set CookieBot cookies to something to prevent cookie banner to show up
         })
 
         it('1. Checking account button.', () => {

--- a/tests/cypress/e2e/englishTranslation.cy.ts
+++ b/tests/cypress/e2e/englishTranslation.cy.ts
@@ -9,6 +9,7 @@ describe('English translation', { testIsolation: false }, () => {
       context(device, Cypress.env('resolution')[`${device}`], () => {
         before(() => {
           cy.visit('/kontakty')
+          cy.setCookie('CookieConsent', 'false') // Set CookieBot cookies to something to prevent cookie banner to show up
         })
 
         it('1. Translating contact page.', () => {

--- a/tests/cypress/e2e/homepageSearch.cy.ts
+++ b/tests/cypress/e2e/homepageSearch.cy.ts
@@ -9,6 +9,7 @@ describe('S02 - ', { testIsolation: false }, () => {
       context(device, Cypress.env('resolution')[`${device}`], () => {
         beforeEach(() => {
           cy.visit('/')
+          cy.setCookie('CookieConsent', 'false') // Set CookieBot cookies to something to prevent cookie banner to show up
         })
 
         it('1. Checking homepage search with results.', () => {

--- a/tests/cypress/e2e/officialBoard.cy.ts
+++ b/tests/cypress/e2e/officialBoard.cy.ts
@@ -9,6 +9,7 @@ describe('OB - 1', { testIsolation: false }, () => {
       context(device, Cypress.env('resolution')[`${device}`], () => {
         before(() => {
           cy.visit('/')
+          cy.setCookie('CookieConsent', 'false') // Set CookieBot cookies to something to prevent cookie banner to show up
         })
 
         it('1. Checking official board.', () => {

--- a/tests/cypress/e2e/organizationalStructure.cy.ts
+++ b/tests/cypress/e2e/organizationalStructure.cy.ts
@@ -9,6 +9,7 @@ describe('OS01 -', { testIsolation: false }, () => {
       context(device, Cypress.env('resolution')[`${device}`], () => {
         before(() => {
           cy.visit('/mesto-bratislava/sprava-mesta/magistrat/organizacna-struktura')
+          cy.setCookie('CookieConsent', 'false') // Set CookieBot cookies to something to prevent cookie banner to show up
         })
 
         it('1. Check organizational structure data.', () => {

--- a/tests/cypress/e2e/searchPage.cy.ts
+++ b/tests/cypress/e2e/searchPage.cy.ts
@@ -9,6 +9,7 @@ describe('S01 - ', { testIsolation: false }, () => {
       context(device, Cypress.env('resolution')[`${device}`], () => {
         beforeEach(() => {
           cy.visit('/')
+          cy.setCookie('CookieConsent', 'false') // Set CookieBot cookies to something to prevent cookie banner to show up
         })
 
         it('1. Checking search page.', () => {

--- a/tests/cypress/fixtures/URLsForSmokeTests.json
+++ b/tests/cypress/fixtures/URLsForSmokeTests.json
@@ -8,7 +8,7 @@
     "status": 200
   },
   {
-    "path": "/uradne-a-navstevne-hodiny",
+    "path": "/kontakty",
     "status": 200
   },
   {
@@ -28,7 +28,15 @@
     "status": 200
   },
   {
+    "path": "/socialne-sluzby-a-byvanie",
+    "status": 200
+  },
+  {
     "path": "/vzdelavanie-a-volny-cas",
+    "status": 200
+  },
+  {
+    "path": "/kultura-a-komunity",
     "status": 200
   }
 ]


### PR DESCRIPTION
Setting cookiebot cookies to something prevents the banner to pop up, so it doesn't break the tests.
Update smokeTests urls.