### PR TITLE
#1550 Add title to ColumnedText section and remove contentAlignment

### DIFF
--- a/next/public/locales/en/translation.json
+++ b/next/public/locales/en/translation.json
@@ -135,6 +135,8 @@
   "SearchPage.whatAreYouLookingFor": "What are you looking for?",
   "ShareButtonsSection.share": "Share",
   "SkipToContentButton.skipNavigation": "Skip navigation",
+  "slider.aria.controlButtons": "Control buttons",
+  "slider.aria.goToSlide": "Go to slide {{number}}",
   "Tag.aria.removeTag": "Remove tag {{tag}}",
   "TopServices.learnMore": "Read more",
   "useLocalizations.longName.en": "English",

--- a/next/public/locales/sk/translation.json
+++ b/next/public/locales/sk/translation.json
@@ -145,6 +145,8 @@
   "SearchPage.whatAreYouLookingFor": "Čo hľadáte?",
   "ShareButtonsSection.share": "Zdieľať",
   "SkipToContentButton.skipNavigation": "Preskočiť navigáciu",
+  "slider.aria.controlButtons": "Ovládacie tlačidlá",
+  "slider.aria.goToSlide": "Ísť na slide {{number}}",
   "Tag.aria.removeTag": "Odstrániť tag {{tag}}",
   "TopServices.learnMore": "Zistiť viac",
   "useLocalizations.longName.en": "English",

--- a/next/src/components/common/ColumnedText/ColumnedText.tsx
+++ b/next/src/components/common/ColumnedText/ColumnedText.tsx
@@ -1,47 +1,38 @@
+import { Typography } from '@bratislava/component-library'
+
 import Markdown from '@/src/components/formatting/Markdown/Markdown'
-import { Enum_Componentsectionscolumnedtext_Contentalignment } from '@/src/services/graphql'
 import cn from '@/src/utils/cn'
 
 export type ColumnedTextProps = {
+  title: string | null | undefined
   content: string
-  contentAlignment?: Enum_Componentsectionscolumnedtext_Contentalignment | null
 }
 
