### PR TITLE
#1611 Add documentsFetcher and use it in search

### DIFF
--- a/next/public/locales/en/translation.json
+++ b/next/public/locales/en/translation.json
@@ -130,6 +130,7 @@
   "SearchPage.contact": "Contact",
   "SearchPage.contacts": "Contacts",
   "SearchPage.document": "Document",
+  "SearchPage.documents": "Documents",
   "SearchPage.enterKeyword": "Enter a keyword",
   "SearchPage.enterSearchQuery": "Enter a search query",
   "SearchPage.inbaArticle": "in.ba article",

--- a/next/public/locales/sk/translation.json
+++ b/next/public/locales/sk/translation.json
@@ -138,6 +138,7 @@
   "SearchPage.contact": "Kontakt",
   "SearchPage.contacts": "Kontakty",
   "SearchPage.document": "Dokument",
+  "SearchPage.documents": "Dokumenty",
   "SearchPage.enterKeyword": "Zadajte kľúčové slovo",
   "SearchPage.enterSearchQuery": "Zadajte hľadaný výraz",
   "SearchPage.inbaArticle": "in.ba článok",

--- a/next/src/components/sections/SearchSection/GlobalSearchSectionContent.tsx
+++ b/next/src/components/sections/SearchSection/GlobalSearchSectionContent.tsx
@@ -14,16 +14,7 @@ import { officialBoardListDefaultFilters } from '@/src/services/ginis/fetchers/o
 import { OfficialBoardPublicationState } from '@/src/services/ginis/types'
 import { getCategoryColorLocalStyle } from '@/src/utils/colors'
 import { useTranslation } from '@/src/utils/useTranslation'
