### PR TITLE
#1569 Temporarily add articles to Inba Release detail page using graphql

### DIFF
--- a/next/public/locales/en/translation.json
+++ b/next/public/locales/en/translation.json
@@ -53,6 +53,7 @@
   "HomepageTabs.tabs.RoadClosures": "Road closures",
   "InbaArticle.publishedInThisRelease": "This article was published in the issue {{releaseTitle}} on {{releaseDate}}.",
   "InbaArticlesFilter.articleFilter": "Articles filter",
+  "InbaRelease.articlesInThisRelease": "Articles in this issue",
   "InbaRelease.inThisRelease": "In this issue",
   "InbaRelease.releaseDetail": "Issue detail",
   "InbaRelease.releasedOn": "Published on {{date}}",

--- a/next/public/locales/sk/translation.json
+++ b/next/public/locales/sk/translation.json
@@ -57,6 +57,7 @@
   "HomepageTabs.tabs.RoadClosures": "Rozkopávky",
   "InbaArticle.publishedInThisRelease": "Publikované v čísle {{releaseTitle}}, ktoré vyšlo {{releaseDate}}.",
   "InbaArticlesFilter.articleFilter": "Filter článkov",
+  "InbaRelease.articlesInThisRelease": "Články v tomto čísle",
   "InbaRelease.inThisRelease": "V tomto čísle nájdete",
   "InbaRelease.releaseDetail": "Detail čísla",
   "InbaRelease.releasedOn": "Publikované {{date}}",

--- a/next/src/services/graphql/index.ts
+++ b/next/src/services/graphql/index.ts
@@ -8888,6 +8888,37 @@ export type InbaReleaseBySlugQuery = {
             } | null
           } | null
         } | null> | null
+        inbaArticles?: {
+          __typename?: 'InbaArticleRelationResponseCollection'
+          data: Array<{
+            __typename?: 'InbaArticleEntity'
+            id?: string | null
+            attributes?: {
+              __typename?: 'InbaArticle'
+              perex?: string | null
+              publishedAt?: any | null
+              slug: string
+              title: string
+              locale?: string | null
+              coverImage?: {
+                __typename?: 'UploadFileEntityResponse'
+                data?: {
+                  __typename?: 'UploadFileEntity'
+                  id?: string | null
+                  attributes?: { __typename?: 'UploadFile'; url: string } | null
+                } | null
+              } | null
+              inbaTag?: {
+                __typename?: 'InbaTagEntityResponse'
+                data?: {
+                  __typename?: 'InbaTagEntity'
+                  id?: string | null
+                  attributes?: { __typename?: 'InbaTag'; title: string } | null
+                } | null
+              } | null
+            } | null
+          }>
+        } | null
       } | null
     }>
   } | null
@@ -8996,6 +9027,37 @@ export type InbaReleaseEntityFragment = {
         } | null
       } | null
     } | null> | null
+    inbaArticles?: {
+      __typename?: 'InbaArticleRelationResponseCollection'
+      data: Array<{
+        __typename?: 'InbaArticleEntity'
+        id?: string | null
+        attributes?: {
+          __typename?: 'InbaArticle'
+          perex?: string | null
+          publishedAt?: any | null
+          slug: string
+          title: string
+          locale?: string | null
+          coverImage?: {
+            __typename?: 'UploadFileEntityResponse'
+            data?: {
+              __typename?: 'UploadFileEntity'
+              id?: string | null
+              attributes?: { __typename?: 'UploadFile'; url: string } | null
+            } | null
+          } | null
+          inbaTag?: {
+            __typename?: 'InbaTagEntityResponse'
+            data?: {
+              __typename?: 'InbaTagEntity'
+              id?: string | null
+              attributes?: { __typename?: 'InbaTag'; title: string } | null
+            } | null
+          } | null
+        } | null
+      }>
+    } | null
   } | null
 }
 
@@ -15852,10 +15914,16 @@ export const InbaReleaseEntityFragmentDoc = gql`
           }
         }
       }
+      inbaArticles {
+        data {
+          ...InbaArticleCardEntity
+        }
+      }
     }
   }
   ${UploadImageEntityFragmentDoc}
   ${UploadFileEntityFragmentDoc}
+  ${InbaArticleCardEntityFragmentDoc}
 `
 export const DividerSectionFragmentDoc = gql`
   fragment DividerSection on ComponentSectionsDivider {

--- a/next/src/services/graphql/queries/InbaReleases.graphql
+++ b/next/src/services/graphql/queries/InbaReleases.graphql
@@ -64,5 +64,10 @@ fragment InbaReleaseEntity on InbaReleaseEntity {
         }
       }
     }
+    inbaArticles {
+      data {
+        ...InbaArticleCardEntity
+      }
+    }
   }
 }


### PR DESCRIPTION
**Description**
- add related Inba Articles to Inba Release detail page
  - I wrote this solution, then I realised we need pagination, and that will be probably better done with meilisearch fetcher and useQuery + prefetch instead of SSR
  - but I think we can merge this solution until the better one is implemented

**TODOs**
- pagination
- upper part of detail page redesign

**Screenshots**

![image](https://github.com/user-attachments/assets/2d6280fc-adc3-4bea-b103-26f5f893f85e)
