### PR TITLE
#1414 Announce current page in Pagination

### DIFF
--- a/next/public/locales/en/translation.json
+++ b/next/public/locales/en/translation.json
@@ -72,6 +72,7 @@
   "OfficialBoard.published": "Published",
   "OfficialBoard.publishedFrom": "Published from",
   "OfficialBoard.publishedTo": "Published to",
+  "Pagination.aria.currentPage": "Page {{page}}, current page",
   "Pagination.aria.goToNextPage": "Go to next page",
   "Pagination.aria.goToPage": "Go to page {{page}}",
   "Pagination.aria.goToPreviousPage": "Go to previous page",

--- a/next/public/locales/sk/translation.json
+++ b/next/public/locales/sk/translation.json
@@ -74,6 +74,7 @@
   "OfficialBoard.published": "Zverejnené",
   "OfficialBoard.publishedFrom": "Zverejnené od",
   "OfficialBoard.publishedTo": "Zverejnené do",
+  "Pagination.aria.currentPage": "Stránka {{page}}, aktuálna stránka",
   "Pagination.aria.goToNextPage": "Ísť na ďalšiu stranu",
   "Pagination.aria.goToPage": "Ísť na stranu {{page}}",
   "Pagination.aria.goToPreviousPage": "Ísť na predchádzajúcu stranu",

--- a/next/public/locales/sk/translation.json
+++ b/next/public/locales/sk/translation.json
@@ -74,7 +74,7 @@
   "OfficialBoard.published": "Zverejnené",
   "OfficialBoard.publishedFrom": "Zverejnené od",
   "OfficialBoard.publishedTo": "Zverejnené do",
-  "Pagination.aria.currentPage": "Stránka {{page}}, aktuálna stránka",
+  "Pagination.aria.currentPage": "Strana {{page}}, aktuálna strana",
   "Pagination.aria.goToNextPage": "Ísť na ďalšiu stranu",
   "Pagination.aria.goToPage": "Ísť na stranu {{page}}",
   "Pagination.aria.goToPreviousPage": "Ísť na predchádzajúcu stranu",

--- a/next/src/components/common/Pagination/Pagination.tsx
+++ b/next/src/components/common/Pagination/Pagination.tsx
@@ -40,66 +40,68 @@ const Pagination = ({ currentPage, totalCount, onPageChange = () => {} }: Pagina
         className="flex flex-wrap items-center justify-center gap-1 lg:gap-2"
         data-cy="pagination"
       >
-        {items.map(
-          ({ page, type, selected, disabled, onPress, 'aria-current': ariaCurrent }, index) => {
-            let children: ReactNode = null
+        {items.map(({ page, type, selected, disabled, onPress }, index) => {
+          let children: ReactNode = null
 
-            // eslint-disable-next-line unicorn/prefer-switch
-            if (type === 'start-ellipsis' || type === 'end-ellipsis') {
-              children = '…'
-            } else if (type === 'page') {
-              children = (
-                <Button
-                  variant={selected ? 'solid' : 'outline'}
-                  isDisabled={disabled}
-                  onPress={onPress}
-                  aria-current={ariaCurrent}
-                  aria-label={t('Pagination.aria.goToPage', { page })}
-                  className="flex size-10 shrink-0 grow-0 items-center justify-center rounded-full lg:size-12"
-                >
-                  {page}
-                </Button>
-              )
-            } else if (type === 'previous' || type === 'next') {
-              let icon: ReactNode
-              let ariaLabel = ''
-              if (type === 'previous') {
-                icon = <ArrowLeftIcon />
-                ariaLabel = t('Pagination.aria.goToPreviousPage')
-              }
-              if (type === 'next') {
-                icon = <ArrowRightIcon />
-                ariaLabel = t('Pagination.aria.goToNextPage')
-              }
-
-              children = (
-                <Button
-                  variant="plain"
-                  isDisabled={disabled}
-                  onPress={onPress}
-                  aria-label={ariaLabel}
-                  icon={icon}
-                  className="rounded-full"
-                />
-              )
+          // eslint-disable-next-line unicorn/prefer-switch
+          if (type === 'start-ellipsis' || type === 'end-ellipsis') {
+            children = '…'
+          } else if (type === 'page') {
+            children = (
+              <Button
+                variant={selected ? 'solid' : 'outline'}
+                isDisabled={disabled}
+                onPress={onPress}
+                aria-current={selected}
+                aria-label={
+                  selected
+                    ? t('Pagination.aria.currentPage', { page })
+                    : t('Pagination.aria.goToPage', { page })
+                }
+                className="flex size-10 shrink-0 grow-0 items-center justify-center rounded-full lg:size-12"
+              >
+                {page}
+              </Button>
+            )
+          } else if (type === 'previous' || type === 'next') {
+            let icon: ReactNode
+            let ariaLabel = ''
+            if (type === 'previous') {
+              icon = <ArrowLeftIcon />
+              ariaLabel = t('Pagination.aria.goToPreviousPage')
+            }
+            if (type === 'next') {
+              icon = <ArrowRightIcon />
+              ariaLabel = t('Pagination.aria.goToNextPage')
             }
 
-            return (
-              <li
-                // eslint-disable-next-line react/no-array-index-key
-                key={index}
-                className={cn({
-                  'flex w-10 items-center justify-center text-size-p-small font-semibold lg:w-12':
-                    type === 'start-ellipsis' || type === 'end-ellipsis',
-                  'lg:mr-2': type === 'previous',
-                  'lg:ml-2': type === 'next',
-                })}
-              >
-                {children}
-              </li>
+            children = (
+              <Button
+                variant="plain"
+                isDisabled={disabled}
+                onPress={onPress}
+                aria-label={ariaLabel}
+                icon={icon}
+                className="rounded-full"
+              />
             )
-          },
-        )}
+          }
+
+          return (
+            <li
+              // eslint-disable-next-line react/no-array-index-key
+              key={index}
+              className={cn({
+                'flex w-10 items-center justify-center text-size-p-small font-semibold lg:w-12':
+                  type === 'start-ellipsis' || type === 'end-ellipsis',
+                'lg:mr-2': type === 'previous',
+                'lg:ml-2': type === 'next',
+              })}
+            >
+              {children}
+            </li>
+          )
+        })}
       </ul>
     </nav>
   )

--- a/next/src/components/common/Pagination/usePagination.ts
+++ b/next/src/components/common/Pagination/usePagination.ts
@@ -133,7 +133,6 @@ export default function usePagination(props: {
           page: item,
           selected: item === page,
           disabled,
-          'aria-current': item === page ? ('true' as const) : undefined,
         }
       : {
           onPress: (event: PressEvent) => {


### PR DESCRIPTION
### Description

Improve pagination accessibility

Changes:
- Add new translation strings to differentiate between the current page ("Page 3, current page") and navigable pages ("Go to page 3")
- Use the existing `selected` prop to set `aria-current`, creating consistency with the visual styling logic
- Remove the unused `aria-current` prop from the pagination item type returned by usePagination hook

These changes ensure screen reader users can clearly identify which page they're currently viewing

### Screenshots

<img width="1680" alt="Screenshot 2025-05-23 at 14 54 23" src="https://github.com/user-attachments/assets/6b7e74b3-3f34-4fec-8ae0-6525002aba12" />
