### PR TITLE
#1539 Fix bug showing undefined link in accordions

### DIFF
--- a/next/src/components/sections/AccordionSection.tsx
+++ b/next/src/components/sections/AccordionSection.tsx
@@ -64,7 +64,7 @@ const AccordionSection = ({ section }: AccordionSectionProps) => {
                   {item.fileList?.filter(isDefined).length ? (
                     <FileList files={item.fileList.filter(isDefined) ?? []} />
                   ) : null}
-                  {item.moreLinkUrl || item.moreLinkPage ? (
+                  {item.moreLinkUrl || item.moreLinkPage?.data?.attributes ? (
                     <Button
                       variant="link"
                       {...getLinkProps({


### PR DESCRIPTION
Testing:
Check accordions starting with "Pre koho sú zariadenia pre seniorov určené?"
http://localhost:3000/socialne-sluzby-a-byvanie/socialne-sluzby-a-zariadenia/zariadenia-a-sluzby-pre-seniorov

![image](https://github.com/user-attachments/assets/04f958f3-bad9-4233-9686-b41a731ce8cb)