-/*
- * RAC library recommends Selection as type for selection state, which is of type `'all' | Set`.
- * To use standard operations on Set, you have to check if selection is not 'all' to satisfy Typescript.
- * Even though we never use 'all' for selection, because it acts differently than we want.
- */
-/*
- * RAC library recommends Selection as type for selection state, which is of type `'all' | Set`.
- * To use standard operations on Set, you have to check if selection is not 'all' to satisfy Typescript.
- * Even though we never use 'all' for selection, because it acts differently than we want.
- */
+import { isProductionDeployment } from '@/src/utils/utils'
 
 /*
  * RAC library recommends Selection as type for selection state, which is of type `'all' | Set`.
@@ -36,6 +27,7 @@ export type SearchOption = {
     | 'allResults'
     | 'pages'
     | 'articles'
+    | 'documents'
     | 'inbaArticles'
     | 'regulations'
     | 'users'
@@ -82,6 +74,16 @@ const GlobalSearchSectionContent = ({ variant, searchOption }: Props) => {
       displayName: t('SearchPage.article'),
       displayNamePlural: t('SearchPage.articles'),
     },
+    // Show Documents only if not in prod - TODO remove when ready to use according to OSO
+    ...(isProductionDeployment()
+      ? []
+      : [
+          {
+            id: 'documents' as const,
+            displayName: t('SearchPage.document'),
+            displayNamePlural: t('SearchPage.documents'),
+          },
+        ]),
     // {
     //   id: 'inbaArticles',
     //   displayName: t('SearchPage.inbaArticle'),

--- a/next/src/components/sections/SearchSection/useQueryBySearchOption.ts
+++ b/next/src/components/sections/SearchSection/useQueryBySearchOption.ts
@@ -14,6 +14,10 @@ import {
   getArticlesQueryKey,
 } from '@/src/services/meili/fetchers/articlesFetcher'
 import {
+  documentsFetcher,
+  getDocumentsQueryKey,
+} from '@/src/services/meili/fetchers/documentsFetcher'
+import {
   getInbaArticlesQueryKey,
   inbaArticlesFetcher,
   InbaArticlesFilters,
@@ -97,16 +101,36 @@ export const useQueryBySearchOption = ({
     placeholderData: keepPreviousData,
     select: (data) => {
       const formattedData: SearchResult[] =
-        data?.hits?.map((articles): SearchResult => {
+        data?.hits?.map((article): SearchResult => {
           return {
-            title: articles.attributes?.title,
-            uniqueId: articles.attributes?.slug,
-            linkHref: `/spravy/${articles.attributes?.slug}`,
+            title: article.attributes?.title,
+            uniqueId: article.attributes?.slug,
+            linkHref: `/spravy/${article.attributes?.slug}`,
             metadata: [
-              articles.attributes?.tag?.data?.attributes?.title,
-              formatDate(articles.attributes?.addedAt),
+              article.attributes?.tag?.data?.attributes?.title,
+              formatDate(article.attributes?.addedAt),
             ],
-            coverImageSrc: articles.attributes?.coverMedia?.data?.attributes?.url,
+            coverImageSrc: article.attributes?.coverMedia?.data?.attributes?.url,
+          }
+        }) ?? []
+
+      return { searchResultsData: formattedData, searchResultsCount: data?.estimatedTotalHits ?? 0 }
+    },
+  })
+
+  const documentsQuery = useQuery({
+    queryKey: getDocumentsQueryKey(filters),
+    queryFn: () => documentsFetcher(filters),
+    placeholderData: keepPreviousData,
+    select: (data) => {
+      const formattedData: SearchResult[] =
+        data?.hits?.map((document): SearchResult => {
+          return {
+            title: document.title,
+            uniqueId: document.slug,
+            linkHref: `/dokumenty/${document.slug}`,
+            metadata: [document.documentCategory?.title, formatDate(document.updatedAt)],
+            customIconName: 'search_result_official_board',
           }
         }) ?? []
 
@@ -239,6 +263,9 @@ export const useQueryBySearchOption = ({
 
     case 'articles':
       return articlesQuery
+
+    case 'documents':
+      return documentsQuery
 
     case 'inbaArticles':
       return inbaArticlesQuery

--- a/next/src/services/meili/fetchers/documentsFetcher.ts
+++ b/next/src/services/meili/fetchers/documentsFetcher.ts
@@ -1,0 +1,28 @@
+import { meiliClient } from '../meiliClient'
+import { DocumentMeili, SearchIndexWrapped } from '../types'
+import { getMeilisearchPageOptions, unwrapFromSearchIndex } from '../utils'
+
+export type DocumentFilters = {
+  search: string
+  pageSize: number
+  page: number
+}
+
+export const DocumentDefaultFilters: DocumentFilters = {
+  search: '',
+  pageSize: 9,
+  page: 1,
+}
+
+export const getDocumentsQueryKey = (filters: DocumentFilters) => ['Search', 'Documents', filters]
+
+export const documentsFetcher = (filters: DocumentFilters) => {
+  return meiliClient
+    .index('search_index')
+    .search<SearchIndexWrapped<'document', DocumentMeili>>(filters.search, {
+      ...getMeilisearchPageOptions({ page: filters.page, pageSize: filters.pageSize }),
+      filter: ['type = "document"'],
+      sort: ['document.updatedAtTimestamp:desc'],
+    })
+    .then(unwrapFromSearchIndex('document'))
+}

--- a/next/src/services/meili/types.ts
+++ b/next/src/services/meili/types.ts
@@ -1,6 +1,8 @@
 import {
   Article,
   ArticleEntity,
+  Document,
+  DocumentCategory,
   InbaArticle,
   InbaTag,
   Page,
@@ -47,6 +49,10 @@ export type ArticleMeili = Pick<ArticleEntity, 'id'> &
       pageCategory?: Omit<PageCategory, '__typename' | 'pages'>
     }
   }
+
+export type DocumentMeili = Omit<Document, '__typename' | 'documentCategory' | 'files'> & {
+  documentCategory?: Omit<DocumentCategory, '__typename' | 'documents'>
+}
 
 export type InbaArticleMeili = Omit<InbaArticle, '__typename' | 'tags' | 'coverImage'> & {
   coverImage?: UploadFile

--- a/next/src/utils/utils.ts
+++ b/next/src/utils/utils.ts
@@ -3,9 +3,4 @@ export const isPresent = <U>(a: U | null | undefined | void): a is U => {
   return a !== undefined && a !== null
 }
 
-const isServer = () => typeof window === 'undefined'
-
-// TODO replace by `useIsClient` hook from `usehooks-ts`
-export const isBrowser = () => !isServer()
-
 export const isProductionDeployment = () => process.env.NEXT_PUBLIC_DEPLOYMENT === 'prod'

--- a/strapi/config/plugins.meilisearch.config.ts
+++ b/strapi/config/plugins.meilisearch.config.ts
@@ -29,37 +29,34 @@ const searchIndexSettings = {
     'article.perex',
     'blog-post.title',
     'blog-post.excerpt',
+    'document.title',
+    'document.description',
     'inba-article.title',
     'regulation.regNumber',
     'regulation.titleText',
     'regulation.fullTitle',
   ],
   filterableAttributes: [
-    // All
     'type',
-    // Page + Blog post + Article + Inba article
     'locale',
     'article.tag.id',
     'blog-post.tag.id',
+    'document.documentCategory.id',
     'inba-article.inbaTag.id',
-    // Regulation
     'regulation.category',
   ],
   sortableAttributes: [
-    // Article
     'article.title',
     'article.addedAtTimestamp',
-    // Blog post
     'blog-post.title',
     'blog-post.addedAtTimestamp',
-    // Inba article
+    'document.publishedAtTimestamp',
+    'document.updatedAtTimestamp',
     'inba-article.title',
     'inba-article.publishedAtTimestamp',
-    // Vzn
     'vzn.validFrom',
     'vzn.publishedAt', // TODO is it needed?
     'vzn.publishedAtTimestamp',
-    // Regulation
     'regulation.effectiveFromTimestamp',
   ],
   pagination: {
@@ -108,6 +105,21 @@ const config = {
         // Meilisearch doesn't support filtering dates as ISO strings, therefore we convert it to UNIX timestamp to
         // use (number) filters.
         addedAtTimestamp: entry.addedAt ? new Date(entry.addedAt).getTime() : undefined,
+      }),
+  },
+  document: {
+    indexName: 'search_index',
+    entriesQuery: {
+      locale: 'all',
+    },
+    settings: searchIndexSettings,
+    transformEntry: ({ entry }) =>
+      wrapSearchIndexEntry('document', {
+        ...entry,
+        // Meilisearch doesn't support filtering dates as ISO strings, therefore we convert it to UNIX timestamp to
+        // use (number) filters.
+        publishedAtTimestamp: entry.publishedAt ? new Date(entry.publishedAt).getTime() : undefined,
+        updatedAtTimestamp: entry.updatedAt ? new Date(entry.updatedAt).getTime() : undefined,
       }),
   },
   'inba-article': {


### PR DESCRIPTION
Description

- add documents meilisearch config
- add `documentsFetcher`
- add new search option for documents - hidden on production until ready (OSO needs to add Documents in Strapi and use them accros the web)
- remove unused `isClient` and `isServer` util functions - if needed, we can use `usehooks-ts` lib hooks
- remove duplicated comment

Testing

- create some documents in your local strapi
- index them in meilisearch settings
- open Vyhladavanie page and try to search in them

TODO
- add showAll field to Documents section and show "specific search results" if true, to be able to create Documents parent page