### PR TITLE
#1581 Replace class break-words by wrap-break-word

### DIFF
--- a/next/src/components/cards/RegulationRowCard.tsx
+++ b/next/src/components/cards/RegulationRowCard.tsx
@@ -39,7 +39,7 @@ const RegulationRowCard = ({
           <div className="flex flex-col items-start gap-2 lg:flex-row lg:items-center lg:gap-4">
             <MLink
               href={path ?? '#'}
-              className="text-h6 font-bold break-words"
+              className="text-h6 font-bold wrap-break-word"
               stretched
               variant="underlineOnHover"
             >

--- a/next/src/components/common/OrganizationalStructure_Deprecated/OrganizationalStructureAccordionCard_Deprecated.tsx
+++ b/next/src/components/common/OrganizationalStructure_Deprecated/OrganizationalStructureAccordionCard_Deprecated.tsx
@@ -21,7 +21,7 @@ const OrganizationalStructureAccordionCard = ({
     displayName && jobTitle ? (
       <div
         className={twMerge(
-          'flex flex-col rounded-lg border-2 bg-white p-4 break-words lg:p-5',
+          'flex flex-col rounded-lg border-2 bg-white p-4 wrap-break-word lg:p-5',
           className,
         )}
       >


### PR DESCRIPTION
In tailwind v4, the correct utility class for `overflow-wrap: break-word;` changed (see https://tailwindcss.com/docs/overflow-wrap)
The previous utility break-words works correctly, this is just for consistency.
