### PR TITLE
#1662 starz articles automatic sport tag for starz articles

### DIFF
--- a/strapi/src/customizations/document-service-middlewares.ts
+++ b/strapi/src/customizations/document-service-middlewares.ts
@@ -17,13 +17,13 @@ const getAdminGroup = async ({
     })
 
     if (adminGroups.length === 0) {
-      console.log('no adminGroup with adminGroupId=' + adminGroupId + ' found')
+      console.log('No adminGroup with adminGroupId=' + adminGroupId + ' found')
     }
 
     // adminGroupId has unique values, so we get at most one result
     return adminGroups[0]
   } catch (error) {
-    console.log('getAdminGroup failed with error', error)
+    console.log('Function getAdminGroup failed with error', error)
   }
 }
 
@@ -61,7 +61,7 @@ export const registerDocumentServiceMiddlewares = ({ strapi }: { strapi: Core.St
           return new RegExp(STARZ_ROLE_NAME_REGEX, 'i').test(role.name)
         })
       ) {
-        // Add admingroup based on document creator
+        // Add adminGroup based on document creator
         if (document.adminGroups && 'connect' in document.adminGroups) {
           // Some value(s) in adminGroups already present
           document.adminGroups = {
@@ -87,14 +87,14 @@ export const registerDocumentServiceMiddlewares = ({ strapi }: { strapi: Core.St
               },
             })
 
-            if (!tagToAssign) console.log('No tag ' + STARZ_ARTICLE_TAG_TITLE + 'found in database')
+            if (!tagToAssign) console.log('No tag with name ' + STARZ_ARTICLE_TAG_TITLE + ' found in database')
 
             article.tag = tagToAssign
           } catch (error) {
             console.log(
-              'Failed to assign tag' +
+              'Failed to assign tag ' +
                 STARZ_ARTICLE_TAG_TITLE +
-                ' to article documentId: ' +
+                ' to article with documentId: ' +
                 article.documentId
             )
             console.log(error)


### PR DESCRIPTION
## In this PR
- the 'sport' tag is added to a newly created article when created by starz admin
- **important addition** - during work on this PR I noticed an error when first saving a new article and only then publishing it - what fixed it, in document service middleware, was to search for the active user not by the createdBy property, but by the updatedBy property as this should in theory always retireve the active user

## Testing
- log into strapi as a user with a starz role (the role needs to have 'starz' included in its name)
- create a new article, don't add any tag or adminGroup - only fill the required fields and publish the article
- you should now see that the article automatically recieved a tag "sport" and adminGroup "starz" (if you see weird text instead in the tag and adminGroup fields, ask me to configure strapi properly)
- try doing this both for SK and EN locales
- try at first only saving the new article and then publishing it
- report any errors