-const ColumnedText = ({
-  content,
-  contentAlignment = Enum_Componentsectionscolumnedtext_Contentalignment.Left,
-}: ColumnedTextProps) => {
+const ColumnedText = ({ title, content }: ColumnedTextProps) => {
   const breakWord = '<break>'
   const columns = content.split(breakWord)
-  if (!content) return null
 
   return (
-    <div
-      className={cn('grid gap-6', {
-        'grid-cols-1': columns.length === 1,
-        'grid-cols-1 md:grid-cols-2': columns.length === 2,
-        'grid-cols-1 md:grid-cols-3': columns.length === 3,
-        'grid-cols-1 md:grid-cols-4': columns.length === 4,
-        'grid-cols-2 md:grid-cols-3 lg:grid-cols-5': columns.length === 5,
-        'grid-cols-2 md:grid-cols-3 lg:grid-cols-6': columns.length === 6,
-        'grid-cols-2 md:grid-cols-4 lg:grid-cols-6': columns.length > 6,
-      })}
-    >
-      {columns.map((column, i) => (
-        <div
-          key={i}
-          className={cn({
-            'text-left':
-              contentAlignment === Enum_Componentsectionscolumnedtext_Contentalignment.Left,
-            'text-center':
-              contentAlignment === Enum_Componentsectionscolumnedtext_Contentalignment.Center,
-            'text-right':
-              contentAlignment === Enum_Componentsectionscolumnedtext_Contentalignment.Right,
-          })}
-        >
-          <Markdown content={column} />
-        </div>
-      ))}
+    <div className="flex flex-col gap-6 lg:gap-8">
+      {title ? <Typography variant="h2">{title}</Typography> : null}
+      <div
+        className={cn('grid gap-6', {
+          'grid-cols-1': columns.length === 1,
+          'grid-cols-1 md:grid-cols-2': columns.length === 2,
+          'grid-cols-1 md:grid-cols-3': columns.length === 3,
+          'grid-cols-1 md:grid-cols-4': columns.length === 4,
+          'grid-cols-2 md:grid-cols-3 lg:grid-cols-5': columns.length === 5,
+          'grid-cols-2 md:grid-cols-3 lg:grid-cols-6': columns.length === 6,
+          'grid-cols-2 md:grid-cols-4 lg:grid-cols-6': columns.length > 6,
+        })}
+      >
+        {columns.map((column, index) => (
+          <Markdown
+            content={column} // eslint-disable-next-line react/no-array-index-key
+            key={index}
+          />
+        ))}
+      </div>
     </div>
   )
 }

--- a/next/src/components/sections/ColumnedTextSection.tsx
+++ b/next/src/components/sections/ColumnedTextSection.tsx
@@ -6,12 +6,7 @@ import { ColumnedTextSectionFragment } from '@/src/services/graphql'
 type ColumnedTextSectionProps = { section: ColumnedTextSectionFragment }
 
 const ColumnedTextSection = ({ section }: ColumnedTextSectionProps) => {
-  return (
-    <ColumnedText
-      content={section.content ?? ''}
-      contentAlignment={section.contentAlignment ?? undefined}
-    />
-  )
+  return <ColumnedText title={section.title} content={section.content ?? ''} />
 }
 
 export default ColumnedTextSection

--- a/next/src/services/graphql/index.ts
+++ b/next/src/services/graphql/index.ts
@@ -1111,22 +1111,22 @@ export type ComponentSectionsCalculatorInput = {
 export type ComponentSectionsColumnedText = {
   __typename?: 'ComponentSectionsColumnedText'
   content?: Maybe<Scalars['String']['output']>
-  contentAlignment?: Maybe<Enum_Componentsectionscolumnedtext_Contentalignment>
   id: Scalars['ID']['output']
+  title?: Maybe<Scalars['String']['output']>
 }
 
 export type ComponentSectionsColumnedTextFiltersInput = {
   and?: InputMaybe<Array<InputMaybe<ComponentSectionsColumnedTextFiltersInput>>>
   content?: InputMaybe<StringFilterInput>
-  contentAlignment?: InputMaybe<StringFilterInput>
   not?: InputMaybe<ComponentSectionsColumnedTextFiltersInput>
   or?: InputMaybe<Array<InputMaybe<ComponentSectionsColumnedTextFiltersInput>>>
+  title?: InputMaybe<StringFilterInput>
 }
 
 export type ComponentSectionsColumnedTextInput = {
   content?: InputMaybe<Scalars['String']['input']>
-  contentAlignment?: InputMaybe<Enum_Componentsectionscolumnedtext_Contentalignment>
   id?: InputMaybe<Scalars['ID']['input']>
+  title?: InputMaybe<Scalars['String']['input']>
 }
 
 export type ComponentSectionsColumns = {
@@ -2205,12 +2205,6 @@ export enum Enum_Componentsectionsbanner_Variant {
   Color = 'color',
   Dark = 'dark',
   WhiteCondensed = 'white_condensed',
-}
-
-export enum Enum_Componentsectionscolumnedtext_Contentalignment {
-  Center = 'center',
-  Left = 'left',
-  Right = 'right',
 }
 
 export enum Enum_Componentsectionscolumns_Imagevariant {
@@ -8459,8 +8453,8 @@ export type PageEntityFragment = {
         }
       | {
           __typename: 'ComponentSectionsColumnedText'
+          title?: string | null
           content?: string | null
-          contentAlignment?: Enum_Componentsectionscolumnedtext_Contentalignment | null
         }
       | {
           __typename: 'ComponentSectionsColumns'
@@ -9399,8 +9393,8 @@ export type PageBySlugQuery = {
             }
           | {
               __typename: 'ComponentSectionsColumnedText'
+              title?: string | null
               content?: string | null
-              contentAlignment?: Enum_Componentsectionscolumnedtext_Contentalignment | null
             }
           | {
               __typename: 'ComponentSectionsColumns'
@@ -10379,8 +10373,8 @@ export type Dev_AllPagesQuery = {
             }
           | {
               __typename: 'ComponentSectionsColumnedText'
+              title?: string | null
               content?: string | null
-              contentAlignment?: Enum_Componentsectionscolumnedtext_Contentalignment | null
             }
           | {
               __typename: 'ComponentSectionsColumns'
@@ -12211,8 +12205,8 @@ export type FileItemBlockFragment = {
 
 export type ColumnedTextSectionFragment = {
   __typename?: 'ComponentSectionsColumnedText'
+  title?: string | null
   content?: string | null
-  contentAlignment?: Enum_Componentsectionscolumnedtext_Contentalignment | null
 }
 
 export type ColumnsItemFragment = {
@@ -13131,8 +13125,8 @@ type Sections_ComponentSectionsCalculator_Fragment = {
 
 type Sections_ComponentSectionsColumnedText_Fragment = {
   __typename: 'ComponentSectionsColumnedText'
+  title?: string | null
   content?: string | null
-  contentAlignment?: Enum_Componentsectionscolumnedtext_Contentalignment | null
 }
 
 type Sections_ComponentSectionsColumns_Fragment = {
@@ -14513,8 +14507,8 @@ export const FileListSectionFragmentDoc = gql`
 `
 export const ColumnedTextSectionFragmentDoc = gql`
   fragment ColumnedTextSection on ComponentSectionsColumnedText {
+    title
     content
-    contentAlignment
   }
 `
 export const ColumnsItemFragmentDoc = gql`

--- a/next/src/services/graphql/queries/Sections.graphql
+++ b/next/src/services/graphql/queries/Sections.graphql
@@ -138,8 +138,8 @@ fragment FileItemBlock on ComponentBlocksFileItem {
 }
 
 fragment ColumnedTextSection on ComponentSectionsColumnedText {
+  title
   content
-  contentAlignment
 }
 
 fragment ColumnsItem on ComponentBlocksColumnsItem {

--- a/next/src/utils/dev/strapiHelper.ts
+++ b/next/src/utils/dev/strapiHelper.ts
@@ -87,11 +87,14 @@ export async function listPages() {
     .filter((page) => {
       const sections =
         page.sections?.filter(
-          (section) => section?.__typename === 'ComponentSectionsTextWithImage',
+          (section) => section?.__typename === 'ComponentSectionsColumnedText',
         ) ?? []
       if (
         sections.some(
-          (section) => section?.__typename === 'ComponentSectionsTextWithImage' && !section.content,
+          (section) =>
+            section?.__typename === 'ComponentSectionsColumnedText' &&
+            section.content &&
+            section.content.split('<break>').length > 2,
         )
       ) {
         return true

--- a/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.columned-text.json
+++ b/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.columned-text.json
@@ -7,7 +7,7 @@
       "filterable": true,
       "searchable": true,
       "pageSize": 10,
-      "mainField": "id",
+      "mainField": "title",
       "defaultSortBy": "id",
       "defaultSortOrder": "ASC"
     },
@@ -20,10 +20,24 @@
           "sortable": false
         }
       },
+      "title": {
+        "edit": {
+          "label": "Nadpis",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "title",
+          "searchable": true,
+          "sortable": true
+        }
+      },
       "content": {
         "edit": {
-          "label": "content",
-          "description": "",
+          "label": "Text",
+          "description": "Stĺpce oddeľujeme slovom <break>.",
           "placeholder": "",
           "visible": true,
           "editable": true
@@ -33,38 +47,24 @@
           "searchable": false,
           "sortable": false
         }
-      },
-      "contentAlignment": {
-        "edit": {
-          "label": "contentAlignment",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true
-        },
-        "list": {
-          "label": "contentAlignment",
-          "searchable": true,
-          "sortable": true
-        }
       }
     },
     "layouts": {
       "list": [
         "id",
-        "contentAlignment"
+        "title"
       ],
       "edit": [
         [
           {
-            "name": "content",
+            "name": "title",
             "size": 12
           }
         ],
         [
           {
-            "name": "contentAlignment",
-            "size": 6
+            "name": "content",
+            "size": 12
           }
         ]
       ]

--- a/strapi/schema.graphql
+++ b/strapi/schema.graphql
@@ -941,22 +941,22 @@ input ComponentSectionsCalculatorInput {
 
 type ComponentSectionsColumnedText {
   content: String
-  contentAlignment: ENUM_COMPONENTSECTIONSCOLUMNEDTEXT_CONTENTALIGNMENT
   id: ID!
+  title: String
 }
 
 input ComponentSectionsColumnedTextFiltersInput {
   and: [ComponentSectionsColumnedTextFiltersInput]
   content: StringFilterInput
-  contentAlignment: StringFilterInput
   not: ComponentSectionsColumnedTextFiltersInput
   or: [ComponentSectionsColumnedTextFiltersInput]
+  title: StringFilterInput
 }
 
 input ComponentSectionsColumnedTextInput {
   content: String
-  contentAlignment: ENUM_COMPONENTSECTIONSCOLUMNEDTEXT_CONTENTALIGNMENT
   id: ID
+  title: String
 }
 
 type ComponentSectionsColumns {
@@ -1888,12 +1888,6 @@ enum ENUM_COMPONENTSECTIONSBANNER_VARIANT {
   color
   dark
   white_condensed
-}
-
-enum ENUM_COMPONENTSECTIONSCOLUMNEDTEXT_CONTENTALIGNMENT {
-  center
-  left
-  right
 }
 
 enum ENUM_COMPONENTSECTIONSCOLUMNS_IMAGEVARIANT {

--- a/strapi/src/components/sections/columned-text.json
+++ b/strapi/src/components/sections/columned-text.json
@@ -6,14 +6,11 @@
   },
   "options": {},
   "attributes": {
+    "title": {
+      "type": "string"
+    },
     "content": {
       "type": "richtext"
-    },
-    "contentAlignment": {
-      "type": "enumeration",
-      "enum": ["left", "center", "right"],
-      "default": "left",
-      "required": false
     }
   }
 }

--- a/strapi/types/generated/components.d.ts
+++ b/strapi/types/generated/components.d.ts
@@ -488,8 +488,7 @@ export interface SectionsColumnedText extends Schema.Component {
   }
   attributes: {
     content: Attribute.RichText
-    contentAlignment: Attribute.Enumeration<['left', 'center', 'right']> &
-      Attribute.DefaultTo<'left'>
+    title: Attribute.String
   }
 }
 


### PR DESCRIPTION
- add `title` that is full width
- remove sparely used `contentAlignment` - I check it through the whole page - other than `left` or undefined was used only 2 times and it was not neceray because it was on partners logos.

![image](https://github.com/user-attachments/assets/79baefb9-41e5-4952-a6fc-f3c5479b9319)
