### PR TITLE
#1601 Create new Documents content type and section in Strapi

### DIFF
--- a/strapi/config/sync/admin-role.strapi-super-admin.json
+++ b/strapi/config/sync/admin-role.strapi-super-admin.json
@@ -303,6 +303,111 @@
     },
     {
       "action": "plugin::content-manager.explorer.create",
+      "subject": "api::document-category.document-category",
+      "properties": {
+        "fields": [
+          "title",
+          "slug",
+          "documents"
+        ]
+      },
+      "conditions": [],
+      "actionParameters": {}
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "subject": "api::document-category.document-category",
+      "properties": {},
+      "conditions": [],
+      "actionParameters": {}
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "subject": "api::document-category.document-category",
+      "properties": {
+        "fields": [
+          "title",
+          "slug",
+          "documents"
+        ]
+      },
+      "conditions": [],
+      "actionParameters": {}
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "subject": "api::document-category.document-category",
+      "properties": {
+        "fields": [
+          "title",
+          "slug",
+          "documents"
+        ]
+      },
+      "conditions": [],
+      "actionParameters": {}
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "subject": "api::document.document",
+      "properties": {
+        "fields": [
+          "title",
+          "slug",
+          "files",
+          "description",
+          "documentCategory"
+        ]
+      },
+      "conditions": [],
+      "actionParameters": {}
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "subject": "api::document.document",
+      "properties": {},
+      "conditions": [],
+      "actionParameters": {}
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "subject": "api::document.document",
+      "properties": {},
+      "conditions": [],
+      "actionParameters": {}
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "subject": "api::document.document",
+      "properties": {
+        "fields": [
+          "title",
+          "slug",
+          "files",
+          "description",
+          "documentCategory"
+        ]
+      },
+      "conditions": [],
+      "actionParameters": {}
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "subject": "api::document.document",
+      "properties": {
+        "fields": [
+          "title",
+          "slug",
+          "files",
+          "description",
+          "documentCategory"
+        ]
+      },
+      "conditions": [],
+      "actionParameters": {}
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
       "subject": "api::faq-category.faq-category",
       "properties": {
         "fields": [

--- a/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.documents.json
+++ b/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.documents.json
@@ -1,0 +1,100 @@
+{
+  "key": "plugin_content_manager_configuration_components::sections.documents",
+  "value": {
+    "settings": {
+      "bulkable": true,
+      "filterable": true,
+      "searchable": true,
+      "pageSize": 10,
+      "mainField": "title",
+      "defaultSortBy": "title",
+      "defaultSortOrder": "ASC"
+    },
+    "metadatas": {
+      "id": {
+        "edit": {},
+        "list": {
+          "label": "id",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "title": {
+        "edit": {
+          "label": "Nadpis",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "title",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "text": {
+        "edit": {
+          "label": "Text",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "text",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "documents": {
+        "edit": {
+          "label": "Dokumenty",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "title"
+        },
+        "list": {
+          "label": "documents",
+          "searchable": false,
+          "sortable": false
+        }
+      }
+    },
+    "layouts": {
+      "list": [
+        "id",
+        "title",
+        "text",
+        "documents"
+      ],
+      "edit": [
+        [
+          {
+            "name": "title",
+            "size": 12
+          }
+        ],
+        [
+          {
+            "name": "text",
+            "size": 12
+          }
+        ],
+        [
+          {
+            "name": "documents",
+            "size": 12
+          }
+        ]
+      ]
+    },
+    "uid": "sections.documents",
+    "isComponent": true
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/strapi/config/sync/core-store.plugin_content_manager_configuration_content_types##api##document-category.document-category.json
+++ b/strapi/config/sync/core-store.plugin_content_manager_configuration_content_types##api##document-category.document-category.json
@@ -1,0 +1,157 @@
+{
+  "key": "plugin_content_manager_configuration_content_types::api::document-category.document-category",
+  "value": {
+    "settings": {
+      "bulkable": true,
+      "filterable": true,
+      "searchable": true,
+      "pageSize": 10,
+      "mainField": "title",
+      "defaultSortBy": "title",
+      "defaultSortOrder": "ASC"
+    },
+    "metadatas": {
+      "id": {
+        "edit": {},
+        "list": {
+          "label": "id",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "title": {
+        "edit": {
+          "label": "Nadpis",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "title",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "slug": {
+        "edit": {
+          "label": "Slug",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "slug",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "documents": {
+        "edit": {
+          "label": "Dokumenty",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "title"
+        },
+        "list": {
+          "label": "documents",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "createdAt": {
+        "edit": {
+          "label": "createdAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "createdAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedAt": {
+        "edit": {
+          "label": "updatedAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "updatedAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "createdBy": {
+        "edit": {
+          "label": "createdBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "createdBy",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedBy": {
+        "edit": {
+          "label": "updatedBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "updatedBy",
+          "searchable": true,
+          "sortable": true
+        }
+      }
+    },
+    "layouts": {
+      "edit": [
+        [
+          {
+            "name": "title",
+            "size": 12
+          }
+        ],
+        [
+          {
+            "name": "slug",
+            "size": 12
+          }
+        ],
+        [
+          {
+            "name": "documents",
+            "size": 12
+          }
+        ]
+      ],
+      "list": [
+        "id",
+        "title",
+        "createdAt",
+        "updatedAt"
+      ]
+    },
+    "uid": "api::document-category.document-category"
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/strapi/config/sync/core-store.plugin_content_manager_configuration_content_types##api##document.document.json
+++ b/strapi/config/sync/core-store.plugin_content_manager_configuration_content_types##api##document.document.json
@@ -1,0 +1,195 @@
+{
+  "key": "plugin_content_manager_configuration_content_types::api::document.document",
+  "value": {
+    "settings": {
+      "bulkable": true,
+      "filterable": true,
+      "searchable": true,
+      "pageSize": 10,
+      "mainField": "title",
+      "defaultSortBy": "title",
+      "defaultSortOrder": "ASC"
+    },
+    "metadatas": {
+      "id": {
+        "edit": {},
+        "list": {
+          "label": "id",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "title": {
+        "edit": {
+          "label": "Nadpis",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "title",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "slug": {
+        "edit": {
+          "label": "Slug",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "slug",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "description": {
+        "edit": {
+          "label": "Popis",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "description",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "documentCategory": {
+        "edit": {
+          "label": "Kategória",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "title"
+        },
+        "list": {
+          "label": "documentCategory",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "files": {
+        "edit": {
+          "label": "Súbory",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "files",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "createdAt": {
+        "edit": {
+          "label": "createdAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "createdAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedAt": {
+        "edit": {
+          "label": "updatedAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "updatedAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "createdBy": {
+        "edit": {
+          "label": "createdBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "createdBy",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedBy": {
+        "edit": {
+          "label": "updatedBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "updatedBy",
+          "searchable": true,
+          "sortable": true
+        }
+      }
+    },
+    "layouts": {
+      "edit": [
+        [
+          {
+            "name": "title",
+            "size": 12
+          }
+        ],
+        [
+          {
+            "name": "slug",
+            "size": 12
+          }
+        ],
+        [
+          {
+            "name": "files",
+            "size": 6
+          },
+          {
+            "name": "documentCategory",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "description",
+            "size": 12
+          }
+        ]
+      ],
+      "list": [
+        "id",
+        "title",
+        "slug",
+        "createdAt"
+      ]
+    },
+    "uid": "api::document.document"
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/strapi/schema.graphql
+++ b/strapi/schema.graphql
@@ -1144,6 +1144,29 @@ input ComponentSectionsDividerInput {
   style: ENUM_COMPONENTSECTIONSDIVIDER_STYLE
 }
 
+type ComponentSectionsDocuments {
+  documents(filters: DocumentFiltersInput, pagination: PaginationArg = {}, publicationState: PublicationState = LIVE, sort: [String] = []): DocumentRelationResponseCollection
+  id: ID!
+  text: String
+  title: String
+}
+
+input ComponentSectionsDocumentsFiltersInput {
+  and: [ComponentSectionsDocumentsFiltersInput]
+  documents: DocumentFiltersInput
+  not: ComponentSectionsDocumentsFiltersInput
+  or: [ComponentSectionsDocumentsFiltersInput]
+  text: StringFilterInput
+  title: StringFilterInput
+}
+
+input ComponentSectionsDocumentsInput {
+  documents: [ID]
+  id: ID
+  text: String
+  title: String
+}
+
 type ComponentSectionsFaqCategories {
   faqCategories(filters: FaqCategoryFiltersInput, pagination: PaginationArg = {}, publicationState: PublicationState = LIVE, sort: [String] = []): FaqCategoryRelationResponseCollection
   id: ID!
@@ -1862,6 +1885,102 @@ input DateTimeFilterInput {
   startsWith: DateTime
 }
 
+type Document {
+  createdAt: DateTime
+  description: String
+  documentCategory: DocumentCategoryEntityResponse
+  files(filters: UploadFileFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): UploadFileRelationResponseCollection!
+  publishedAt: DateTime
+  slug: String!
+  title: String!
+  updatedAt: DateTime
+}
+
+type DocumentCategory {
+  createdAt: DateTime
+  documents(filters: DocumentFiltersInput, pagination: PaginationArg = {}, publicationState: PublicationState = LIVE, sort: [String] = []): DocumentRelationResponseCollection
+  slug: String!
+  title: String!
+  updatedAt: DateTime
+}
+
+type DocumentCategoryEntity {
+  attributes: DocumentCategory
+  id: ID
+}
+
+type DocumentCategoryEntityResponse {
+  data: DocumentCategoryEntity
+}
+
+type DocumentCategoryEntityResponseCollection {
+  data: [DocumentCategoryEntity!]!
+  meta: ResponseCollectionMeta!
+}
+
+input DocumentCategoryFiltersInput {
+  and: [DocumentCategoryFiltersInput]
+  createdAt: DateTimeFilterInput
+  documents: DocumentFiltersInput
+  id: IDFilterInput
+  not: DocumentCategoryFiltersInput
+  or: [DocumentCategoryFiltersInput]
+  slug: StringFilterInput
+  title: StringFilterInput
+  updatedAt: DateTimeFilterInput
+}
+
+input DocumentCategoryInput {
+  documents: [ID]
+  slug: String
+  title: String
+}
+
+type DocumentCategoryRelationResponseCollection {
+  data: [DocumentCategoryEntity!]!
+}
+
+type DocumentEntity {
+  attributes: Document
+  id: ID
+}
+
+type DocumentEntityResponse {
+  data: DocumentEntity
+}
+
+type DocumentEntityResponseCollection {
+  data: [DocumentEntity!]!
+  meta: ResponseCollectionMeta!
+}
+
+input DocumentFiltersInput {
+  and: [DocumentFiltersInput]
+  createdAt: DateTimeFilterInput
+  description: StringFilterInput
+  documentCategory: DocumentCategoryFiltersInput
+  id: IDFilterInput
+  not: DocumentFiltersInput
+  or: [DocumentFiltersInput]
+  publishedAt: DateTimeFilterInput
+  slug: StringFilterInput
+  title: StringFilterInput
+  updatedAt: DateTimeFilterInput
+}
+
+input DocumentInput {
+  description: String
+  documentCategory: ID
+  files: [ID]
+  publishedAt: DateTime
+  slug: String
+  title: String
+}
+
+type DocumentRelationResponseCollection {
+  data: [DocumentEntity!]!
+}
+
 enum ENUM_COMPONENTACCORDIONITEMSFLATTEXT_ALIGN {
   center
   left
@@ -2331,7 +2450,7 @@ type GeneralRelationResponseCollection {
   data: [GeneralEntity!]!
 }
 
-union GenericMorph = AdminGroup | Alert | Article | BlogPost | ComponentAccordionItemsFlatText | ComponentAccordionItemsInstitution | ComponentAccordionItemsInstitutionNarrow | ComponentBlocksColumnsItem | ComponentBlocksCommonLink | ComponentBlocksComparisonCard | ComponentBlocksComparisonItem | ComponentBlocksContactCard | ComponentBlocksContactPersonCard | ComponentBlocksFile | ComponentBlocksFileItem | ComponentBlocksFooterColumn | ComponentBlocksHomepageHighlightsItem | ComponentBlocksIconWithTitleAndDescription | ComponentBlocksInBa | ComponentBlocksNumericalListItem | ComponentBlocksPageLink | ComponentBlocksPartner | ComponentBlocksProsAndConsCard | ComponentBlocksTimelineItem | ComponentBlocksTopServicesItem | ComponentBlocksVideo | ComponentGeneralHeader | ComponentGeneralHeaderLink | ComponentMenuMenuItem | ComponentMenuMenuLink | ComponentMenuMenuSection | ComponentSectionsAccordion | ComponentSectionsArticles | ComponentSectionsBanner | ComponentSectionsCalculator | ComponentSectionsColumnedText | ComponentSectionsColumns | ComponentSectionsComparisonSection | ComponentSectionsContactsSection | ComponentSectionsDivider | ComponentSectionsFaqCategories | ComponentSectionsFaqs | ComponentSectionsFileList | ComponentSectionsGallery | ComponentSectionsHomepageEvents | ComponentSectionsHomepageHighlights | ComponentSectionsHomepageMayorAndCouncil | ComponentSectionsHomepageTabs | ComponentSectionsIconTitleDesc | ComponentSectionsIframe | ComponentSectionsInbaArticlesList | ComponentSectionsInbaReleases | ComponentSectionsLinks | ComponentSectionsNarrowText | ComponentSectionsNumericalList | ComponentSectionsOfficialBoard | ComponentSectionsOrganizationalStructure | ComponentSectionsPartners | ComponentSectionsProsAndConsSection | ComponentSectionsRegulations | ComponentSectionsRegulationsList | ComponentSectionsSubpageList | ComponentSectionsTextWithImage | ComponentSectionsTextWithImageOverlapped | ComponentSectionsTimeline | ComponentSectionsTootootEvents | ComponentSectionsTopServices | ComponentSectionsVideos | ComponentTaxAdministratorsTaxAdministrator | Faq | FaqCategory | Footer | General | Homepage | I18NLocale | InbaArticle | InbaRelease | InbaTag | Menu | Page | PageCategory | Regulation | Tag | TaxAdministratorsList | UploadFile | UploadFolder | UsersPermissionsPermission | UsersPermissionsRole | UsersPermissionsUser
+union GenericMorph = AdminGroup | Alert | Article | BlogPost | ComponentAccordionItemsFlatText | ComponentAccordionItemsInstitution | ComponentAccordionItemsInstitutionNarrow | ComponentBlocksColumnsItem | ComponentBlocksCommonLink | ComponentBlocksComparisonCard | ComponentBlocksComparisonItem | ComponentBlocksContactCard | ComponentBlocksContactPersonCard | ComponentBlocksFile | ComponentBlocksFileItem | ComponentBlocksFooterColumn | ComponentBlocksHomepageHighlightsItem | ComponentBlocksIconWithTitleAndDescription | ComponentBlocksInBa | ComponentBlocksNumericalListItem | ComponentBlocksPageLink | ComponentBlocksPartner | ComponentBlocksProsAndConsCard | ComponentBlocksTimelineItem | ComponentBlocksTopServicesItem | ComponentBlocksVideo | ComponentGeneralHeader | ComponentGeneralHeaderLink | ComponentMenuMenuItem | ComponentMenuMenuLink | ComponentMenuMenuSection | ComponentSectionsAccordion | ComponentSectionsArticles | ComponentSectionsBanner | ComponentSectionsCalculator | ComponentSectionsColumnedText | ComponentSectionsColumns | ComponentSectionsComparisonSection | ComponentSectionsContactsSection | ComponentSectionsDivider | ComponentSectionsDocuments | ComponentSectionsFaqCategories | ComponentSectionsFaqs | ComponentSectionsFileList | ComponentSectionsGallery | ComponentSectionsHomepageEvents | ComponentSectionsHomepageHighlights | ComponentSectionsHomepageMayorAndCouncil | ComponentSectionsHomepageTabs | ComponentSectionsIconTitleDesc | ComponentSectionsIframe | ComponentSectionsInbaArticlesList | ComponentSectionsInbaReleases | ComponentSectionsLinks | ComponentSectionsNarrowText | ComponentSectionsNumericalList | ComponentSectionsOfficialBoard | ComponentSectionsOrganizationalStructure | ComponentSectionsPartners | ComponentSectionsProsAndConsSection | ComponentSectionsRegulations | ComponentSectionsRegulationsList | ComponentSectionsSubpageList | ComponentSectionsTextWithImage | ComponentSectionsTextWithImageOverlapped | ComponentSectionsTimeline | ComponentSectionsTootootEvents | ComponentSectionsTopServices | ComponentSectionsVideos | ComponentTaxAdministratorsTaxAdministrator | Document | DocumentCategory | Faq | FaqCategory | Footer | General | Homepage | I18NLocale | InbaArticle | InbaRelease | InbaTag | Menu | Page | PageCategory | Regulation | Tag | TaxAdministratorsList | UploadFile | UploadFolder | UsersPermissionsPermission | UsersPermissionsRole | UsersPermissionsUser
 
 type Homepage {
   createdAt: DateTime
@@ -2781,6 +2900,8 @@ type Mutation {
   createArticleLocalization(data: ArticleInput, id: ID, locale: I18NLocaleCode): ArticleEntityResponse
   createBlogPost(data: BlogPostInput!, locale: I18NLocaleCode): BlogPostEntityResponse
   createBlogPostLocalization(data: BlogPostInput, id: ID, locale: I18NLocaleCode): BlogPostEntityResponse
+  createDocument(data: DocumentInput!): DocumentEntityResponse
+  createDocumentCategory(data: DocumentCategoryInput!): DocumentCategoryEntityResponse
   createFaq(data: FaqInput!, locale: I18NLocaleCode): FaqEntityResponse
   createFaqCategory(data: FaqCategoryInput!, locale: I18NLocaleCode): FaqCategoryEntityResponse
   createFaqCategoryLocalization(data: FaqCategoryInput, id: ID, locale: I18NLocaleCode): FaqCategoryEntityResponse
@@ -2813,6 +2934,8 @@ type Mutation {
   deleteAlert(locale: I18NLocaleCode): AlertEntityResponse
   deleteArticle(id: ID!, locale: I18NLocaleCode): ArticleEntityResponse
   deleteBlogPost(id: ID!, locale: I18NLocaleCode): BlogPostEntityResponse
+  deleteDocument(id: ID!): DocumentEntityResponse
+  deleteDocumentCategory(id: ID!): DocumentCategoryEntityResponse
   deleteFaq(id: ID!, locale: I18NLocaleCode): FaqEntityResponse
   deleteFaqCategory(id: ID!, locale: I18NLocaleCode): FaqCategoryEntityResponse
   deleteFooter(locale: I18NLocaleCode): FooterEntityResponse
@@ -2856,6 +2979,8 @@ type Mutation {
   updateAlert(data: AlertInput!, locale: I18NLocaleCode): AlertEntityResponse
   updateArticle(data: ArticleInput!, id: ID!, locale: I18NLocaleCode): ArticleEntityResponse
   updateBlogPost(data: BlogPostInput!, id: ID!, locale: I18NLocaleCode): BlogPostEntityResponse
+  updateDocument(data: DocumentInput!, id: ID!): DocumentEntityResponse
+  updateDocumentCategory(data: DocumentCategoryInput!, id: ID!): DocumentCategoryEntityResponse
   updateFaq(data: FaqInput!, id: ID!, locale: I18NLocaleCode): FaqEntityResponse
   updateFaqCategory(data: FaqCategoryInput!, id: ID!, locale: I18NLocaleCode): FaqCategoryEntityResponse
   updateFileInfo(id: ID!, info: FileInfoInput): UploadFileEntityResponse!
@@ -3030,7 +3155,7 @@ type PageRelationResponseCollection {
   data: [PageEntity!]!
 }
 
-union PageSectionsDynamicZone = ComponentSectionsAccordion | ComponentSectionsArticles | ComponentSectionsBanner | ComponentSectionsCalculator | ComponentSectionsColumnedText | ComponentSectionsColumns | ComponentSectionsComparisonSection | ComponentSectionsContactsSection | ComponentSectionsDivider | ComponentSectionsFaqCategories | ComponentSectionsFaqs | ComponentSectionsFileList | ComponentSectionsGallery | ComponentSectionsIconTitleDesc | ComponentSectionsIframe | ComponentSectionsInbaArticlesList | ComponentSectionsInbaReleases | ComponentSectionsLinks | ComponentSectionsNarrowText | ComponentSectionsNumericalList | ComponentSectionsOfficialBoard | ComponentSectionsOrganizationalStructure | ComponentSectionsPartners | ComponentSectionsProsAndConsSection | ComponentSectionsRegulations | ComponentSectionsRegulationsList | ComponentSectionsTextWithImage | ComponentSectionsTextWithImageOverlapped | ComponentSectionsTimeline | ComponentSectionsTootootEvents | ComponentSectionsVideos | Error
+union PageSectionsDynamicZone = ComponentSectionsAccordion | ComponentSectionsArticles | ComponentSectionsBanner | ComponentSectionsCalculator | ComponentSectionsColumnedText | ComponentSectionsColumns | ComponentSectionsComparisonSection | ComponentSectionsContactsSection | ComponentSectionsDivider | ComponentSectionsDocuments | ComponentSectionsFaqCategories | ComponentSectionsFaqs | ComponentSectionsFileList | ComponentSectionsGallery | ComponentSectionsIconTitleDesc | ComponentSectionsIframe | ComponentSectionsInbaArticlesList | ComponentSectionsInbaReleases | ComponentSectionsLinks | ComponentSectionsNarrowText | ComponentSectionsNumericalList | ComponentSectionsOfficialBoard | ComponentSectionsOrganizationalStructure | ComponentSectionsPartners | ComponentSectionsProsAndConsSection | ComponentSectionsRegulations | ComponentSectionsRegulationsList | ComponentSectionsTextWithImage | ComponentSectionsTextWithImageOverlapped | ComponentSectionsTimeline | ComponentSectionsTootootEvents | ComponentSectionsVideos | Error
 
 scalar PageSectionsDynamicZoneInput
 
@@ -3061,6 +3186,10 @@ type Query {
   articles(filters: ArticleFiltersInput, locale: I18NLocaleCode, pagination: PaginationArg = {}, publicationState: PublicationState = LIVE, sort: [String] = []): ArticleEntityResponseCollection
   blogPost(id: ID, locale: I18NLocaleCode): BlogPostEntityResponse
   blogPosts(filters: BlogPostFiltersInput, locale: I18NLocaleCode, pagination: PaginationArg = {}, publicationState: PublicationState = LIVE, sort: [String] = []): BlogPostEntityResponseCollection
+  document(id: ID): DocumentEntityResponse
+  documentCategories(filters: DocumentCategoryFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): DocumentCategoryEntityResponseCollection
+  documentCategory(id: ID): DocumentCategoryEntityResponse
+  documents(filters: DocumentFiltersInput, pagination: PaginationArg = {}, publicationState: PublicationState = LIVE, sort: [String] = []): DocumentEntityResponseCollection
   faq(id: ID, locale: I18NLocaleCode): FaqEntityResponse
   faqCategories(filters: FaqCategoryFiltersInput, locale: I18NLocaleCode, pagination: PaginationArg = {}, publicationState: PublicationState = LIVE, sort: [String] = []): FaqCategoryEntityResponseCollection
   faqCategory(id: ID, locale: I18NLocaleCode): FaqCategoryEntityResponse

--- a/strapi/src/api/document-category/content-types/document-category/schema.json
+++ b/strapi/src/api/document-category/content-types/document-category/schema.json
@@ -1,0 +1,31 @@
+{
+  "kind": "collectionType",
+  "collectionName": "document_categories",
+  "info": {
+    "singularName": "document-category",
+    "pluralName": "document-categories",
+    "displayName": "Dokumenty - kategórie",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title",
+      "required": true
+    },
+    "documents": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::document.document",
+      "mappedBy": "documentCategory"
+    }
+  }
+}

--- a/strapi/src/api/document-category/controllers/document-category.ts
+++ b/strapi/src/api/document-category/controllers/document-category.ts
@@ -1,0 +1,7 @@
+/**
+ * document-category controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::document-category.document-category');

--- a/strapi/src/api/document-category/routes/document-category.ts
+++ b/strapi/src/api/document-category/routes/document-category.ts
@@ -1,0 +1,7 @@
+/**
+ * document-category router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::document-category.document-category');

--- a/strapi/src/api/document-category/services/document-category.ts
+++ b/strapi/src/api/document-category/services/document-category.ts
@@ -1,0 +1,7 @@
+/**
+ * document-category service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::document-category.document-category');

--- a/strapi/src/api/document/content-types/document/schema.json
+++ b/strapi/src/api/document/content-types/document/schema.json
@@ -1,0 +1,40 @@
+{
+  "kind": "collectionType",
+  "collectionName": "documents",
+  "info": {
+    "singularName": "document",
+    "pluralName": "documents",
+    "displayName": "Dokumenty",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title",
+      "required": true
+    },
+    "files": {
+      "type": "media",
+      "multiple": true,
+      "required": true,
+      "allowedTypes": ["images", "files"]
+    },
+    "description": {
+      "type": "text"
+    },
+    "documentCategory": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::document-category.document-category",
+      "inversedBy": "documents"
+    }
+  }
+}

--- a/strapi/src/api/document/controllers/document.ts
+++ b/strapi/src/api/document/controllers/document.ts
@@ -1,0 +1,7 @@
+/**
+ * document controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::document.document');

--- a/strapi/src/api/document/routes/document.ts
+++ b/strapi/src/api/document/routes/document.ts
@@ -1,0 +1,7 @@
+/**
+ * document router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::document.document');

--- a/strapi/src/api/document/services/document.ts
+++ b/strapi/src/api/document/services/document.ts
@@ -1,0 +1,7 @@
+/**
+ * document service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::document.document');

--- a/strapi/src/api/page/content-types/page/schema.json
+++ b/strapi/src/api/page/content-types/page/schema.json
@@ -78,25 +78,13 @@
         }
       },
       "type": "enumeration",
-      "enum": [
-        "red",
-        "blue",
-        "green",
-        "yellow",
-        "purple",
-        "brown"
-      ]
+      "enum": ["red", "blue", "green", "yellow", "purple", "brown"]
     },
     "pageBackgroundImage": {
       "type": "media",
       "multiple": false,
       "required": false,
-      "allowedTypes": [
-        "images",
-        "files",
-        "videos",
-        "audios"
-      ],
+      "allowedTypes": ["images", "files", "videos", "audios"],
       "pluginOptions": {
         "i18n": {
           "localized": true
@@ -120,9 +108,7 @@
         }
       },
       "type": "dynamiczone",
-      "components": [
-        "sections.subpage-list"
-      ]
+      "components": ["sections.subpage-list"]
     },
     "sections": {
       "pluginOptions": {
@@ -141,6 +127,7 @@
         "sections.comparison-section",
         "sections.contacts-section",
         "sections.divider",
+        "sections.documents",
         "sections.faqs",
         "sections.faq-categories",
         "sections.file-list",

--- a/strapi/src/components/sections/documents.json
+++ b/strapi/src/components/sections/documents.json
@@ -1,0 +1,22 @@
+{
+  "collectionName": "components_sections_documents",
+  "info": {
+    "displayName": "Documents",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "default": "Dokumenty"
+    },
+    "text": {
+      "type": "text"
+    },
+    "documents": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::document.document"
+    }
+  }
+}

--- a/strapi/types/generated/components.d.ts
+++ b/strapi/types/generated/components.d.ts
@@ -608,6 +608,19 @@ export interface SectionsDivider extends Schema.Component {
   }
 }
 
+export interface SectionsDocuments extends Schema.Component {
+  collectionName: 'components_sections_documents'
+  info: {
+    description: ''
+    displayName: 'Documents'
+  }
+  attributes: {
+    documents: Attribute.Relation<'sections.documents', 'oneToMany', 'api::document.document'>
+    text: Attribute.Text
+    title: Attribute.String & Attribute.DefaultTo<'Dokumenty'>
+  }
+}
+
 export interface SectionsFaqCategories extends Schema.Component {
   collectionName: 'components_sections_faq_categories'
   info: {
@@ -1044,6 +1057,7 @@ declare module '@strapi/types' {
       'sections.comparison-section': SectionsComparisonSection
       'sections.contacts-section': SectionsContactsSection
       'sections.divider': SectionsDivider
+      'sections.documents': SectionsDocuments
       'sections.faq-categories': SectionsFaqCategories
       'sections.faqs': SectionsFaqs
       'sections.file-list': SectionsFileList

--- a/strapi/types/generated/contentTypes.d.ts
+++ b/strapi/types/generated/contentTypes.d.ts
@@ -541,6 +541,73 @@ export interface ApiBlogPostBlogPost extends Schema.CollectionType {
   }
 }
 
+export interface ApiDocumentCategoryDocumentCategory extends Schema.CollectionType {
+  collectionName: 'document_categories'
+  info: {
+    description: ''
+    displayName: 'Dokumenty - kateg\u00F3rie'
+    pluralName: 'document-categories'
+    singularName: 'document-category'
+  }
+  options: {
+    draftAndPublish: false
+  }
+  attributes: {
+    createdAt: Attribute.DateTime
+    createdBy: Attribute.Relation<
+      'api::document-category.document-category',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private
+    documents: Attribute.Relation<
+      'api::document-category.document-category',
+      'oneToMany',
+      'api::document.document'
+    >
+    slug: Attribute.UID<'api::document-category.document-category', 'title'> & Attribute.Required
+    title: Attribute.String & Attribute.Required
+    updatedAt: Attribute.DateTime
+    updatedBy: Attribute.Relation<
+      'api::document-category.document-category',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private
+  }
+}
+
+export interface ApiDocumentDocument extends Schema.CollectionType {
+  collectionName: 'documents'
+  info: {
+    description: ''
+    displayName: 'Dokumenty'
+    pluralName: 'documents'
+    singularName: 'document'
+  }
+  options: {
+    draftAndPublish: true
+  }
+  attributes: {
+    createdAt: Attribute.DateTime
+    createdBy: Attribute.Relation<'api::document.document', 'oneToOne', 'admin::user'> &
+      Attribute.Private
+    description: Attribute.Text
+    documentCategory: Attribute.Relation<
+      'api::document.document',
+      'manyToOne',
+      'api::document-category.document-category'
+    >
+    files: Attribute.Media<'images' | 'files', true> & Attribute.Required
+    publishedAt: Attribute.DateTime
+    slug: Attribute.UID<'api::document.document', 'title'> & Attribute.Required
+    title: Attribute.String & Attribute.Required
+    updatedAt: Attribute.DateTime
+    updatedBy: Attribute.Relation<'api::document.document', 'oneToOne', 'admin::user'> &
+      Attribute.Private
+  }
+}
+
 export interface ApiFaqCategoryFaqCategory extends Schema.CollectionType {
   collectionName: 'faq_categories'
   info: {
@@ -1199,6 +1266,7 @@ export interface ApiPagePage extends Schema.CollectionType {
         'sections.comparison-section',
         'sections.contacts-section',
         'sections.divider',
+        'sections.documents',
         'sections.faqs',
         'sections.faq-categories',
         'sections.file-list',
@@ -1754,6 +1822,8 @@ declare module '@strapi/types' {
       'api::alert.alert': ApiAlertAlert
       'api::article.article': ApiArticleArticle
       'api::blog-post.blog-post': ApiBlogPostBlogPost
+      'api::document-category.document-category': ApiDocumentCategoryDocumentCategory
+      'api::document.document': ApiDocumentDocument
       'api::faq-category.faq-category': ApiFaqCategoryFaqCategory
       'api::faq.faq': ApiFaqFaq
       'api::footer.footer': ApiFooterFooter


### PR DESCRIPTION
- create new content types for Documents and Document Categories
- create new section
- export config-sync (add rights also to Admin, even though there is no FE yet, but Admins will see the new section nevertheless)

TODOs
- FE