### PR TITLE
#1543 Add new Columns section

### DIFF
--- a/next/src/components/common/ColumnsSectionItem/ColumnsSectionItem.tsx
+++ b/next/src/components/common/ColumnsSectionItem/ColumnsSectionItem.tsx
@@ -1,0 +1,50 @@
+import { Typography } from '@bratislava/component-library'
+import React from 'react'
+
+import StrapiImage from '@/src/components/common/Image/StrapiImage'
+import { ColumnsSectionFragment } from '@/src/services/graphql'
+import cn from '@/src/utils/cn'
+
+type ColumnsSectionItemProps = ColumnsSectionFragment['columns'][0] & {
+  imageSizes?: string
+  className?: string
+}
+
+/**
+ * Figma: https://www.figma.com/design/2qF09hDT9QNcpdztVMNAY4/OLO-Web?node-id=1341-10129&m=dev
+ */
+
+const ColumnsSectionItem = ({
+  title,
+  text,
+  image,
+  imageSizes,
+  className,
+}: ColumnsSectionItemProps) => {
+  return (
+    <div className={cn('flex grow justify-center', className)}>
+      <div className="flex flex-col items-center gap-4">
+        {image?.data?.attributes ? (
+          <div>
+            <StrapiImage
+              image={image.data.attributes}
+              sizes={imageSizes}
+              // pointer-events must be disabled to drag-events work properly in Slider
+              className="pointer-events-none"
+            />
+          </div>
+        ) : null}
+        <div className="flex flex-col gap-2 text-center empty:hidden">
+          {title ? (
+            <Typography variant="h5" as="h3">
+              {title}
+            </Typography>
+          ) : null}
+          {text ? <Typography>{text}</Typography> : null}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default ColumnsSectionItem

--- a/next/src/components/common/ColumnsSectionItem/ColumnsSectionItem.tsx
+++ b/next/src/components/common/ColumnsSectionItem/ColumnsSectionItem.tsx
@@ -23,7 +23,8 @@ const ColumnsSectionItem = ({
   imageSizes,
   className,
 }: ColumnsSectionItemProps) => {
-  const isPictogramVariant = imageVariant === 'columnsSection_imageVariant_withCircleIconBackground'
+  const isCircleBackgroundVariant =
+    imageVariant === 'columnsSection_imageVariant_withCircleBackground'
   const isOriginalSizeVariant = imageVariant === 'columnsSection_imageVariant_imageOriginalSize'
 
   return (
@@ -32,38 +33,25 @@ const ColumnsSectionItem = ({
         {image?.data?.attributes ? (
           <div
             className={cn('flex shrink-0 items-center justify-center', {
-              'bg-category-200 rounded-full p-6': isPictogramVariant,
+              'bg-category-200 rounded-full p-6': isCircleBackgroundVariant,
               'w-full': isOriginalSizeVariant,
             })}
           >
-            {/* For variants withCircleIconBackground and imageFixedSize, we set the parent div to be `relative`,
-                and we use `fill` property with `object-contain` class on the image */}
-            <div
-              className={cn('border', {
-                'relative h-18 w-18': isPictogramVariant,
-              })}
-            >
-              {isPictogramVariant ? (
-                <StrapiImage
-                  alt=""
-                  image={image.data.attributes}
-                  sizes={imageSizes}
-                  // pointer-events must be disabled to drag-events work properly in Slider
-                  className="pointer-events-none object-contain"
-                  fill
-                />
-              ) : (
-                <StrapiImage
-                  alt=""
-                  image={image.data.attributes}
-                  sizes={imageSizes}
-                  // pointer-events must be disabled to drag-events work properly in Slider
-                  className="pointer-events-none"
-                />
-              )}
+            <div className={cn({ 'relative h-18 w-18': isCircleBackgroundVariant })}>
+              <StrapiImage
+                alt=""
+                image={image.data.attributes}
+                sizes={imageSizes}
+                // pointer-events must be disabled to drag-events work properly in Slider
+                className={cn('pointer-events-none', {
+                  'object-contain': isCircleBackgroundVariant,
+                })}
+                fill={isCircleBackgroundVariant}
+              />
             </div>
           </div>
         ) : null}
+
         <div className="flex flex-col gap-2 text-center empty:hidden">
           {title ? (
             <Typography variant="h5" as="h3">

--- a/next/src/components/common/ColumnsSectionItem/ColumnsSectionItem.tsx
+++ b/next/src/components/common/ColumnsSectionItem/ColumnsSectionItem.tsx
@@ -30,36 +30,34 @@ const ColumnsSectionItem = ({
           <div
             className={cn('flex shrink-0 items-center justify-center', {
               'bg-category-200 rounded-full p-6':
-                imageVariant === 'columnsSection_variant_withCircleIconBackground',
-              'w-full': imageVariant !== 'columnsSection_variant_withCircleIconBackground',
+                imageVariant === 'columnsSection_imageVariant_withCircleIconBackground',
+              'w-full': imageVariant === 'columnsSection_imageVariant_imageOriginalSize',
             })}
           >
             {/* For variants withCircleIconBackground and imageFixedSize, we set the parent div to be `relative`,
                 and we use `fill` property with `object-contain` class on the image */}
             <div
-              className={cn('relative', {
+              className={cn({
                 'relative h-18 w-18':
-                  imageVariant === 'columnsSection_variant_withCircleIconBackground',
-                'relative h-30 w-full': imageVariant === 'columnsSection_variant_imageFixedHeight',
-                // no classes for imageVariant === 'columnsSection_variant_imageNonFixedSize'
+                  imageVariant === 'columnsSection_imageVariant_withCircleIconBackground',
               })}
             >
-              {imageVariant === 'columnsSection_variant_imageNonFixedSize' ? (
+              {imageVariant === 'columnsSection_imageVariant_imageOriginalSize' ? (
                 <StrapiImage
+                  alt=""
                   image={image.data.attributes}
                   sizes={imageSizes}
                   // pointer-events must be disabled to drag-events work properly in Slider
                   className="pointer-events-none"
-                  alt=""
                 />
               ) : (
                 <StrapiImage
+                  alt=""
                   image={image.data.attributes}
                   sizes={imageSizes}
                   // pointer-events must be disabled to drag-events work properly in Slider
                   className="pointer-events-none object-contain"
                   fill
-                  alt=""
                 />
               )}
             </div>

--- a/next/src/components/common/ColumnsSectionItem/ColumnsSectionItem.tsx
+++ b/next/src/components/common/ColumnsSectionItem/ColumnsSectionItem.tsx
@@ -6,6 +6,7 @@ import { ColumnsSectionFragment } from '@/src/services/graphql'
 import cn from '@/src/utils/cn'
 
 type ColumnsSectionItemProps = ColumnsSectionFragment['columns'][0] & {
+  imageVariant?: ColumnsSectionFragment['imageVariant']
   imageSizes?: string
   className?: string
 }
@@ -18,20 +19,50 @@ const ColumnsSectionItem = ({
   title,
   text,
   image,
+  imageVariant,
   imageSizes,
   className,
 }: ColumnsSectionItemProps) => {
   return (
     <div className={cn('flex grow justify-center', className)}>
-      <div className="flex flex-col items-center gap-4">
+      <div className="flex w-full flex-col items-center gap-4">
         {image?.data?.attributes ? (
-          <div>
-            <StrapiImage
-              image={image.data.attributes}
-              sizes={imageSizes}
-              // pointer-events must be disabled to drag-events work properly in Slider
-              className="pointer-events-none"
-            />
+          <div
+            className={cn('flex shrink-0 items-center justify-center', {
+              'bg-category-200 rounded-full p-6':
+                imageVariant === 'columnsSection_variant_withCircleIconBackground',
+              'w-full': imageVariant !== 'columnsSection_variant_withCircleIconBackground',
+            })}
+          >
+            {/* For variants withCircleIconBackground and imageFixedSize, we set the parent div to be `relative`,
+                and we use `fill` property with `object-contain` class on the image */}
+            <div
+              className={cn('relative', {
+                'relative h-18 w-18':
+                  imageVariant === 'columnsSection_variant_withCircleIconBackground',
+                'relative h-30 w-full': imageVariant === 'columnsSection_variant_imageFixedSize',
+                // no classes for imageVariant === 'columnsSection_variant_imageNonFixedSize'
+              })}
+            >
+              {imageVariant === 'columnsSection_variant_imageNonFixedSize' ? (
+                <StrapiImage
+                  image={image.data.attributes}
+                  sizes={imageSizes}
+                  // pointer-events must be disabled to drag-events work properly in Slider
+                  className="pointer-events-none"
+                  alt=""
+                />
+              ) : (
+                <StrapiImage
+                  image={image.data.attributes}
+                  sizes={imageSizes}
+                  // pointer-events must be disabled to drag-events work properly in Slider
+                  className="pointer-events-none object-contain"
+                  fill
+                  alt=""
+                />
+              )}
+            </div>
           </div>
         ) : null}
         <div className="flex flex-col gap-2 text-center empty:hidden">

--- a/next/src/components/common/ColumnsSectionItem/ColumnsSectionItem.tsx
+++ b/next/src/components/common/ColumnsSectionItem/ColumnsSectionItem.tsx
@@ -23,34 +23,27 @@ const ColumnsSectionItem = ({
   imageSizes,
   className,
 }: ColumnsSectionItemProps) => {
+  const isPictogramVariant = imageVariant === 'columnsSection_imageVariant_withCircleIconBackground'
+  const isOriginalSizeVariant = imageVariant === 'columnsSection_imageVariant_imageOriginalSize'
+
   return (
     <div className={cn('flex grow justify-center', className)}>
       <div className="flex w-full flex-col items-center gap-4">
         {image?.data?.attributes ? (
           <div
             className={cn('flex shrink-0 items-center justify-center', {
-              'bg-category-200 rounded-full p-6':
-                imageVariant === 'columnsSection_imageVariant_withCircleIconBackground',
-              'w-full': imageVariant === 'columnsSection_imageVariant_imageOriginalSize',
+              'bg-category-200 rounded-full p-6': isPictogramVariant,
+              'w-full': isOriginalSizeVariant,
             })}
           >
             {/* For variants withCircleIconBackground and imageFixedSize, we set the parent div to be `relative`,
                 and we use `fill` property with `object-contain` class on the image */}
             <div
-              className={cn({
-                'relative h-18 w-18':
-                  imageVariant === 'columnsSection_imageVariant_withCircleIconBackground',
+              className={cn('border', {
+                'relative h-18 w-18': isPictogramVariant,
               })}
             >
-              {imageVariant === 'columnsSection_imageVariant_imageOriginalSize' ? (
-                <StrapiImage
-                  alt=""
-                  image={image.data.attributes}
-                  sizes={imageSizes}
-                  // pointer-events must be disabled to drag-events work properly in Slider
-                  className="pointer-events-none"
-                />
-              ) : (
+              {isPictogramVariant ? (
                 <StrapiImage
                   alt=""
                   image={image.data.attributes}
@@ -58,6 +51,14 @@ const ColumnsSectionItem = ({
                   // pointer-events must be disabled to drag-events work properly in Slider
                   className="pointer-events-none object-contain"
                   fill
+                />
+              ) : (
+                <StrapiImage
+                  alt=""
+                  image={image.data.attributes}
+                  sizes={imageSizes}
+                  // pointer-events must be disabled to drag-events work properly in Slider
+                  className="pointer-events-none"
                 />
               )}
             </div>

--- a/next/src/components/common/ColumnsSectionItem/ColumnsSectionItem.tsx
+++ b/next/src/components/common/ColumnsSectionItem/ColumnsSectionItem.tsx
@@ -40,7 +40,7 @@ const ColumnsSectionItem = ({
               className={cn('relative', {
                 'relative h-18 w-18':
                   imageVariant === 'columnsSection_variant_withCircleIconBackground',
-                'relative h-30 w-full': imageVariant === 'columnsSection_variant_imageFixedSize',
+                'relative h-30 w-full': imageVariant === 'columnsSection_variant_imageFixedHeight',
                 // no classes for imageVariant === 'columnsSection_variant_imageNonFixedSize'
               })}
             >

--- a/next/src/components/common/Slider/Slider.tsx
+++ b/next/src/components/common/Slider/Slider.tsx
@@ -1,0 +1,119 @@
+import { AriaLabelingProps } from '@react-types/shared'
+import { AnimatePresence, motion, MotionProps, Variant } from 'framer-motion'
+import { useTranslation } from 'next-i18next'
+import { isValidElement, ReactNode } from 'react'
+
+import Button from '@/src/components/common/Button/Button'
+import cn from '@/src/utils/cn'
+
+import DotSvg from './dot.svg'
+import DotSelectedSvg from './dot-selected.svg'
+import { useSlider } from './useSlider'
+
+type SliderProps = {
+  items: ReactNode[]
+  autoRotateInterval?: number
+  className?: string
+} & AriaLabelingProps
+
+export const variants: Record<string, Variant> = {
+  initial: (direction: number) => {
+    return {
+      x: direction === 0 ? 100 : -100, // 100 = right, -100 = left
+      opacity: 0,
+    }
+  },
+  center: {
+    x: 0,
+    opacity: 1,
+  },
+  exit: (direction: number) => {
+    return {
+      x: direction === 0 ? -100 : 100,
+      opacity: 0,
+    }
+  },
+}
+
+/**
+ * Figma tmp DS: https://www.figma.com/design/17wbd0MDQcMW9NbXl6UPs8/DS--Component-library?node-id=5865-22574&m=dev
+ * Figma OLO: https://www.figma.com/design/2qF09hDT9QNcpdztVMNAY4/OLO-Web?node-id=2097-20203&m=dev
+ * Based on OLO https://github.com/bratislava/olo.sk/blob/master/next/src/components/common/Slider/Slider.tsx
+ *
+ * TODO from OLO
+ *  - Add support for keyboard navigation by arrows
+ *  - Consistent slides height
+ *  - Pause button
+ */
+
+const Slider = ({ items, autoRotateInterval, className, ...rest }: SliderProps) => {
+  const { t } = useTranslation()
+
+  const { activeItemIndex, activeItemDirection, handleGoToPage, dragStartHandler, dragEndHandler } =
+    useSlider(items.length, autoRotateInterval)
+
+  const sliderMotionProps: MotionProps = {
+    transition: {
+      x: { type: 'spring', stiffness: 300, damping: 30, duration: 0.2 },
+      opacity: { duration: 0.2 },
+    },
+    initial: 'initial',
+    animate: 'center',
+    exit: 'exit',
+    drag: items.length > 1 ? 'x' : undefined,
+    dragConstraints: { left: 0, right: 0 },
+    dragElastic: 1,
+    onDragStart: dragStartHandler,
+    onDragEnd: dragEndHandler,
+  }
+
+  return (
+    <div className={cn('-mx-4 overflow-x-hidden px-4', className)}>
+      <div role="tabpanel" className="flex flex-col items-center justify-center gap-6" {...rest}>
+        <div className={cn('flex h-full w-full flex-col')}>
+          <AnimatePresence initial={false} mode="wait">
+            {isValidElement(items[activeItemIndex]) ? (
+              <motion.div
+                key={activeItemIndex}
+                custom={activeItemDirection}
+                variants={variants}
+                {...sliderMotionProps}
+                className="size-full"
+              >
+                {items[activeItemIndex]}
+              </motion.div>
+            ) : null}
+          </AnimatePresence>
+        </div>
+
+        {items.length > 1 ? (
+          <ul
+            // Inspired by: https://inclusive-components.design/a-content-slider/#thebuttongroup
+            role="tablist"
+            aria-label={t('slider.aria.controlButtons')}
+            className="flex flex-row items-center justify-center gap-3"
+          >
+            {items.map((_, index) => (
+              <li
+                // eslint-disable-next-line react/no-array-index-key
+                key={index}
+                role="tab"
+              >
+                <Button
+                  variant="unstyled"
+                  aria-label={t('slider.aria.goToSlide', { number: index + 1 })}
+                  onPress={() => handleGoToPage(index, activeItemDirection)}
+                  className="-m-1 rounded-sm p-1"
+                >
+                  {index === activeItemIndex ? <DotSelectedSvg /> : <DotSvg />}
+                </Button>
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+export default Slider

--- a/next/src/components/common/Slider/dot-selected.svg
+++ b/next/src/components/common/Slider/dot-selected.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="17" viewBox="0 0 16 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect x="1" y="1.5293" width="14" height="14" rx="7" stroke="currentColor" stroke-width="2"/>
+    <circle cx="8" cy="8.5293" r="4" fill="currentColor"/>
+</svg>

--- a/next/src/components/common/Slider/dot.svg
+++ b/next/src/components/common/Slider/dot.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="17" viewBox="0 0 16 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <circle cx="8" cy="8.5293" r="4" fill="currentColor"/>
+</svg>

--- a/next/src/components/common/Slider/useSlider.ts
+++ b/next/src/components/common/Slider/useSlider.ts
@@ -1,0 +1,85 @@
+import { PanInfo, useReducedMotion } from 'framer-motion'
+import { useCallback, useEffect, useState } from 'react'
+
+const SWIPE_CONFIDENCE_THRESHOLD = 10_000
+
+const getSwipePower = (offset: number, velocity: number) => Math.abs(offset) * velocity
+
+/**
+ * Based on OLO https://github.com/bratislava/olo.sk/blob/master/next/src/utils/useSlider.ts
+ *
+ * TODO from OLO: isDragged is not used
+ */
+
+export const useSlider = (itemsCount: number, autoRotateInterval?: number) => {
+  const [[index, direction], setIndex] = useState<[number, 0 | 1]>([0, 0])
+  const [isDragged, setIsDragged] = useState(false)
+  const [isWindowFocused, setIsWindowFocused] = useState(true)
+
+  const shouldReduceMotion = useReducedMotion()
+  const canAutoRotate = !!(isWindowFocused && autoRotateInterval && !shouldReduceMotion)
+
+  const handleGoToNext = useCallback(() => {
+    if (!autoRotateInterval && index === itemsCount - 1) return // Avoid wrapping array indices when autorotation is disabled
+    setIndex([(index + 1) % itemsCount, 0])
+  }, [index, autoRotateInterval, itemsCount])
+
+  const handleGoToPrevious = useCallback(() => {
+    if (!autoRotateInterval && index === 0) return // Avoid wrapping array indices when autorotation is disabled
+    setIndex([index === 0 ? itemsCount - 1 : index - 1, 1])
+  }, [index, autoRotateInterval, itemsCount])
+
+  const handleGoToPage = (newIndex: number, newDirection: 0 | 1) => {
+    setIndex([newIndex, newDirection])
+  }
+
+  const dragStartHandler = useCallback(() => {
+    setIsDragged(true)
+  }, [])
+
+  const dragEndHandler = useCallback(
+    (event: MouseEvent | TouchEvent | PointerEvent, { offset, velocity }: PanInfo) => {
+      const swipe = getSwipePower(offset.x, velocity.x)
+      if (swipe < -SWIPE_CONFIDENCE_THRESHOLD) {
+        handleGoToNext()
+      } else if (swipe > SWIPE_CONFIDENCE_THRESHOLD) {
+        handleGoToPrevious()
+      }
+
+      setIsDragged(false)
+    },
+    [handleGoToNext, handleGoToPrevious],
+  )
+
+  // eslint-disable-next-line consistent-return
+  useEffect(() => {
+    if (canAutoRotate) {
+      const handleVisibilityChange = () => setIsWindowFocused(!document.hidden)
+      // Pause autorotation when the window is unfocused to prevent slide rendering bugs
+      document.addEventListener('visibilitychange', handleVisibilityChange)
+
+      return () => document.removeEventListener('visibilitychange', handleVisibilityChange)
+    }
+  }, [canAutoRotate])
+
+  // eslint-disable-next-line consistent-return
+  useEffect(() => {
+    if (canAutoRotate) {
+      // The slider auto-rotates only from left to right to avoid rendering bugs
+      const timer = setInterval(handleGoToNext, autoRotateInterval)
+
+      return () => clearInterval(timer)
+    }
+  }, [canAutoRotate, autoRotateInterval, handleGoToNext])
+
+  return {
+    activeItemIndex: index,
+    activeItemDirection: direction,
+    isActiveItemDragged: isDragged,
+    handleGoToNext,
+    handleGoToPrevious,
+    handleGoToPage,
+    dragStartHandler,
+    dragEndHandler,
+  }
+}

--- a/next/src/components/layouts/Sections.tsx
+++ b/next/src/components/layouts/Sections.tsx
@@ -7,6 +7,7 @@ import InbaArticlesList from '@/src/components/sections/ArticlesListSection/Inba
 import BannerSection from '@/src/components/sections/BannerSection'
 import CalculatorSection from '@/src/components/sections/CalculatorSection_Deprecated/CalculatorSection_Deprecated'
 import ColumnedTextSection from '@/src/components/sections/ColumnedTextSection'
+import ColumnsSection from '@/src/components/sections/ColumnsSection'
 import ComparisonSection from '@/src/components/sections/ComparisonSection'
 import ContactsSection from '@/src/components/sections/ContactsSection'
 import DividerSection from '@/src/components/sections/DividerSection'
@@ -45,6 +46,9 @@ const SectionContent = ({ section }: { section: SectionsFragment }) => {
 
     case 'ComponentSectionsColumnedText':
       return <ColumnedTextSection section={section} />
+
+    case 'ComponentSectionsColumns':
+      return <ColumnsSection section={section} />
 
     case 'ComponentSectionsTextWithImage':
       return <TextWithImageSection section={section} />

--- a/next/src/components/sections/ColumnsSection.tsx
+++ b/next/src/components/sections/ColumnsSection.tsx
@@ -17,7 +17,7 @@ type Props = {
  */
 
 const ColumnsSection = ({ section }: Props) => {
-  const { title, text, columns, imageVariant, respoLayout } = section
+  const { title, text, columns, imageVariant, responsiveLayout } = section
 
   // eslint-disable-next-line unicorn/no-array-callback-reference
   const filteredColumns = columns?.filter(isDefined) ?? []
@@ -71,7 +71,7 @@ const ColumnsSection = ({ section }: Props) => {
       </ul>
 
       {/* Screen: Mobile */}
-      {respoLayout === 'columnsSection_respoLayout_slider' ? (
+      {responsiveLayout === 'columnsSection_responsiveLayout_slider' ? (
         <Slider
           // aria-labelledby={titleId} // TODO for better accessibility
           items={filteredColumns.map((item, index) => {

--- a/next/src/components/sections/ColumnsSection.tsx
+++ b/next/src/components/sections/ColumnsSection.tsx
@@ -16,7 +16,7 @@ type Props = {
  */
 
 const ColumnsSection = ({ section }: Props) => {
-  const { title, text, columns } = section
+  const { title, text, columns, imageVariant } = section
 
   // eslint-disable-next-line unicorn/no-array-callback-reference
   const filteredColumns = columns?.filter(isDefined) ?? []
@@ -61,6 +61,7 @@ const ColumnsSection = ({ section }: Props) => {
             >
               <ColumnsSectionItem
                 {...item}
+                imageVariant={imageVariant}
                 imageSizes={generateImageSizes({
                   default: '100vw',
                   // Note that this doesn't match the logic above for 100%, but it's okay, because it's just a simple optimization

--- a/next/src/components/sections/ColumnsSection.tsx
+++ b/next/src/components/sections/ColumnsSection.tsx
@@ -80,6 +80,7 @@ const ColumnsSection = ({ section }: Props) => {
                 // eslint-disable-next-line react/no-array-index-key
                 key={index}
                 {...item}
+                imageVariant={imageVariant}
                 imageSizes={generateImageSizes({ default: '100vw' })}
                 className="w-full"
               />

--- a/next/src/components/sections/ColumnsSection.tsx
+++ b/next/src/components/sections/ColumnsSection.tsx
@@ -25,18 +25,13 @@ const ColumnsSection = ({ section }: Props) => {
     <div className="flex flex-col gap-6 lg:gap-12">
       {title || text ? (
         <div className="flex">
-          <div
-            className={cn(
-              'grow',
-              // { 'text-center': textAlign === 'center' }
-            )}
-          >
-            {title && <Typography variant="h2">{title}</Typography>}
-            {text && (
+          <div className={cn('grow text-center')}>
+            {title ? <Typography variant="h2">{title}</Typography> : null}
+            {text ? (
               <Typography variant="p-default" className="not-first:mt-2">
                 {text}
               </Typography>
-            )}
+            ) : null}
           </div>
         </div>
       ) : null}

--- a/next/src/components/sections/ColumnsSection.tsx
+++ b/next/src/components/sections/ColumnsSection.tsx
@@ -1,0 +1,96 @@
+import { Typography } from '@bratislava/component-library'
+import React from 'react'
+
+import ColumnsSectionItem from '@/src/components/common/ColumnsSectionItem/ColumnsSectionItem'
+import { ColumnsSectionFragment } from '@/src/services/graphql'
+import cn from '@/src/utils/cn'
+import { generateImageSizes } from '@/src/utils/generateImageSizes'
+import { isDefined } from '@/src/utils/isDefined'
+
+type Props = {
+  section: ColumnsSectionFragment
+}
+
+/**
+ * Figma: https://www.figma.com/design/17wbd0MDQcMW9NbXl6UPs8/DS--Component-library?node-id=5865-16442&t=TcrEN6rQPU300Ipo-0
+ */
+
+const ColumnsSection = ({ section }: Props) => {
+  const { title, text, columns } = section
+
+  // eslint-disable-next-line unicorn/no-array-callback-reference
+  const filteredColumns = columns?.filter(isDefined) ?? []
+
+  return (
+    <div className="flex flex-col gap-6 lg:gap-12">
+      {title || text ? (
+        <div className="flex">
+          <div
+            className={cn(
+              'grow',
+              // { 'text-center': textAlign === 'center' }
+            )}
+          >
+            {title && <Typography variant="h2">{title}</Typography>}
+            {text && (
+              <Typography variant="p-default" className="not-first:mt-2">
+                {text}
+              </Typography>
+            )}
+          </div>
+        </div>
+      ) : null}
+
+      {/* Screen: Desktop */}
+      <ul className="flex w-full flex-wrap items-stretch justify-center gap-4 gap-y-6 max-lg:hidden lg:gap-8 lg:gap-y-14">
+        {filteredColumns.map((item, index) => {
+          return (
+            <li
+              // eslint-disable-next-line react/no-array-index-key
+              key={index}
+              className={cn('w-[33%] max-w-[50%]', {
+                // Control number of items per row based on their count so it looks good
+                'w-full max-w-[100%] sm:max-w-full': filteredColumns.length === 1,
+                'w-[40%] max-w-[100%] sm:max-w-full': filteredColumns.length === 2,
+                'sm:w-[25%]': filteredColumns.length % 3 === 0,
+                'sm:w-[20%] sm:max-w-[22%]':
+                  filteredColumns.length > 2 && filteredColumns.length % 3 === 1,
+                'sm:w-[25%] sm:max-w-[33%]':
+                  filteredColumns.length > 2 && filteredColumns.length % 3 === 2,
+              })}
+            >
+              <ColumnsSectionItem
+                {...item}
+                imageSizes={generateImageSizes({
+                  default: '100vw',
+                  // Note that this doesn't match the logic above for 100%, but it's okay, because it's just a simple optimization
+                  sm: filteredColumns.length === 2 ? '50vw' : '33vw',
+                })}
+                className="w-full"
+              />
+            </li>
+          )
+        })}
+      </ul>
+
+      {/* /!* Screen: Mobile *!/ */}
+      {/* <Slider */}
+      {/*   aria-labelledby={titleId} */}
+      {/*   items={filteredColumns.map((item, index) => { */}
+      {/*     return ( */}
+      {/*       <ColumnsSectionItem */}
+      {/*         // eslint-disable-next-line react/no-array-index-key */}
+      {/*         key={index} */}
+      {/*         {...item} */}
+      {/*         imageSizes={generateImageSizes({ default: '100vw' })} */}
+      {/*         className="w-full" */}
+      {/*       /> */}
+      {/*     ) */}
+      {/*   })} */}
+      {/*   className="lg:hidden" */}
+      {/* /> */}
+    </div>
+  )
+}
+
+export default ColumnsSection

--- a/next/src/components/sections/ColumnsSection.tsx
+++ b/next/src/components/sections/ColumnsSection.tsx
@@ -69,7 +69,25 @@ const ColumnsSection = ({ section }: Props) => {
         })}
       </ul>
 
-      {/* /!* Screen: Mobile *!/ */}
+      {/* Screen: Mobile */}
+      <ul className="grid grid-cols-1 gap-x-8 gap-y-12">
+        {filteredColumns.map((item, index) => {
+          return (
+            <li
+              // eslint-disable-next-line react/no-array-index-key
+              key={index}
+            >
+              <ColumnsSectionItem
+                {...item}
+                imageVariant={imageVariant}
+                imageSizes={generateImageSizes({ default: '100vw' })}
+                className="w-full"
+              />
+            </li>
+          )
+        })}
+      </ul>
+      {/* TODO take Slider v OLO */}
       {/* <Slider */}
       {/*   aria-labelledby={titleId} */}
       {/*   items={filteredColumns.map((item, index) => { */}

--- a/next/src/components/sections/ColumnsSection.tsx
+++ b/next/src/components/sections/ColumnsSection.tsx
@@ -2,6 +2,7 @@ import { Typography } from '@bratislava/component-library'
 import React from 'react'
 
 import ColumnsSectionItem from '@/src/components/common/ColumnsSectionItem/ColumnsSectionItem'
+import Slider from '@/src/components/common/Slider/Slider'
 import { ColumnsSectionFragment } from '@/src/services/graphql'
 import cn from '@/src/utils/cn'
 import { generateImageSizes } from '@/src/utils/generateImageSizes'
@@ -16,7 +17,7 @@ type Props = {
  */
 
 const ColumnsSection = ({ section }: Props) => {
-  const { title, text, columns, imageVariant } = section
+  const { title, text, columns, imageVariant, respoLayout } = section
 
   // eslint-disable-next-line unicorn/no-array-callback-reference
   const filteredColumns = columns?.filter(isDefined) ?? []
@@ -70,39 +71,39 @@ const ColumnsSection = ({ section }: Props) => {
       </ul>
 
       {/* Screen: Mobile */}
-      <ul className="grid grid-cols-1 gap-x-8 gap-y-12">
-        {filteredColumns.map((item, index) => {
-          return (
-            <li
-              // eslint-disable-next-line react/no-array-index-key
-              key={index}
-            >
+      {respoLayout === 'columnsSection_respoLayout_slider' ? (
+        <Slider
+          // aria-labelledby={titleId} // TODO for better accessibility
+          items={filteredColumns.map((item, index) => {
+            return (
               <ColumnsSectionItem
+                // eslint-disable-next-line react/no-array-index-key
+                key={index}
                 {...item}
-                imageVariant={imageVariant}
                 imageSizes={generateImageSizes({ default: '100vw' })}
                 className="w-full"
               />
-            </li>
-          )
-        })}
-      </ul>
-      {/* TODO take Slider v OLO */}
-      {/* <Slider */}
-      {/*   aria-labelledby={titleId} */}
-      {/*   items={filteredColumns.map((item, index) => { */}
-      {/*     return ( */}
-      {/*       <ColumnsSectionItem */}
-      {/*         // eslint-disable-next-line react/no-array-index-key */}
-      {/*         key={index} */}
-      {/*         {...item} */}
-      {/*         imageSizes={generateImageSizes({ default: '100vw' })} */}
-      {/*         className="w-full" */}
-      {/*       /> */}
-      {/*     ) */}
-      {/*   })} */}
-      {/*   className="lg:hidden" */}
-      {/* /> */}
+            )
+          })}
+          className="lg:hidden"
+        />
+      ) : (
+        <ul className="flex flex-col gap-8 lg:hidden">
+          {filteredColumns.map((item, index) => {
+            return (
+              // eslint-disable-next-line react/no-array-index-key
+              <li key={index}>
+                <ColumnsSectionItem
+                  {...item}
+                  imageVariant={imageVariant}
+                  imageSizes={generateImageSizes({ default: '100vw' })}
+                  className="w-full"
+                />
+              </li>
+            )
+          })}
+        </ul>
+      )}
     </div>
   )
 }

--- a/next/src/components/styleguide/showcases/ColumnsShowcase.tsx
+++ b/next/src/components/styleguide/showcases/ColumnsShowcase.tsx
@@ -46,14 +46,14 @@ const sections: ColumnsSectionFragment[] = [
   {
     title: 'Pictograms, respo: Slider',
     imageVariant:
-      Enum_Componentsectionscolumns_Imagevariant.ColumnsSectionImageVariantWithCircleIconBackground,
+      Enum_Componentsectionscolumns_Imagevariant.ColumnsSectionImageVariantWithCircleBackground,
     responsiveLayout:
       Enum_Componentsectionscolumns_Responsivelayout.ColumnsSectionResponsiveLayoutSlider,
   },
   {
     title: 'Pictograms, respo: Grid',
     imageVariant:
-      Enum_Componentsectionscolumns_Imagevariant.ColumnsSectionImageVariantWithCircleIconBackground,
+      Enum_Componentsectionscolumns_Imagevariant.ColumnsSectionImageVariantWithCircleBackground,
     responsiveLayout:
       Enum_Componentsectionscolumns_Responsivelayout.ColumnsSectionResponsiveLayoutOneColumn,
   },
@@ -80,8 +80,8 @@ const MarkdownShowcase = () => {
     <Wrapper direction="column" title="Columns">
       {sections.map((section, index) => (
         // eslint-disable-next-line react/no-array-index-key
-        <Stack direction="column" key={index}>
-          <ColumnsSection section={section} />{' '}
+        <Stack direction="column" className="items-stretch" key={index}>
+          <ColumnsSection section={section} />
         </Stack>
       ))}
     </Wrapper>

--- a/next/src/components/styleguide/showcases/ColumnsShowcase.tsx
+++ b/next/src/components/styleguide/showcases/ColumnsShowcase.tsx
@@ -1,0 +1,91 @@
+/* eslint-disable no-console,sonarjs/no-duplicate-string */
+
+import ColumnsSection from '@/src/components/sections/ColumnsSection'
+import {
+  ColumnsSectionFragment,
+  Enum_Componentsectionscolumns_Imagevariant,
+  Enum_Componentsectionscolumns_Responsivelayout,
+} from '@/src/services/graphql'
+
+import Stack from '../Stack'
+import Wrapper from '../Wrapper'
+
+const image = {
+  data: {
+    attributes: {
+      __typename: 'UploadFile' as const,
+      url: 'https://cdn-api.bratislava.sk/strapi-homepage/upload/bratislava4_c7b0b62afe.png',
+      name: 'Bratislava logo',
+      width: 116,
+      height: 105,
+    },
+  },
+}
+
+const sectionData: Omit<ColumnsSectionFragment, 'imageVariant' | 'responsiveLayout'> = {
+  columns: [
+    {
+      title: 'Column 1',
+      text: 'Lorem ipsum',
+      image,
+    },
+    {
+      title: 'Column 2',
+      text: 'Lorem ipsum',
+      image,
+    },
+    {
+      title: 'Column 3',
+      text: 'Lorem ipsum',
+      image,
+    },
+  ],
+}
+
+const sections: ColumnsSectionFragment[] = [
+  {
+    title: 'Pictograms, respo: Slider',
+    imageVariant:
+      Enum_Componentsectionscolumns_Imagevariant.ColumnsSectionImageVariantWithCircleIconBackground,
+    responsiveLayout:
+      Enum_Componentsectionscolumns_Responsivelayout.ColumnsSectionResponsiveLayoutSlider,
+  },
+  {
+    title: 'Pictograms, respo: Grid',
+    imageVariant:
+      Enum_Componentsectionscolumns_Imagevariant.ColumnsSectionImageVariantWithCircleIconBackground,
+    responsiveLayout:
+      Enum_Componentsectionscolumns_Responsivelayout.ColumnsSectionResponsiveLayoutOneColumn,
+  },
+  {
+    title: 'Images, respo: Slider',
+
+    imageVariant:
+      Enum_Componentsectionscolumns_Imagevariant.ColumnsSectionImageVariantImageOriginalSize,
+    responsiveLayout:
+      Enum_Componentsectionscolumns_Responsivelayout.ColumnsSectionResponsiveLayoutSlider,
+  },
+  {
+    title: 'Images, respo: Grid',
+
+    imageVariant:
+      Enum_Componentsectionscolumns_Imagevariant.ColumnsSectionImageVariantImageOriginalSize,
+    responsiveLayout:
+      Enum_Componentsectionscolumns_Responsivelayout.ColumnsSectionResponsiveLayoutOneColumn,
+  },
+].map((section) => ({ ...section, ...sectionData }))
+
+const MarkdownShowcase = () => {
+  return (
+    <Wrapper direction="column" title="Columns">
+      {sections.map((section, index) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <Stack direction="column" key={index}>
+          <ColumnsSection section={section} />{' '}
+        </Stack>
+      ))}
+    </Wrapper>
+  )
+}
+
+export default MarkdownShowcase

--- a/next/src/pages/styleguide.tsx
+++ b/next/src/pages/styleguide.tsx
@@ -7,6 +7,7 @@ import ArticleCardShowcase from '@/src/components/styleguide/showcases/ArticleCa
 import BannerShowCase from '@/src/components/styleguide/showcases/BannerShowCase'
 import ButtonShowCase from '@/src/components/styleguide/showcases/ButtonShowCase'
 import CategoryCardShowcase from '@/src/components/styleguide/showcases/CategoryCardShowcase'
+import ColumnsShowcase from '@/src/components/styleguide/showcases/ColumnsShowcase'
 import ContactsShowcase from '@/src/components/styleguide/showcases/ContactsShowcase'
 import EventCardShowcase from '@/src/components/styleguide/showcases/EventCardShowcase'
 import HomepageHorizontalCardShowcase from '@/src/components/styleguide/showcases/HomepageHorizontalCardShowcase'
@@ -25,6 +26,7 @@ const Styleguide = () => {
    * */
   return (
     <StyleGuideWrapper>
+      <ColumnsShowcase />
       <TokensShowcase /> {/* Temporary */}
       {/* HERE ADD SHOWCASES */}
       <MarkdownShowcase />

--- a/next/src/pages/styleguide.tsx
+++ b/next/src/pages/styleguide.tsx
@@ -26,7 +26,6 @@ const Styleguide = () => {
    * */
   return (
     <StyleGuideWrapper>
-      <ColumnsShowcase />
       <TokensShowcase /> {/* Temporary */}
       {/* HERE ADD SHOWCASES */}
       <MarkdownShowcase />
@@ -41,6 +40,7 @@ const Styleguide = () => {
       <ArticleCardShowcase />
       <HomepageHorizontalCardShowcase />
       <ContactsShowcase />
+      <ColumnsShowcase />
     </StyleGuideWrapper>
   )
 }

--- a/next/src/services/graphql/index.ts
+++ b/next/src/services/graphql/index.ts
@@ -399,6 +399,29 @@ export type ComponentAccordionItemsInstitutionNarrowInput = {
   urlLabel?: InputMaybe<Scalars['String']['input']>
 }
 
+export type ComponentBlocksColumnsItem = {
+  __typename?: 'ComponentBlocksColumnsItem'
+  id: Scalars['ID']['output']
+  image?: Maybe<UploadFileEntityResponse>
+  text?: Maybe<Scalars['String']['output']>
+  title?: Maybe<Scalars['String']['output']>
+}
+
+export type ComponentBlocksColumnsItemFiltersInput = {
+  and?: InputMaybe<Array<InputMaybe<ComponentBlocksColumnsItemFiltersInput>>>
+  not?: InputMaybe<ComponentBlocksColumnsItemFiltersInput>
+  or?: InputMaybe<Array<InputMaybe<ComponentBlocksColumnsItemFiltersInput>>>
+  text?: InputMaybe<StringFilterInput>
+  title?: InputMaybe<StringFilterInput>
+}
+
+export type ComponentBlocksColumnsItemInput = {
+  id?: InputMaybe<Scalars['ID']['input']>
+  image?: InputMaybe<Scalars['ID']['input']>
+  text?: InputMaybe<Scalars['String']['input']>
+  title?: InputMaybe<Scalars['String']['input']>
+}
+
 export type ComponentBlocksCommonLink = {
   __typename?: 'ComponentBlocksCommonLink'
   analyticsId?: Maybe<Scalars['String']['output']>
@@ -1104,6 +1127,39 @@ export type ComponentSectionsColumnedTextInput = {
   content?: InputMaybe<Scalars['String']['input']>
   contentAlignment?: InputMaybe<Enum_Componentsectionscolumnedtext_Contentalignment>
   id?: InputMaybe<Scalars['ID']['input']>
+}
+
+export type ComponentSectionsColumns = {
+  __typename?: 'ComponentSectionsColumns'
+  columns: Array<Maybe<ComponentBlocksColumnsItem>>
+  id: Scalars['ID']['output']
+  imageVariant: Enum_Componentsectionscolumns_Imagevariant
+  text?: Maybe<Scalars['String']['output']>
+  title?: Maybe<Scalars['String']['output']>
+}
+
+export type ComponentSectionsColumnsColumnsArgs = {
+  filters?: InputMaybe<ComponentBlocksColumnsItemFiltersInput>
+  pagination?: InputMaybe<PaginationArg>
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>
+}
+
+export type ComponentSectionsColumnsFiltersInput = {
+  and?: InputMaybe<Array<InputMaybe<ComponentSectionsColumnsFiltersInput>>>
+  columns?: InputMaybe<ComponentBlocksColumnsItemFiltersInput>
+  imageVariant?: InputMaybe<StringFilterInput>
+  not?: InputMaybe<ComponentSectionsColumnsFiltersInput>
+  or?: InputMaybe<Array<InputMaybe<ComponentSectionsColumnsFiltersInput>>>
+  text?: InputMaybe<StringFilterInput>
+  title?: InputMaybe<StringFilterInput>
+}
+
+export type ComponentSectionsColumnsInput = {
+  columns?: InputMaybe<Array<InputMaybe<ComponentBlocksColumnsItemInput>>>
+  id?: InputMaybe<Scalars['ID']['input']>
+  imageVariant?: InputMaybe<Enum_Componentsectionscolumns_Imagevariant>
+  text?: InputMaybe<Scalars['String']['input']>
+  title?: InputMaybe<Scalars['String']['input']>
 }
 
 export type ComponentSectionsComparisonSection = {
@@ -2154,6 +2210,12 @@ export enum Enum_Componentsectionscolumnedtext_Contentalignment {
   Right = 'right',
 }
 
+export enum Enum_Componentsectionscolumns_Imagevariant {
+  ColumnsSectionVariantImageFixedSize = 'columnsSection_variant_imageFixedSize',
+  ColumnsSectionVariantImageNonFixedSize = 'columnsSection_variant_imageNonFixedSize',
+  ColumnsSectionVariantWithCircleIconBackground = 'columnsSection_variant_withCircleIconBackground',
+}
+
 export enum Enum_Componentsectionscomparisonsection_Textalign {
   Center = 'center',
   Left = 'left',
@@ -2585,6 +2647,7 @@ export type GenericMorph =
   | ComponentAccordionItemsFlatText
   | ComponentAccordionItemsInstitution
   | ComponentAccordionItemsInstitutionNarrow
+  | ComponentBlocksColumnsItem
   | ComponentBlocksCommonLink
   | ComponentBlocksComparisonCard
   | ComponentBlocksComparisonItem
@@ -2612,6 +2675,7 @@ export type GenericMorph =
   | ComponentSectionsBanner
   | ComponentSectionsCalculator
   | ComponentSectionsColumnedText
+  | ComponentSectionsColumns
   | ComponentSectionsComparisonSection
   | ComponentSectionsContactsSection
   | ComponentSectionsDivider
@@ -3867,6 +3931,7 @@ export type PageSectionsDynamicZone =
   | ComponentSectionsBanner
   | ComponentSectionsCalculator
   | ComponentSectionsColumnedText
+  | ComponentSectionsColumns
   | ComponentSectionsComparisonSection
   | ComponentSectionsContactsSection
   | ComponentSectionsDivider
@@ -8391,6 +8456,34 @@ export type PageEntityFragment = {
           contentAlignment?: Enum_Componentsectionscolumnedtext_Contentalignment | null
         }
       | {
+          __typename: 'ComponentSectionsColumns'
+          title?: string | null
+          text?: string | null
+          imageVariant: Enum_Componentsectionscolumns_Imagevariant
+          columns: Array<{
+            __typename?: 'ComponentBlocksColumnsItem'
+            id: string
+            title?: string | null
+            text?: string | null
+            image?: {
+              __typename?: 'UploadFileEntityResponse'
+              data?: {
+                __typename?: 'UploadFileEntity'
+                id?: string | null
+                attributes?: {
+                  __typename?: 'UploadFile'
+                  url: string
+                  width?: number | null
+                  height?: number | null
+                  caption?: string | null
+                  alternativeText?: string | null
+                  name: string
+                } | null
+              } | null
+            } | null
+          } | null>
+        }
+      | {
           __typename: 'ComponentSectionsComparisonSection'
           title?: string | null
           text?: string | null
@@ -9301,6 +9394,34 @@ export type PageBySlugQuery = {
               __typename: 'ComponentSectionsColumnedText'
               content?: string | null
               contentAlignment?: Enum_Componentsectionscolumnedtext_Contentalignment | null
+            }
+          | {
+              __typename: 'ComponentSectionsColumns'
+              title?: string | null
+              text?: string | null
+              imageVariant: Enum_Componentsectionscolumns_Imagevariant
+              columns: Array<{
+                __typename?: 'ComponentBlocksColumnsItem'
+                id: string
+                title?: string | null
+                text?: string | null
+                image?: {
+                  __typename?: 'UploadFileEntityResponse'
+                  data?: {
+                    __typename?: 'UploadFileEntity'
+                    id?: string | null
+                    attributes?: {
+                      __typename?: 'UploadFile'
+                      url: string
+                      width?: number | null
+                      height?: number | null
+                      caption?: string | null
+                      alternativeText?: string | null
+                      name: string
+                    } | null
+                  } | null
+                } | null
+              } | null>
             }
           | {
               __typename: 'ComponentSectionsComparisonSection'
@@ -10253,6 +10374,34 @@ export type Dev_AllPagesQuery = {
               __typename: 'ComponentSectionsColumnedText'
               content?: string | null
               contentAlignment?: Enum_Componentsectionscolumnedtext_Contentalignment | null
+            }
+          | {
+              __typename: 'ComponentSectionsColumns'
+              title?: string | null
+              text?: string | null
+              imageVariant: Enum_Componentsectionscolumns_Imagevariant
+              columns: Array<{
+                __typename?: 'ComponentBlocksColumnsItem'
+                id: string
+                title?: string | null
+                text?: string | null
+                image?: {
+                  __typename?: 'UploadFileEntityResponse'
+                  data?: {
+                    __typename?: 'UploadFileEntity'
+                    id?: string | null
+                    attributes?: {
+                      __typename?: 'UploadFile'
+                      url: string
+                      width?: number | null
+                      height?: number | null
+                      caption?: string | null
+                      alternativeText?: string | null
+                      name: string
+                    } | null
+                  } | null
+                } | null
+              } | null>
             }
           | {
               __typename: 'ComponentSectionsComparisonSection'
@@ -12059,6 +12208,58 @@ export type ColumnedTextSectionFragment = {
   contentAlignment?: Enum_Componentsectionscolumnedtext_Contentalignment | null
 }
 
+export type ColumnsItemFragment = {
+  __typename?: 'ComponentBlocksColumnsItem'
+  id: string
+  title?: string | null
+  text?: string | null
+  image?: {
+    __typename?: 'UploadFileEntityResponse'
+    data?: {
+      __typename?: 'UploadFileEntity'
+      id?: string | null
+      attributes?: {
+        __typename?: 'UploadFile'
+        url: string
+        width?: number | null
+        height?: number | null
+        caption?: string | null
+        alternativeText?: string | null
+        name: string
+      } | null
+    } | null
+  } | null
+}
+
+export type ColumnsSectionFragment = {
+  __typename?: 'ComponentSectionsColumns'
+  title?: string | null
+  text?: string | null
+  imageVariant: Enum_Componentsectionscolumns_Imagevariant
+  columns: Array<{
+    __typename?: 'ComponentBlocksColumnsItem'
+    id: string
+    title?: string | null
+    text?: string | null
+    image?: {
+      __typename?: 'UploadFileEntityResponse'
+      data?: {
+        __typename?: 'UploadFileEntity'
+        id?: string | null
+        attributes?: {
+          __typename?: 'UploadFile'
+          url: string
+          width?: number | null
+          height?: number | null
+          caption?: string | null
+          alternativeText?: string | null
+          name: string
+        } | null
+      } | null
+    } | null
+  } | null>
+}
+
 export type NarrowTextSectionFragment = {
   __typename?: 'ComponentSectionsNarrowText'
   content?: string | null
@@ -12928,6 +13129,35 @@ type Sections_ComponentSectionsColumnedText_Fragment = {
   contentAlignment?: Enum_Componentsectionscolumnedtext_Contentalignment | null
 }
 
+type Sections_ComponentSectionsColumns_Fragment = {
+  __typename: 'ComponentSectionsColumns'
+  title?: string | null
+  text?: string | null
+  imageVariant: Enum_Componentsectionscolumns_Imagevariant
+  columns: Array<{
+    __typename?: 'ComponentBlocksColumnsItem'
+    id: string
+    title?: string | null
+    text?: string | null
+    image?: {
+      __typename?: 'UploadFileEntityResponse'
+      data?: {
+        __typename?: 'UploadFileEntity'
+        id?: string | null
+        attributes?: {
+          __typename?: 'UploadFile'
+          url: string
+          width?: number | null
+          height?: number | null
+          caption?: string | null
+          alternativeText?: string | null
+          name: string
+        } | null
+      } | null
+    } | null
+  } | null>
+}
+
 type Sections_ComponentSectionsComparisonSection_Fragment = {
   __typename: 'ComponentSectionsComparisonSection'
   title?: string | null
@@ -13480,6 +13710,7 @@ export type SectionsFragment =
   | Sections_ComponentSectionsBanner_Fragment
   | Sections_ComponentSectionsCalculator_Fragment
   | Sections_ComponentSectionsColumnedText_Fragment
+  | Sections_ComponentSectionsColumns_Fragment
   | Sections_ComponentSectionsComparisonSection_Fragment
   | Sections_ComponentSectionsContactsSection_Fragment
   | Sections_ComponentSectionsDivider_Fragment
@@ -14280,6 +14511,30 @@ export const ColumnedTextSectionFragmentDoc = gql`
     contentAlignment
   }
 `
+export const ColumnsItemFragmentDoc = gql`
+  fragment ColumnsItem on ComponentBlocksColumnsItem {
+    id
+    title
+    text
+    image {
+      data {
+        ...UploadImageEntity
+      }
+    }
+  }
+  ${UploadImageEntityFragmentDoc}
+`
+export const ColumnsSectionFragmentDoc = gql`
+  fragment ColumnsSection on ComponentSectionsColumns {
+    title
+    text
+    columns(pagination: { limit: -1 }) {
+      ...ColumnsItem
+    }
+    imageVariant
+  }
+  ${ColumnsItemFragmentDoc}
+`
 export const NarrowTextSectionFragmentDoc = gql`
   fragment NarrowTextSection on ComponentSectionsNarrowText {
     content
@@ -14782,6 +15037,9 @@ export const SectionsFragmentDoc = gql`
     ... on ComponentSectionsColumnedText {
       ...ColumnedTextSection
     }
+    ... on ComponentSectionsColumns {
+      ...ColumnsSection
+    }
     ... on ComponentSectionsNarrowText {
       ...NarrowTextSection
     }
@@ -14854,6 +15112,7 @@ export const SectionsFragmentDoc = gql`
   ${GallerySectionFragmentDoc}
   ${FileListSectionFragmentDoc}
   ${ColumnedTextSectionFragmentDoc}
+  ${ColumnsSectionFragmentDoc}
   ${NarrowTextSectionFragmentDoc}
   ${WavesSectionFragmentDoc}
   ${LinksSectionFragmentDoc}

--- a/next/src/services/graphql/index.ts
+++ b/next/src/services/graphql/index.ts
@@ -2211,7 +2211,7 @@ export enum Enum_Componentsectionscolumnedtext_Contentalignment {
 }
 
 export enum Enum_Componentsectionscolumns_Imagevariant {
-  ColumnsSectionVariantImageFixedSize = 'columnsSection_variant_imageFixedSize',
+  ColumnsSectionVariantImageFixedHeight = 'columnsSection_variant_imageFixedHeight',
   ColumnsSectionVariantImageNonFixedSize = 'columnsSection_variant_imageNonFixedSize',
   ColumnsSectionVariantWithCircleIconBackground = 'columnsSection_variant_withCircleIconBackground',
 }

--- a/next/src/services/graphql/index.ts
+++ b/next/src/services/graphql/index.ts
@@ -2215,7 +2215,7 @@ export enum Enum_Componentsectionscolumnedtext_Contentalignment {
 
 export enum Enum_Componentsectionscolumns_Imagevariant {
   ColumnsSectionImageVariantImageOriginalSize = 'columnsSection_imageVariant_imageOriginalSize',
-  ColumnsSectionImageVariantWithCircleIconBackground = 'columnsSection_imageVariant_withCircleIconBackground',
+  ColumnsSectionImageVariantWithCircleBackground = 'columnsSection_imageVariant_withCircleBackground',
 }
 
 export enum Enum_Componentsectionscolumns_Responsivelayout {

--- a/next/src/services/graphql/index.ts
+++ b/next/src/services/graphql/index.ts
@@ -1134,7 +1134,7 @@ export type ComponentSectionsColumns = {
   columns: Array<Maybe<ComponentBlocksColumnsItem>>
   id: Scalars['ID']['output']
   imageVariant: Enum_Componentsectionscolumns_Imagevariant
-  respoLayout: Enum_Componentsectionscolumns_Respolayout
+  responsiveLayout: Enum_Componentsectionscolumns_Responsivelayout
   text?: Maybe<Scalars['String']['output']>
   title?: Maybe<Scalars['String']['output']>
 }
@@ -1151,7 +1151,7 @@ export type ComponentSectionsColumnsFiltersInput = {
   imageVariant?: InputMaybe<StringFilterInput>
   not?: InputMaybe<ComponentSectionsColumnsFiltersInput>
   or?: InputMaybe<Array<InputMaybe<ComponentSectionsColumnsFiltersInput>>>
-  respoLayout?: InputMaybe<StringFilterInput>
+  responsiveLayout?: InputMaybe<StringFilterInput>
   text?: InputMaybe<StringFilterInput>
   title?: InputMaybe<StringFilterInput>
 }
@@ -1160,7 +1160,7 @@ export type ComponentSectionsColumnsInput = {
   columns?: InputMaybe<Array<InputMaybe<ComponentBlocksColumnsItemInput>>>
   id?: InputMaybe<Scalars['ID']['input']>
   imageVariant?: InputMaybe<Enum_Componentsectionscolumns_Imagevariant>
-  respoLayout?: InputMaybe<Enum_Componentsectionscolumns_Respolayout>
+  responsiveLayout?: InputMaybe<Enum_Componentsectionscolumns_Responsivelayout>
   text?: InputMaybe<Scalars['String']['input']>
   title?: InputMaybe<Scalars['String']['input']>
 }
@@ -2214,14 +2214,13 @@ export enum Enum_Componentsectionscolumnedtext_Contentalignment {
 }
 
 export enum Enum_Componentsectionscolumns_Imagevariant {
-  ColumnsSectionVariantImageFixedHeight = 'columnsSection_variant_imageFixedHeight',
-  ColumnsSectionVariantImageNonFixedSize = 'columnsSection_variant_imageNonFixedSize',
-  ColumnsSectionVariantWithCircleIconBackground = 'columnsSection_variant_withCircleIconBackground',
+  ColumnsSectionImageVariantImageOriginalSize = 'columnsSection_imageVariant_imageOriginalSize',
+  ColumnsSectionImageVariantWithCircleIconBackground = 'columnsSection_imageVariant_withCircleIconBackground',
 }
 
-export enum Enum_Componentsectionscolumns_Respolayout {
-  ColumnsSectionRespoLayoutOneColumn = 'columnsSection_respoLayout_oneColumn',
-  ColumnsSectionRespoLayoutSlider = 'columnsSection_respoLayout_slider',
+export enum Enum_Componentsectionscolumns_Responsivelayout {
+  ColumnsSectionResponsiveLayoutOneColumn = 'columnsSection_responsiveLayout_oneColumn',
+  ColumnsSectionResponsiveLayoutSlider = 'columnsSection_responsiveLayout_slider',
 }
 
 export enum Enum_Componentsectionscomparisonsection_Textalign {
@@ -8468,10 +8467,9 @@ export type PageEntityFragment = {
           title?: string | null
           text?: string | null
           imageVariant: Enum_Componentsectionscolumns_Imagevariant
-          respoLayout: Enum_Componentsectionscolumns_Respolayout
+          responsiveLayout: Enum_Componentsectionscolumns_Responsivelayout
           columns: Array<{
             __typename?: 'ComponentBlocksColumnsItem'
-            id: string
             title?: string | null
             text?: string | null
             image?: {
@@ -9409,10 +9407,9 @@ export type PageBySlugQuery = {
               title?: string | null
               text?: string | null
               imageVariant: Enum_Componentsectionscolumns_Imagevariant
-              respoLayout: Enum_Componentsectionscolumns_Respolayout
+              responsiveLayout: Enum_Componentsectionscolumns_Responsivelayout
               columns: Array<{
                 __typename?: 'ComponentBlocksColumnsItem'
-                id: string
                 title?: string | null
                 text?: string | null
                 image?: {
@@ -10390,10 +10387,9 @@ export type Dev_AllPagesQuery = {
               title?: string | null
               text?: string | null
               imageVariant: Enum_Componentsectionscolumns_Imagevariant
-              respoLayout: Enum_Componentsectionscolumns_Respolayout
+              responsiveLayout: Enum_Componentsectionscolumns_Responsivelayout
               columns: Array<{
                 __typename?: 'ComponentBlocksColumnsItem'
-                id: string
                 title?: string | null
                 text?: string | null
                 image?: {
@@ -12221,7 +12217,6 @@ export type ColumnedTextSectionFragment = {
 
 export type ColumnsItemFragment = {
   __typename?: 'ComponentBlocksColumnsItem'
-  id: string
   title?: string | null
   text?: string | null
   image?: {
@@ -12247,10 +12242,9 @@ export type ColumnsSectionFragment = {
   title?: string | null
   text?: string | null
   imageVariant: Enum_Componentsectionscolumns_Imagevariant
-  respoLayout: Enum_Componentsectionscolumns_Respolayout
+  responsiveLayout: Enum_Componentsectionscolumns_Responsivelayout
   columns: Array<{
     __typename?: 'ComponentBlocksColumnsItem'
-    id: string
     title?: string | null
     text?: string | null
     image?: {
@@ -13146,10 +13140,9 @@ type Sections_ComponentSectionsColumns_Fragment = {
   title?: string | null
   text?: string | null
   imageVariant: Enum_Componentsectionscolumns_Imagevariant
-  respoLayout: Enum_Componentsectionscolumns_Respolayout
+  responsiveLayout: Enum_Componentsectionscolumns_Responsivelayout
   columns: Array<{
     __typename?: 'ComponentBlocksColumnsItem'
-    id: string
     title?: string | null
     text?: string | null
     image?: {
@@ -14526,7 +14519,6 @@ export const ColumnedTextSectionFragmentDoc = gql`
 `
 export const ColumnsItemFragmentDoc = gql`
   fragment ColumnsItem on ComponentBlocksColumnsItem {
-    id
     title
     text
     image {
@@ -14545,7 +14537,7 @@ export const ColumnsSectionFragmentDoc = gql`
       ...ColumnsItem
     }
     imageVariant
-    respoLayout
+    responsiveLayout
   }
   ${ColumnsItemFragmentDoc}
 `

--- a/next/src/services/graphql/index.ts
+++ b/next/src/services/graphql/index.ts
@@ -1134,6 +1134,7 @@ export type ComponentSectionsColumns = {
   columns: Array<Maybe<ComponentBlocksColumnsItem>>
   id: Scalars['ID']['output']
   imageVariant: Enum_Componentsectionscolumns_Imagevariant
+  respoLayout: Enum_Componentsectionscolumns_Respolayout
   text?: Maybe<Scalars['String']['output']>
   title?: Maybe<Scalars['String']['output']>
 }
@@ -1150,6 +1151,7 @@ export type ComponentSectionsColumnsFiltersInput = {
   imageVariant?: InputMaybe<StringFilterInput>
   not?: InputMaybe<ComponentSectionsColumnsFiltersInput>
   or?: InputMaybe<Array<InputMaybe<ComponentSectionsColumnsFiltersInput>>>
+  respoLayout?: InputMaybe<StringFilterInput>
   text?: InputMaybe<StringFilterInput>
   title?: InputMaybe<StringFilterInput>
 }
@@ -1158,6 +1160,7 @@ export type ComponentSectionsColumnsInput = {
   columns?: InputMaybe<Array<InputMaybe<ComponentBlocksColumnsItemInput>>>
   id?: InputMaybe<Scalars['ID']['input']>
   imageVariant?: InputMaybe<Enum_Componentsectionscolumns_Imagevariant>
+  respoLayout?: InputMaybe<Enum_Componentsectionscolumns_Respolayout>
   text?: InputMaybe<Scalars['String']['input']>
   title?: InputMaybe<Scalars['String']['input']>
 }
@@ -2214,6 +2217,11 @@ export enum Enum_Componentsectionscolumns_Imagevariant {
   ColumnsSectionVariantImageFixedHeight = 'columnsSection_variant_imageFixedHeight',
   ColumnsSectionVariantImageNonFixedSize = 'columnsSection_variant_imageNonFixedSize',
   ColumnsSectionVariantWithCircleIconBackground = 'columnsSection_variant_withCircleIconBackground',
+}
+
+export enum Enum_Componentsectionscolumns_Respolayout {
+  ColumnsSectionRespoLayoutOneColumn = 'columnsSection_respoLayout_oneColumn',
+  ColumnsSectionRespoLayoutSlider = 'columnsSection_respoLayout_slider',
 }
 
 export enum Enum_Componentsectionscomparisonsection_Textalign {
@@ -8460,6 +8468,7 @@ export type PageEntityFragment = {
           title?: string | null
           text?: string | null
           imageVariant: Enum_Componentsectionscolumns_Imagevariant
+          respoLayout: Enum_Componentsectionscolumns_Respolayout
           columns: Array<{
             __typename?: 'ComponentBlocksColumnsItem'
             id: string
@@ -9400,6 +9409,7 @@ export type PageBySlugQuery = {
               title?: string | null
               text?: string | null
               imageVariant: Enum_Componentsectionscolumns_Imagevariant
+              respoLayout: Enum_Componentsectionscolumns_Respolayout
               columns: Array<{
                 __typename?: 'ComponentBlocksColumnsItem'
                 id: string
@@ -10380,6 +10390,7 @@ export type Dev_AllPagesQuery = {
               title?: string | null
               text?: string | null
               imageVariant: Enum_Componentsectionscolumns_Imagevariant
+              respoLayout: Enum_Componentsectionscolumns_Respolayout
               columns: Array<{
                 __typename?: 'ComponentBlocksColumnsItem'
                 id: string
@@ -12236,6 +12247,7 @@ export type ColumnsSectionFragment = {
   title?: string | null
   text?: string | null
   imageVariant: Enum_Componentsectionscolumns_Imagevariant
+  respoLayout: Enum_Componentsectionscolumns_Respolayout
   columns: Array<{
     __typename?: 'ComponentBlocksColumnsItem'
     id: string
@@ -13134,6 +13146,7 @@ type Sections_ComponentSectionsColumns_Fragment = {
   title?: string | null
   text?: string | null
   imageVariant: Enum_Componentsectionscolumns_Imagevariant
+  respoLayout: Enum_Componentsectionscolumns_Respolayout
   columns: Array<{
     __typename?: 'ComponentBlocksColumnsItem'
     id: string
@@ -14532,6 +14545,7 @@ export const ColumnsSectionFragmentDoc = gql`
       ...ColumnsItem
     }
     imageVariant
+    respoLayout
   }
   ${ColumnsItemFragmentDoc}
 `

--- a/next/src/services/graphql/queries/Sections.graphql
+++ b/next/src/services/graphql/queries/Sections.graphql
@@ -143,7 +143,6 @@ fragment ColumnedTextSection on ComponentSectionsColumnedText {
 }
 
 fragment ColumnsItem on ComponentBlocksColumnsItem {
-  id
   title
   text
   image {
@@ -160,7 +159,7 @@ fragment ColumnsSection on ComponentSectionsColumns {
     ...ColumnsItem
   }
   imageVariant
-  respoLayout
+  responsiveLayout
 }
 
 fragment NarrowTextSection on ComponentSectionsNarrowText {

--- a/next/src/services/graphql/queries/Sections.graphql
+++ b/next/src/services/graphql/queries/Sections.graphql
@@ -142,6 +142,26 @@ fragment ColumnedTextSection on ComponentSectionsColumnedText {
   contentAlignment
 }
 
+fragment ColumnsItem on ComponentBlocksColumnsItem {
+  id
+  title
+  text
+  image {
+    data {
+      ...UploadImageEntity
+    }
+  }
+}
+
+fragment ColumnsSection on ComponentSectionsColumns {
+  title
+  text
+  columns(pagination: { limit: -1 }) {
+    ...ColumnsItem
+  }
+  imageVariant
+}
+
 fragment NarrowTextSection on ComponentSectionsNarrowText {
   content
   width
@@ -420,6 +440,10 @@ fragment Sections on PageSectionsDynamicZone {
 
   ... on ComponentSectionsColumnedText {
     ...ColumnedTextSection
+  }
+
+  ... on ComponentSectionsColumns {
+    ...ColumnsSection
   }
 
   ... on ComponentSectionsNarrowText {

--- a/next/src/services/graphql/queries/Sections.graphql
+++ b/next/src/services/graphql/queries/Sections.graphql
@@ -160,6 +160,7 @@ fragment ColumnsSection on ComponentSectionsColumns {
     ...ColumnsItem
   }
   imageVariant
+  respoLayout
 }
 
 fragment NarrowTextSection on ComponentSectionsNarrowText {

--- a/strapi/config/sync/core-store.plugin_content_manager_configuration_components##blocks.columns-item.json
+++ b/strapi/config/sync/core-store.plugin_content_manager_configuration_components##blocks.columns-item.json
@@ -1,13 +1,13 @@
 {
-  "key": "plugin_content_manager_configuration_components::sections.text-with-image-overlapped",
+  "key": "plugin_content_manager_configuration_components::blocks.columns-item",
   "value": {
     "settings": {
       "bulkable": true,
       "filterable": true,
       "searchable": true,
       "pageSize": 10,
-      "mainField": "id",
-      "defaultSortBy": "id",
+      "mainField": "title",
+      "defaultSortBy": "title",
       "defaultSortOrder": "ASC"
     },
     "metadatas": {
@@ -19,23 +19,37 @@
           "sortable": false
         }
       },
-      "content": {
+      "title": {
         "edit": {
-          "label": "Text",
-          "description": "V tejto sekcii prosíme používať iba nadpis, obyčajný text a hrubé písmo. Ostatné formátovanie textu nie je v tejto sekcii vhodné.",
+          "label": "Nadpis",
+          "description": "",
           "placeholder": "",
           "visible": true,
           "editable": true
         },
         "list": {
-          "label": "content",
+          "label": "title",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "text": {
+        "edit": {
+          "label": "Text",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "text",
           "searchable": false,
           "sortable": false
         }
       },
       "image": {
         "edit": {
-          "label": "Obrázok",
+          "label": "Piktogram / Obrázok",
           "description": "",
           "placeholder": "",
           "visible": true,
@@ -46,32 +60,24 @@
           "searchable": false,
           "sortable": false
         }
-      },
-      "imagePosition": {
-        "edit": {
-          "label": "Pozícia obrázku",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true
-        },
-        "list": {
-          "label": "imagePosition",
-          "searchable": true,
-          "sortable": true
-        }
       }
     },
     "layouts": {
       "list": [
         "id",
-        "image",
-        "imagePosition"
+        "title",
+        "image"
       ],
       "edit": [
         [
           {
-            "name": "content",
+            "name": "title",
+            "size": 12
+          }
+        ],
+        [
+          {
+            "name": "text",
             "size": 12
           }
         ],
@@ -79,15 +85,11 @@
           {
             "name": "image",
             "size": 6
-          },
-          {
-            "name": "imagePosition",
-            "size": 6
           }
         ]
       ]
     },
-    "uid": "sections.text-with-image-overlapped",
+    "uid": "blocks.columns-item",
     "isComponent": true
   },
   "type": "object",

--- a/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.columns.json
+++ b/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.columns.json
@@ -1,0 +1,137 @@
+{
+  "key": "plugin_content_manager_configuration_components::sections.columns",
+  "value": {
+    "settings": {
+      "bulkable": true,
+      "filterable": true,
+      "searchable": true,
+      "pageSize": 10,
+      "mainField": "title",
+      "defaultSortBy": "title",
+      "defaultSortOrder": "ASC"
+    },
+    "metadatas": {
+      "id": {
+        "edit": {},
+        "list": {
+          "label": "id",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "title": {
+        "edit": {
+          "label": "Nadpis",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "title",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "text": {
+        "edit": {
+          "label": "Text",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "text",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "columns": {
+        "edit": {
+          "label": "Stĺpce",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "columns",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "imageVariant": {
+        "edit": {
+          "label": "Zobrazovať obrázky ako:",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "imageVariant",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "responsiveLayout": {
+        "edit": {
+          "label": "Rozloženie pri responzívnom zobrazení (mobil, tablet)",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "responsiveLayout",
+          "searchable": true,
+          "sortable": true
+        }
+      }
+    },
+    "layouts": {
+      "list": [
+        "id",
+        "title",
+        "text",
+        "columns"
+      ],
+      "edit": [
+        [
+          {
+            "name": "title",
+            "size": 12
+          }
+        ],
+        [
+          {
+            "name": "text",
+            "size": 12
+          }
+        ],
+        [
+          {
+            "name": "columns",
+            "size": 12
+          }
+        ],
+        [
+          {
+            "name": "imageVariant",
+            "size": 6
+          },
+          {
+            "name": "responsiveLayout",
+            "size": 6
+          }
+        ]
+      ]
+    },
+    "uid": "sections.columns",
+    "isComponent": true
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/strapi/schema.graphql
+++ b/strapi/schema.graphql
@@ -1894,7 +1894,7 @@ enum ENUM_COMPONENTSECTIONSCOLUMNEDTEXT_CONTENTALIGNMENT {
 }
 
 enum ENUM_COMPONENTSECTIONSCOLUMNS_IMAGEVARIANT {
-  columnsSection_variant_imageFixedSize
+  columnsSection_variant_imageFixedHeight
   columnsSection_variant_imageNonFixedSize
   columnsSection_variant_withCircleIconBackground
 }

--- a/strapi/schema.graphql
+++ b/strapi/schema.graphql
@@ -1898,7 +1898,7 @@ enum ENUM_COMPONENTSECTIONSCOLUMNEDTEXT_CONTENTALIGNMENT {
 
 enum ENUM_COMPONENTSECTIONSCOLUMNS_IMAGEVARIANT {
   columnsSection_imageVariant_imageOriginalSize
-  columnsSection_imageVariant_withCircleIconBackground
+  columnsSection_imageVariant_withCircleBackground
 }
 
 enum ENUM_COMPONENTSECTIONSCOLUMNS_RESPONSIVELAYOUT {

--- a/strapi/schema.graphql
+++ b/strapi/schema.graphql
@@ -311,6 +311,28 @@ input ComponentAccordionItemsInstitutionNarrowInput {
   urlLabel: String
 }
 
+type ComponentBlocksColumnsItem {
+  id: ID!
+  image: UploadFileEntityResponse
+  text: String
+  title: String
+}
+
+input ComponentBlocksColumnsItemFiltersInput {
+  and: [ComponentBlocksColumnsItemFiltersInput]
+  not: ComponentBlocksColumnsItemFiltersInput
+  or: [ComponentBlocksColumnsItemFiltersInput]
+  text: StringFilterInput
+  title: StringFilterInput
+}
+
+input ComponentBlocksColumnsItemInput {
+  id: ID
+  image: ID
+  text: String
+  title: String
+}
+
 type ComponentBlocksCommonLink {
   analyticsId: String
   article: ArticleEntityResponse
@@ -935,6 +957,32 @@ input ComponentSectionsColumnedTextInput {
   content: String
   contentAlignment: ENUM_COMPONENTSECTIONSCOLUMNEDTEXT_CONTENTALIGNMENT
   id: ID
+}
+
+type ComponentSectionsColumns {
+  columns(filters: ComponentBlocksColumnsItemFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): [ComponentBlocksColumnsItem]!
+  id: ID!
+  imageVariant: ENUM_COMPONENTSECTIONSCOLUMNS_IMAGEVARIANT!
+  text: String
+  title: String
+}
+
+input ComponentSectionsColumnsFiltersInput {
+  and: [ComponentSectionsColumnsFiltersInput]
+  columns: ComponentBlocksColumnsItemFiltersInput
+  imageVariant: StringFilterInput
+  not: ComponentSectionsColumnsFiltersInput
+  or: [ComponentSectionsColumnsFiltersInput]
+  text: StringFilterInput
+  title: StringFilterInput
+}
+
+input ComponentSectionsColumnsInput {
+  columns: [ComponentBlocksColumnsItemInput]
+  id: ID
+  imageVariant: ENUM_COMPONENTSECTIONSCOLUMNS_IMAGEVARIANT
+  text: String
+  title: String
 }
 
 type ComponentSectionsComparisonSection {
@@ -1845,6 +1893,12 @@ enum ENUM_COMPONENTSECTIONSCOLUMNEDTEXT_CONTENTALIGNMENT {
   right
 }
 
+enum ENUM_COMPONENTSECTIONSCOLUMNS_IMAGEVARIANT {
+  columnsSection_variant_imageFixedSize
+  columnsSection_variant_imageNonFixedSize
+  columnsSection_variant_withCircleIconBackground
+}
+
 enum ENUM_COMPONENTSECTIONSCOMPARISONSECTION_TEXTALIGN {
   center
   left
@@ -2217,7 +2271,7 @@ type GeneralRelationResponseCollection {
   data: [GeneralEntity!]!
 }
 
-union GenericMorph = Alert | Article | BlogPost | ComponentAccordionItemsFlatText | ComponentAccordionItemsInstitution | ComponentAccordionItemsInstitutionNarrow | ComponentBlocksCommonLink | ComponentBlocksComparisonCard | ComponentBlocksComparisonItem | ComponentBlocksContactCard | ComponentBlocksFile | ComponentBlocksFileItem | ComponentBlocksFooterColumn | ComponentBlocksHomepageHighlightsItem | ComponentBlocksIconWithTitleAndDescription | ComponentBlocksInBa | ComponentBlocksNumericalListItem | ComponentBlocksPageLink | ComponentBlocksProsAndConsCard | ComponentBlocksTestimonialItem | ComponentBlocksTimelineItem | ComponentBlocksTopServicesItem | ComponentBlocksVideo | ComponentGeneralHeader | ComponentGeneralHeaderLink | ComponentMenuMenuItem | ComponentMenuMenuLink | ComponentMenuMenuSection | ComponentSectionsAccordion | ComponentSectionsArticles | ComponentSectionsBanner | ComponentSectionsCalculator | ComponentSectionsColumnedText | ComponentSectionsComparisonSection | ComponentSectionsContactsSection | ComponentSectionsDivider | ComponentSectionsFaqCategories | ComponentSectionsFaqs | ComponentSectionsFileList | ComponentSectionsGallery | ComponentSectionsHomepageEvents | ComponentSectionsHomepageHighlights | ComponentSectionsHomepageMayorAndCouncil | ComponentSectionsHomepageTabs | ComponentSectionsIconTitleDesc | ComponentSectionsIframe | ComponentSectionsInbaArticlesList | ComponentSectionsInbaReleases | ComponentSectionsLinks | ComponentSectionsNarrowText | ComponentSectionsNumericalList | ComponentSectionsOfficialBoard | ComponentSectionsOrganizationalStructure | ComponentSectionsProsAndConsSection | ComponentSectionsRegulations | ComponentSectionsRegulationsList | ComponentSectionsSubpageList | ComponentSectionsTestimonials | ComponentSectionsTextWithImage | ComponentSectionsTextWithImageOverlapped | ComponentSectionsTimeline | ComponentSectionsTootootEvents | ComponentSectionsTopServices | ComponentSectionsVideos | ComponentSectionsWaves | ComponentTaxAdministratorsTaxAdministrator | Faq | FaqCategory | Footer | General | Homepage | I18NLocale | InbaArticle | InbaRelease | InbaTag | Menu | Page | PageCategory | Regulation | Tag | TaxAdministratorsList | UploadFile | UploadFolder | UsersPermissionsPermission | UsersPermissionsRole | UsersPermissionsUser
+union GenericMorph = Alert | Article | BlogPost | ComponentAccordionItemsFlatText | ComponentAccordionItemsInstitution | ComponentAccordionItemsInstitutionNarrow | ComponentBlocksColumnsItem | ComponentBlocksCommonLink | ComponentBlocksComparisonCard | ComponentBlocksComparisonItem | ComponentBlocksContactCard | ComponentBlocksFile | ComponentBlocksFileItem | ComponentBlocksFooterColumn | ComponentBlocksHomepageHighlightsItem | ComponentBlocksIconWithTitleAndDescription | ComponentBlocksInBa | ComponentBlocksNumericalListItem | ComponentBlocksPageLink | ComponentBlocksProsAndConsCard | ComponentBlocksTestimonialItem | ComponentBlocksTimelineItem | ComponentBlocksTopServicesItem | ComponentBlocksVideo | ComponentGeneralHeader | ComponentGeneralHeaderLink | ComponentMenuMenuItem | ComponentMenuMenuLink | ComponentMenuMenuSection | ComponentSectionsAccordion | ComponentSectionsArticles | ComponentSectionsBanner | ComponentSectionsCalculator | ComponentSectionsColumnedText | ComponentSectionsColumns | ComponentSectionsComparisonSection | ComponentSectionsContactsSection | ComponentSectionsDivider | ComponentSectionsFaqCategories | ComponentSectionsFaqs | ComponentSectionsFileList | ComponentSectionsGallery | ComponentSectionsHomepageEvents | ComponentSectionsHomepageHighlights | ComponentSectionsHomepageMayorAndCouncil | ComponentSectionsHomepageTabs | ComponentSectionsIconTitleDesc | ComponentSectionsIframe | ComponentSectionsInbaArticlesList | ComponentSectionsInbaReleases | ComponentSectionsLinks | ComponentSectionsNarrowText | ComponentSectionsNumericalList | ComponentSectionsOfficialBoard | ComponentSectionsOrganizationalStructure | ComponentSectionsProsAndConsSection | ComponentSectionsRegulations | ComponentSectionsRegulationsList | ComponentSectionsSubpageList | ComponentSectionsTestimonials | ComponentSectionsTextWithImage | ComponentSectionsTextWithImageOverlapped | ComponentSectionsTimeline | ComponentSectionsTootootEvents | ComponentSectionsTopServices | ComponentSectionsVideos | ComponentSectionsWaves | ComponentTaxAdministratorsTaxAdministrator | Faq | FaqCategory | Footer | General | Homepage | I18NLocale | InbaArticle | InbaRelease | InbaTag | Menu | Page | PageCategory | Regulation | Tag | TaxAdministratorsList | UploadFile | UploadFolder | UsersPermissionsPermission | UsersPermissionsRole | UsersPermissionsUser
 
 type Homepage {
   createdAt: DateTime
@@ -2910,7 +2964,7 @@ type PageRelationResponseCollection {
   data: [PageEntity!]!
 }
 
-union PageSectionsDynamicZone = ComponentSectionsAccordion | ComponentSectionsArticles | ComponentSectionsBanner | ComponentSectionsCalculator | ComponentSectionsColumnedText | ComponentSectionsComparisonSection | ComponentSectionsContactsSection | ComponentSectionsDivider | ComponentSectionsFaqCategories | ComponentSectionsFaqs | ComponentSectionsFileList | ComponentSectionsGallery | ComponentSectionsIconTitleDesc | ComponentSectionsIframe | ComponentSectionsInbaArticlesList | ComponentSectionsInbaReleases | ComponentSectionsLinks | ComponentSectionsNarrowText | ComponentSectionsNumericalList | ComponentSectionsOfficialBoard | ComponentSectionsOrganizationalStructure | ComponentSectionsProsAndConsSection | ComponentSectionsRegulations | ComponentSectionsRegulationsList | ComponentSectionsTestimonials | ComponentSectionsTextWithImage | ComponentSectionsTextWithImageOverlapped | ComponentSectionsTimeline | ComponentSectionsTootootEvents | ComponentSectionsVideos | ComponentSectionsWaves | Error
+union PageSectionsDynamicZone = ComponentSectionsAccordion | ComponentSectionsArticles | ComponentSectionsBanner | ComponentSectionsCalculator | ComponentSectionsColumnedText | ComponentSectionsColumns | ComponentSectionsComparisonSection | ComponentSectionsContactsSection | ComponentSectionsDivider | ComponentSectionsFaqCategories | ComponentSectionsFaqs | ComponentSectionsFileList | ComponentSectionsGallery | ComponentSectionsIconTitleDesc | ComponentSectionsIframe | ComponentSectionsInbaArticlesList | ComponentSectionsInbaReleases | ComponentSectionsLinks | ComponentSectionsNarrowText | ComponentSectionsNumericalList | ComponentSectionsOfficialBoard | ComponentSectionsOrganizationalStructure | ComponentSectionsProsAndConsSection | ComponentSectionsRegulations | ComponentSectionsRegulationsList | ComponentSectionsTestimonials | ComponentSectionsTextWithImage | ComponentSectionsTextWithImageOverlapped | ComponentSectionsTimeline | ComponentSectionsTootootEvents | ComponentSectionsVideos | ComponentSectionsWaves | Error
 
 scalar PageSectionsDynamicZoneInput
 

--- a/strapi/schema.graphql
+++ b/strapi/schema.graphql
@@ -963,6 +963,7 @@ type ComponentSectionsColumns {
   columns(filters: ComponentBlocksColumnsItemFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): [ComponentBlocksColumnsItem]!
   id: ID!
   imageVariant: ENUM_COMPONENTSECTIONSCOLUMNS_IMAGEVARIANT!
+  respoLayout: ENUM_COMPONENTSECTIONSCOLUMNS_RESPOLAYOUT!
   text: String
   title: String
 }
@@ -973,6 +974,7 @@ input ComponentSectionsColumnsFiltersInput {
   imageVariant: StringFilterInput
   not: ComponentSectionsColumnsFiltersInput
   or: [ComponentSectionsColumnsFiltersInput]
+  respoLayout: StringFilterInput
   text: StringFilterInput
   title: StringFilterInput
 }
@@ -981,6 +983,7 @@ input ComponentSectionsColumnsInput {
   columns: [ComponentBlocksColumnsItemInput]
   id: ID
   imageVariant: ENUM_COMPONENTSECTIONSCOLUMNS_IMAGEVARIANT
+  respoLayout: ENUM_COMPONENTSECTIONSCOLUMNS_RESPOLAYOUT
   text: String
   title: String
 }
@@ -1897,6 +1900,11 @@ enum ENUM_COMPONENTSECTIONSCOLUMNS_IMAGEVARIANT {
   columnsSection_variant_imageFixedHeight
   columnsSection_variant_imageNonFixedSize
   columnsSection_variant_withCircleIconBackground
+}
+
+enum ENUM_COMPONENTSECTIONSCOLUMNS_RESPOLAYOUT {
+  columnsSection_respoLayout_oneColumn
+  columnsSection_respoLayout_slider
 }
 
 enum ENUM_COMPONENTSECTIONSCOMPARISONSECTION_TEXTALIGN {

--- a/strapi/schema.graphql
+++ b/strapi/schema.graphql
@@ -963,7 +963,7 @@ type ComponentSectionsColumns {
   columns(filters: ComponentBlocksColumnsItemFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): [ComponentBlocksColumnsItem]!
   id: ID!
   imageVariant: ENUM_COMPONENTSECTIONSCOLUMNS_IMAGEVARIANT!
-  respoLayout: ENUM_COMPONENTSECTIONSCOLUMNS_RESPOLAYOUT!
+  responsiveLayout: ENUM_COMPONENTSECTIONSCOLUMNS_RESPONSIVELAYOUT!
   text: String
   title: String
 }
@@ -974,7 +974,7 @@ input ComponentSectionsColumnsFiltersInput {
   imageVariant: StringFilterInput
   not: ComponentSectionsColumnsFiltersInput
   or: [ComponentSectionsColumnsFiltersInput]
-  respoLayout: StringFilterInput
+  responsiveLayout: StringFilterInput
   text: StringFilterInput
   title: StringFilterInput
 }
@@ -983,7 +983,7 @@ input ComponentSectionsColumnsInput {
   columns: [ComponentBlocksColumnsItemInput]
   id: ID
   imageVariant: ENUM_COMPONENTSECTIONSCOLUMNS_IMAGEVARIANT
-  respoLayout: ENUM_COMPONENTSECTIONSCOLUMNS_RESPOLAYOUT
+  responsiveLayout: ENUM_COMPONENTSECTIONSCOLUMNS_RESPONSIVELAYOUT
   text: String
   title: String
 }
@@ -1897,14 +1897,13 @@ enum ENUM_COMPONENTSECTIONSCOLUMNEDTEXT_CONTENTALIGNMENT {
 }
 
 enum ENUM_COMPONENTSECTIONSCOLUMNS_IMAGEVARIANT {
-  columnsSection_variant_imageFixedHeight
-  columnsSection_variant_imageNonFixedSize
-  columnsSection_variant_withCircleIconBackground
+  columnsSection_imageVariant_imageOriginalSize
+  columnsSection_imageVariant_withCircleIconBackground
 }
 
-enum ENUM_COMPONENTSECTIONSCOLUMNS_RESPOLAYOUT {
-  columnsSection_respoLayout_oneColumn
-  columnsSection_respoLayout_slider
+enum ENUM_COMPONENTSECTIONSCOLUMNS_RESPONSIVELAYOUT {
+  columnsSection_responsiveLayout_oneColumn
+  columnsSection_responsiveLayout_slider
 }
 
 enum ENUM_COMPONENTSECTIONSCOMPARISONSECTION_TEXTALIGN {

--- a/strapi/src/admin/app.tsx
+++ b/strapi/src/admin/app.tsx
@@ -23,15 +23,17 @@ export default {
         'Settings.webhooks.trigger.test': 'Testovací beh',
 
         // Used in columns section
-        'columnsSection.variant.withCircleIconBackground': 'Piktogramy na kruhovom pozadí',
-        'columnsSection.variant.imageFixedHeight': 'S rovnakou pevnou výškou 120px',
-        'columnsSection.variant.imageNonFixedSize': 'Podľa veľkosti jednotlivých obrázkov',
+        'columnsSection.imageVariant.withCircleIconBackground': 'Piktogramy na kruhovom pozadí',
+        'columnsSection.imageVariant.imageOriginalSize': 'Obrázky s vlastnou veľkosťou',
+        'columnsSection.responsiveLayout.slider': 'Slider',
+        'columnsSection.responsiveLayout.oneColumn': 'Po sebou',
       },
       en: {
         // Used in columns section
-        'columnsSection.variant.withCircleIconBackground': 'Piktogramy na kruhovom pozadí',
-        'columnsSection.variant.imageFixedHeight': 'S rovnakou pevnou výškou 120px',
-        'columnsSection.variant.imageNonFixedSize': 'Podľa veľkosti jednotlivých obrázkov',
+        'columnsSection.imageVariant.withCircleIconBackground': 'Piktogramy na kruhovom pozadí',
+        'columnsSection.imageVariant.imageOriginalSize': 'Obrázky s vlastnou veľkosťou',
+        'columnsSection.responsiveLayout.slider': 'Slider',
+        'columnsSection.responsiveLayout.oneColumn': 'Po sebou',
       },
     },
   },

--- a/strapi/src/admin/app.tsx
+++ b/strapi/src/admin/app.tsx
@@ -21,8 +21,18 @@ export default {
         'Auth.form.username.placeholder': 'napr. jankohrasko',
         'Auth.form.email.placeholder': 'napr. janko.hrasko@bratislava.sk',
         'Settings.webhooks.trigger.test': 'Testovací beh',
+
+        // Used in columns section
+        'columnsSection.variant.withCircleIconBackground': 'Piktogramy na kruhovom pozadí',
+        'columnsSection.variant.imageFixedHeight': 'S rovnakou pevnou výškou 120px',
+        'columnsSection.variant.imageNonFixedSize': 'Podľa veľkosti jednotlivých obrázkov',
       },
-      en: {},
+      en: {
+        // Used in columns section
+        'columnsSection.variant.withCircleIconBackground': 'Piktogramy na kruhovom pozadí',
+        'columnsSection.variant.imageFixedHeight': 'S rovnakou pevnou výškou 120px',
+        'columnsSection.variant.imageNonFixedSize': 'Podľa veľkosti jednotlivých obrázkov',
+      },
     },
   },
   bootstrap() {},

--- a/strapi/src/admin/app.tsx
+++ b/strapi/src/admin/app.tsx
@@ -23,14 +23,14 @@ export default {
         'Settings.webhooks.trigger.test': 'Testovací beh',
 
         // Used in columns section
-        'columnsSection.imageVariant.withCircleIconBackground': 'Piktogramy na kruhovom pozadí',
+        'columnsSection.imageVariant.withCircleBackground': 'Piktogramy na kruhovom pozadí',
         'columnsSection.imageVariant.imageOriginalSize': 'Obrázky s vlastnou veľkosťou',
         'columnsSection.responsiveLayout.slider': 'Slider',
         'columnsSection.responsiveLayout.oneColumn': 'Po sebou',
       },
       en: {
         // Used in columns section
-        'columnsSection.imageVariant.withCircleIconBackground': 'Piktogramy na kruhovom pozadí',
+        'columnsSection.imageVariant.withCircleBackground': 'Piktogramy na kruhovom pozadí',
         'columnsSection.imageVariant.imageOriginalSize': 'Obrázky s vlastnou veľkosťou',
         'columnsSection.responsiveLayout.slider': 'Slider',
         'columnsSection.responsiveLayout.oneColumn': 'Po sebou',

--- a/strapi/src/api/page/content-types/page/schema.json
+++ b/strapi/src/api/page/content-types/page/schema.json
@@ -123,6 +123,7 @@
         "sections.banner",
         "sections.calculator",
         "sections.columned-text",
+        "sections.columns",
         "sections.comparison-section",
         "sections.contacts-section",
         "sections.divider",

--- a/strapi/src/components/blocks/columns-item.json
+++ b/strapi/src/components/blocks/columns-item.json
@@ -1,0 +1,22 @@
+{
+  "collectionName": "components_blocks_columns_items",
+  "info": {
+    "displayName": "columns item"
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "text": {
+      "type": "richtext"
+    },
+    "image": {
+      "allowedTypes": [
+        "images"
+      ],
+      "type": "media",
+      "multiple": false
+    }
+  }
+}

--- a/strapi/src/components/sections/columns.json
+++ b/strapi/src/components/sections/columns.json
@@ -23,7 +23,7 @@
       "type": "enumeration",
       "enum": [
         "columnsSection.variant.withCircleIconBackground",
-        "columnsSection.variant.imageFixedSize",
+        "columnsSection.variant.imageFixedHeight",
         "columnsSection.variant.imageNonFixedSize"
       ],
       "required": true,

--- a/strapi/src/components/sections/columns.json
+++ b/strapi/src/components/sections/columns.json
@@ -28,6 +28,15 @@
       ],
       "required": true,
       "default": "columnsSection.variant.withCircleIconBackground"
+    },
+    "respoLayout": {
+      "type": "enumeration",
+      "enum": [
+        "columnsSection.respoLayout.slider",
+        "columnsSection.respoLayout.oneColumn"
+      ],
+      "required": true,
+      "default": "columnsSection.respoLayout.slider"
     }
   }
 }

--- a/strapi/src/components/sections/columns.json
+++ b/strapi/src/components/sections/columns.json
@@ -22,21 +22,20 @@
     "imageVariant": {
       "type": "enumeration",
       "enum": [
-        "columnsSection.variant.withCircleIconBackground",
-        "columnsSection.variant.imageFixedHeight",
-        "columnsSection.variant.imageNonFixedSize"
+        "columnsSection.imageVariant.withCircleIconBackground",
+        "columnsSection.imageVariant.imageOriginalSize"
       ],
       "required": true,
-      "default": "columnsSection.variant.withCircleIconBackground"
+      "default": "columnsSection.imageVariant.withCircleIconBackground"
     },
-    "respoLayout": {
+    "responsiveLayout": {
       "type": "enumeration",
       "enum": [
-        "columnsSection.respoLayout.slider",
-        "columnsSection.respoLayout.oneColumn"
+        "columnsSection.responsiveLayout.slider",
+        "columnsSection.responsiveLayout.oneColumn"
       ],
       "required": true,
-      "default": "columnsSection.respoLayout.slider"
+      "default": "columnsSection.responsiveLayout.slider"
     }
   }
 }

--- a/strapi/src/components/sections/columns.json
+++ b/strapi/src/components/sections/columns.json
@@ -22,11 +22,11 @@
     "imageVariant": {
       "type": "enumeration",
       "enum": [
-        "columnsSection.imageVariant.withCircleIconBackground",
+        "columnsSection.imageVariant.withCircleBackground",
         "columnsSection.imageVariant.imageOriginalSize"
       ],
       "required": true,
-      "default": "columnsSection.imageVariant.withCircleIconBackground"
+      "default": "columnsSection.imageVariant.withCircleBackground"
     },
     "responsiveLayout": {
       "type": "enumeration",

--- a/strapi/src/components/sections/columns.json
+++ b/strapi/src/components/sections/columns.json
@@ -1,0 +1,33 @@
+{
+  "collectionName": "components_sections_columns",
+  "info": {
+    "displayName": "Columns",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "text": {
+      "type": "text"
+    },
+    "columns": {
+      "type": "component",
+      "repeatable": true,
+      "component": "blocks.columns-item",
+      "required": true,
+      "min": 1
+    },
+    "imageVariant": {
+      "type": "enumeration",
+      "enum": [
+        "columnsSection.variant.withCircleIconBackground",
+        "columnsSection.variant.imageFixedSize",
+        "columnsSection.variant.imageNonFixedSize"
+      ],
+      "required": true,
+      "default": "columnsSection.variant.withCircleIconBackground"
+    }
+  }
+}

--- a/strapi/types/generated/components.d.ts
+++ b/strapi/types/generated/components.d.ts
@@ -51,6 +51,18 @@ export interface AccordionItemsInstitutionNarrow extends Schema.Component {
   }
 }
 
+export interface BlocksColumnsItem extends Schema.Component {
+  collectionName: 'components_blocks_columns_items'
+  info: {
+    displayName: 'columns item'
+  }
+  attributes: {
+    image: Attribute.Media<'images'>
+    text: Attribute.RichText
+    title: Attribute.String
+  }
+}
+
 export interface BlocksCommonLink extends Schema.Component {
   collectionName: 'components_blocks_common_links'
   info: {
@@ -478,6 +490,35 @@ export interface SectionsColumnedText extends Schema.Component {
     content: Attribute.RichText
     contentAlignment: Attribute.Enumeration<['left', 'center', 'right']> &
       Attribute.DefaultTo<'left'>
+  }
+}
+
+export interface SectionsColumns extends Schema.Component {
+  collectionName: 'components_sections_columns'
+  info: {
+    description: ''
+    displayName: 'Columns'
+  }
+  attributes: {
+    columns: Attribute.Component<'blocks.columns-item', true> &
+      Attribute.Required &
+      Attribute.SetMinMax<
+        {
+          min: 1
+        },
+        number
+      >
+    imageVariant: Attribute.Enumeration<
+      [
+        'columnsSection.variant.withCircleIconBackground',
+        'columnsSection.variant.imageFixedSize',
+        'columnsSection.variant.imageNonFixedSize'
+      ]
+    > &
+      Attribute.Required &
+      Attribute.DefaultTo<'columnsSection.variant.withCircleIconBackground'>
+    text: Attribute.Text
+    title: Attribute.String
   }
 }
 
@@ -956,6 +997,7 @@ declare module '@strapi/types' {
       'accordion-items.flat-text': AccordionItemsFlatText
       'accordion-items.institution': AccordionItemsInstitution
       'accordion-items.institution-narrow': AccordionItemsInstitutionNarrow
+      'blocks.columns-item': BlocksColumnsItem
       'blocks.common-link': BlocksCommonLink
       'blocks.comparison-card': BlocksComparisonCard
       'blocks.comparison-item': BlocksComparisonItem
@@ -983,6 +1025,7 @@ declare module '@strapi/types' {
       'sections.banner': SectionsBanner
       'sections.calculator': SectionsCalculator
       'sections.columned-text': SectionsColumnedText
+      'sections.columns': SectionsColumns
       'sections.comparison-section': SectionsComparisonSection
       'sections.contacts-section': SectionsContactsSection
       'sections.divider': SectionsDivider

--- a/strapi/types/generated/components.d.ts
+++ b/strapi/types/generated/components.d.ts
@@ -510,18 +510,17 @@ export interface SectionsColumns extends Schema.Component {
       >
     imageVariant: Attribute.Enumeration<
       [
-        'columnsSection.variant.withCircleIconBackground',
-        'columnsSection.variant.imageFixedHeight',
-        'columnsSection.variant.imageNonFixedSize'
+        'columnsSection.imageVariant.withCircleIconBackground',
+        'columnsSection.imageVariant.imageOriginalSize'
       ]
     > &
       Attribute.Required &
-      Attribute.DefaultTo<'columnsSection.variant.withCircleIconBackground'>
-    respoLayout: Attribute.Enumeration<
-      ['columnsSection.respoLayout.slider', 'columnsSection.respoLayout.oneColumn']
+      Attribute.DefaultTo<'columnsSection.imageVariant.withCircleIconBackground'>
+    responsiveLayout: Attribute.Enumeration<
+      ['columnsSection.responsiveLayout.slider', 'columnsSection.responsiveLayout.oneColumn']
     > &
       Attribute.Required &
-      Attribute.DefaultTo<'columnsSection.respoLayout.slider'>
+      Attribute.DefaultTo<'columnsSection.responsiveLayout.slider'>
     text: Attribute.Text
     title: Attribute.String
   }

--- a/strapi/types/generated/components.d.ts
+++ b/strapi/types/generated/components.d.ts
@@ -510,12 +510,12 @@ export interface SectionsColumns extends Schema.Component {
       >
     imageVariant: Attribute.Enumeration<
       [
-        'columnsSection.imageVariant.withCircleIconBackground',
+        'columnsSection.imageVariant.withCircleBackground',
         'columnsSection.imageVariant.imageOriginalSize'
       ]
     > &
       Attribute.Required &
-      Attribute.DefaultTo<'columnsSection.imageVariant.withCircleIconBackground'>
+      Attribute.DefaultTo<'columnsSection.imageVariant.withCircleBackground'>
     responsiveLayout: Attribute.Enumeration<
       ['columnsSection.responsiveLayout.slider', 'columnsSection.responsiveLayout.oneColumn']
     > &

--- a/strapi/types/generated/components.d.ts
+++ b/strapi/types/generated/components.d.ts
@@ -511,7 +511,7 @@ export interface SectionsColumns extends Schema.Component {
     imageVariant: Attribute.Enumeration<
       [
         'columnsSection.variant.withCircleIconBackground',
-        'columnsSection.variant.imageFixedSize',
+        'columnsSection.variant.imageFixedHeight',
         'columnsSection.variant.imageNonFixedSize'
       ]
     > &

--- a/strapi/types/generated/components.d.ts
+++ b/strapi/types/generated/components.d.ts
@@ -517,6 +517,11 @@ export interface SectionsColumns extends Schema.Component {
     > &
       Attribute.Required &
       Attribute.DefaultTo<'columnsSection.variant.withCircleIconBackground'>
+    respoLayout: Attribute.Enumeration<
+      ['columnsSection.respoLayout.slider', 'columnsSection.respoLayout.oneColumn']
+    > &
+      Attribute.Required &
+      Attribute.DefaultTo<'columnsSection.respoLayout.slider'>
     text: Attribute.Text
     title: Attribute.String
   }

--- a/strapi/types/generated/contentTypes.d.ts
+++ b/strapi/types/generated/contentTypes.d.ts
@@ -1160,6 +1160,7 @@ export interface ApiPagePage extends Schema.CollectionType {
         'sections.banner',
         'sections.calculator',
         'sections.columned-text',
+        'sections.columns',
         'sections.comparison-section',
         'sections.contacts-section',
         'sections.divider',


### PR DESCRIPTION
### Description

Add new `Columns` section, based on OLO. This section will replace IconTitleDesc. It adds support for two image variants (pictogram in circle, arbitrary image), and two layouts on respo screens (standard items below each other, Slider based on OLO).

Potential improvements:
- add respo layout with two columns (helpful for sections with more columns and no or short text or short title)
- add string field to use pictogram from DS instead of uploaded image

### Testing
You can see the section in styleguide (at the end) or test it by add it in Strapi.
http://localhost:3000/styleguide

### Screenshots

![image](https://github.com/user-attachments/assets/f4beab32-ee37-449a-b381-ef11551d8cd9)
