### PR TITLE
#1663 starz page layout with sidebar

### DIFF
--- a/next/src/components/layouts/SectionContainer.tsx
+++ b/next/src/components/layouts/SectionContainer.tsx
@@ -5,8 +5,11 @@ import cn from '@/src/utils/cn'
 type SectionContainerProps = HTMLAttributes<HTMLDivElement>
 
 const SectionContainer = ({ className, children, ...rest }: SectionContainerProps) => (
-  <div className={cn('relative', className)} {...rest}>
-    <div className="mx-auto max-w-(--breakpoint-xl) px-4 lg:px-8">{children}</div>
+  // data-sectionContainer... attributes serve to target these divs by tailwind from above
+  <div data-sectionContainerOuter className={cn('relative', className)} {...rest}>
+    <div data-sectionContainerInner className="mx-auto max-w-(--breakpoint-xl) px-4 lg:px-8">
+      {children}
+    </div>
   </div>
 )
 

--- a/next/src/components/layouts/Sidebars.tsx
+++ b/next/src/components/layouts/Sidebars.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+
+import { SidebarsFragment } from '@/src/services/graphql'
+
+/**
+ * Based on OLO: https://github.com/bratislava/olo.sk/blob/master/next/src/components/layout/Sidebars.tsx
+ */
+
+type Sidebar = SidebarsFragment
+
+type SidebarsProps = {
+  sidebar: Sidebar
+  className?: string
+}
+
+const SidebarContent = ({ sidebar }: Pick<SidebarsProps, 'sidebar'>) => {
+  // eslint-disable-next-line sonarjs/no-small-switch
+  switch (sidebar.__typename) {
+    default:
+      return null
+  }
+}
+
+const Sidebars = ({ sidebar, className }: SidebarsProps) => {
+  if (sidebar.__typename === 'ComponentSidebarsEmptySidebar') return null
+
+  return (
+    <div className={className}>
+      <SidebarContent sidebar={sidebar} />
+    </div>
+  )
+}
+
+export default Sidebars

--- a/next/src/components/page-contents/GeneralPageContent.tsx
+++ b/next/src/components/page-contents/GeneralPageContent.tsx
@@ -6,8 +6,10 @@ import PageHeader from '@/src/components/common/PageHeader/PageHeader'
 import PageHeaderSections from '@/src/components/layouts/PageHeaderSections'
 import SectionContainer from '@/src/components/layouts/SectionContainer'
 import Sections from '@/src/components/layouts/Sections'
+import Sidebars from '@/src/components/layouts/Sidebars'
 import RelatedArticlesSection from '@/src/components/sections/RelatedArticlesSection'
 import { PageEntityFragment } from '@/src/services/graphql'
+import cn from '@/src/utils/cn'
 import { isDefined } from '@/src/utils/isDefined'
 import { getPageBreadcrumbs } from '@/src/utils/pageUtils_Deprecated'
 
@@ -19,6 +21,9 @@ const GeneralPageContent = ({ page }: GeneralPageProps) => {
   const breadcrumbs = useMemo(() => getPageBreadcrumbs(page), [page])
 
   const filteredSections = page.sections?.filter(isDefined) ?? []
+
+  // Sidebar has always max 1 element
+  const [sidebar] = page.sidebar ?? []
 
   return (
     <>
@@ -33,11 +38,29 @@ const GeneralPageContent = ({ page }: GeneralPageProps) => {
         <PageHeaderSections sections={page.pageHeaderSections} />
       </PageHeader>
 
-      {/* Page - Common Sections */}
-      <div className="py-8">
-        <Sections sections={filteredSections} className="*:py-5 *:md:py-9" />
-
-        <RelatedArticlesSection page={page} className="pt-5 lg:pt-9" />
+      {/* Sections & Sidebar */}
+      <div
+        className={cn('flex flex-wrap-reverse gap-5 py-8 lg:gap-8', {
+          'mx-auto max-w-(--breakpoint-xl) px-4 lg:px-8': !!sidebar,
+        })}
+      >
+        <div
+          className={cn(
+            'w-[50rem]',
+            '[&_[data-sectionContainerOuter]]:not-first:pt-10',
+            '[&_[data-sectionContainerOuter]]:not-first:lg:pt-18',
+            {
+              '[&_[data-sectionContainerInner]]:px-0': !!sidebar,
+              '[&_[data-sectionContainerInner]]:lg:px-0': !!sidebar,
+            },
+          )}
+        >
+          <div className="flex w-full flex-col gap-5 lg:gap-9">
+            <Sections sections={filteredSections} />
+            <RelatedArticlesSection page={page} />
+          </div>
+        </div>
+        {sidebar ? <Sidebars sidebar={sidebar} className="max-w-[50rem] grow basis-72" /> : null}
       </div>
 
       {page.alias ? (

--- a/next/src/services/graphql/index.ts
+++ b/next/src/services/graphql/index.ts
@@ -32,6 +32,7 @@ export type Scalars = {
   Long: { input: any; output: any }
   PagePageHeaderSectionsDynamicZoneInput: { input: any; output: any }
   PageSectionsDynamicZoneInput: { input: any; output: any }
+  PageSidebarDynamicZoneInput: { input: any; output: any }
   /** A time string with format HH:mm:ss.SSS */
   Time: { input: any; output: any }
 }
@@ -2284,6 +2285,21 @@ export type ComponentSectionsVideosInput = {
   videos?: InputMaybe<Array<InputMaybe<ComponentBlocksVideoInput>>>
 }
 
+export type ComponentSidebarsEmptySidebar = {
+  __typename?: 'ComponentSidebarsEmptySidebar'
+  id: Scalars['ID']['output']
+}
+
+export type ComponentSidebarsEmptySidebarFiltersInput = {
+  and?: InputMaybe<Array<InputMaybe<ComponentSidebarsEmptySidebarFiltersInput>>>
+  not?: InputMaybe<ComponentSidebarsEmptySidebarFiltersInput>
+  or?: InputMaybe<Array<InputMaybe<ComponentSidebarsEmptySidebarFiltersInput>>>
+}
+
+export type ComponentSidebarsEmptySidebarInput = {
+  id?: InputMaybe<Scalars['ID']['input']>
+}
+
 export type ComponentTaxAdministratorsTaxAdministrator = {
   __typename?: 'ComponentTaxAdministratorsTaxAdministrator'
   email: Scalars['String']['output']
@@ -3152,6 +3168,7 @@ export type GenericMorph =
   | ComponentSectionsTootootEvents
   | ComponentSectionsTopServices
   | ComponentSectionsVideos
+  | ComponentSidebarsEmptySidebar
   | ComponentTaxAdministratorsTaxAdministrator
   | Document
   | DocumentCategory
@@ -4233,6 +4250,7 @@ export type Page = {
   relatedContents: Array<Maybe<Tag>>
   relatedContents_connection?: Maybe<TagRelationResponseCollection>
   sections?: Maybe<Array<Maybe<PageSectionsDynamicZone>>>
+  sidebar?: Maybe<Array<Maybe<PageSidebarDynamicZone>>>
   slug?: Maybe<Scalars['String']['output']>
   subtext?: Maybe<Scalars['String']['output']>
   title: Scalars['String']['output']
@@ -4439,6 +4457,7 @@ export type PageInput = {
   publishedAt?: InputMaybe<Scalars['DateTime']['input']>
   relatedContents?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>
   sections?: InputMaybe<Array<Scalars['PageSectionsDynamicZoneInput']['input']>>
+  sidebar?: InputMaybe<Array<Scalars['PageSidebarDynamicZoneInput']['input']>>
   slug?: InputMaybe<Scalars['String']['input']>
   subtext?: InputMaybe<Scalars['String']['input']>
   title?: InputMaybe<Scalars['String']['input']>
@@ -4483,6 +4502,8 @@ export type PageSectionsDynamicZone =
   | ComponentSectionsTootootEvents
   | ComponentSectionsVideos
   | Error
+
+export type PageSidebarDynamicZone = ComponentSidebarsEmptySidebar | Error
 
 export type Pagination = {
   __typename?: 'Pagination'
@@ -8885,6 +8906,9 @@ export type PageEntityFragment = {
     | { __typename: 'Error' }
     | null
   > | null
+  sidebar?: Array<
+    { __typename: 'ComponentSidebarsEmptySidebar' } | { __typename?: 'Error' } | null
+  > | null
   localizations: Array<{ __typename?: 'Page'; slug?: string | null; locale?: string | null } | null>
   pageHeaderSections?: Array<
     | {
@@ -9610,6 +9634,9 @@ export type PageBySlugQuery = {
         }
       | { __typename: 'Error' }
       | null
+    > | null
+    sidebar?: Array<
+      { __typename: 'ComponentSidebarsEmptySidebar' } | { __typename?: 'Error' } | null
     > | null
     localizations: Array<{
       __typename?: 'Page'
@@ -10362,6 +10389,9 @@ export type Dev_AllPagesQuery = {
         }
       | { __typename: 'Error' }
       | null
+    > | null
+    sidebar?: Array<
+      { __typename: 'ComponentSidebarsEmptySidebar' } | { __typename?: 'Error' } | null
     > | null
     localizations: Array<{
       __typename?: 'Page'
@@ -12509,6 +12539,16 @@ export type PageHeaderSectionsFragment =
   | PageHeaderSections_ComponentSectionsSubpageList_Fragment
   | PageHeaderSections_Error_Fragment
 
+type Sidebars_ComponentSidebarsEmptySidebar_Fragment = {
+  __typename: 'ComponentSidebarsEmptySidebar'
+}
+
+type Sidebars_Error_Fragment = { __typename?: 'Error' }
+
+export type SidebarsFragment =
+  | Sidebars_ComponentSidebarsEmptySidebar_Fragment
+  | Sidebars_Error_Fragment
+
 export type TagEntityFragment = {
   __typename?: 'Tag'
   documentId: string
@@ -13672,6 +13712,13 @@ export const SectionsFragmentDoc = gql`
   ${PartnersSectionFragmentDoc}
   ${DocumentsSectionFragmentDoc}
 `
+export const SidebarsFragmentDoc = gql`
+  fragment Sidebars on PageSidebarDynamicZone {
+    ... on ComponentSidebarsEmptySidebar {
+      __typename
+    }
+  }
+`
 export const SubpageListPageHeaderSectionFragmentDoc = gql`
   fragment SubpageListPageHeaderSection on ComponentSectionsSubpageList {
     id
@@ -13707,6 +13754,9 @@ export const PageEntityFragmentDoc = gql`
     sections {
       ...Sections
     }
+    sidebar {
+      ...Sidebars
+    }
     localizations {
       slug
       locale
@@ -13728,6 +13778,7 @@ export const PageEntityFragmentDoc = gql`
   ${UploadImageSrcEntityFragmentDoc}
   ${CommonLinkFragmentDoc}
   ${SectionsFragmentDoc}
+  ${SidebarsFragmentDoc}
   ${PageHeaderSectionsFragmentDoc}
   ${TagEntityFragmentDoc}
   ${PageParentPagesFragmentDoc}

--- a/next/src/services/graphql/queries/Pages.graphql
+++ b/next/src/services/graphql/queries/Pages.graphql
@@ -49,6 +49,9 @@ fragment PageEntity on Page {
   sections {
     ...Sections
   }
+  sidebar {
+    ...Sidebars
+  }
   localizations {
     slug
     locale

--- a/next/src/services/graphql/queries/Sidebars.graphql
+++ b/next/src/services/graphql/queries/Sidebars.graphql
@@ -1,0 +1,6 @@
+fragment Sidebars on PageSidebarDynamicZone {
+  ... on ComponentSidebarsEmptySidebar {
+    __typename
+    # This component has no fields
+  }
+}

--- a/strapi/config/sync/admin-role.admin-lg0mm2j6.json
+++ b/strapi/config/sync/admin-role.admin-lg0mm2j6.json
@@ -1340,7 +1340,7 @@
       },
       "conditions": [],
       "actionParameters": {},
-      "documentId": "y15iine1j8p29flqlkx14fhi",
+      "documentId": "zami87a4p1tkom9mhfvbyvfw",
       "locale": null
     },
     {
@@ -1403,7 +1403,7 @@
       },
       "conditions": [],
       "actionParameters": {},
-      "documentId": "wdv9c29hagxqc1ueepg77kqk",
+      "documentId": "pph0x94sqlqr5gaorck4mn0g",
       "locale": null
     },
     {
@@ -1438,7 +1438,7 @@
       },
       "conditions": [],
       "actionParameters": {},
-      "documentId": "v1vzxfj20hjkh0l9fnezoahj",
+      "documentId": "oyoy74jb42paiwkjee57f70z",
       "locale": null
     },
     {

--- a/strapi/config/sync/admin-role.starz-md207wo9.json
+++ b/strapi/config/sync/admin-role.starz-md207wo9.json
@@ -24,6 +24,25 @@
       "locale": null
     },
     {
+      "action": "plugin::content-manager.explorer.read",
+      "subject": "api::article-category.article-category",
+      "properties": {
+        "fields": [
+          "title",
+          "slug",
+          "articles"
+        ],
+        "locales": [
+          "en",
+          "sk"
+        ]
+      },
+      "conditions": [],
+      "actionParameters": {},
+      "documentId": "qd0r3oiwes9gpu8d68nivfxy",
+      "locale": null
+    },
+    {
       "action": "plugin::content-manager.explorer.create",
       "subject": "api::article.article",
       "properties": {
@@ -38,7 +57,8 @@
           "content",
           "files.title",
           "files.media",
-          "gallery"
+          "gallery",
+          "articleCategory"
         ],
         "locales": [
           "en",
@@ -49,7 +69,7 @@
         "plugin::content-manager.document-admin-group-includes-starz"
       ],
       "actionParameters": {},
-      "documentId": "ut1h9175yognhmxxkzl0fiwv",
+      "documentId": "tgmq0zpq14u4bj6tae9wy1qu",
       "locale": null
     },
     {
@@ -99,7 +119,8 @@
           "content",
           "files.title",
           "files.media",
-          "gallery"
+          "gallery",
+          "articleCategory"
         ],
         "locales": [
           "en",
@@ -110,7 +131,7 @@
         "plugin::content-manager.document-admin-group-includes-starz"
       ],
       "actionParameters": {},
-      "documentId": "s3lcoiuyusc1rwf8gxmta8x4",
+      "documentId": "b03ydzj4p9r4clxu571gmk5h",
       "locale": null
     },
     {
@@ -128,7 +149,8 @@
           "content",
           "files.title",
           "files.media",
-          "gallery"
+          "gallery",
+          "articleCategory"
         ],
         "locales": [
           "en",
@@ -139,7 +161,7 @@
         "plugin::content-manager.document-admin-group-includes-starz"
       ],
       "actionParameters": {},
-      "documentId": "d5sg5z6dthp9yp13l9mshbt2",
+      "documentId": "czi4ecpl4g7trgxr2cqn8htk",
       "locale": null
     },
     {
@@ -370,6 +392,7 @@
           "headerLinks.analyticsId",
           "pageHeaderSections",
           "sections",
+          "sidebar",
           "parentPage",
           "childPages",
           "relatedContents"
@@ -383,7 +406,7 @@
         "plugin::content-manager.document-admin-group-includes-starz"
       ],
       "actionParameters": {},
-      "documentId": "x4zj9v7kdf4l6e91o3lke5tg",
+      "documentId": "qf77muvruvo3n3tim5kb5pq7",
       "locale": null
     },
     {
@@ -438,6 +461,7 @@
           "headerLinks.analyticsId",
           "pageHeaderSections",
           "sections",
+          "sidebar",
           "parentPage",
           "childPages",
           "relatedContents"
@@ -451,7 +475,7 @@
         "plugin::content-manager.document-admin-group-includes-starz"
       ],
       "actionParameters": {},
-      "documentId": "v1vl7takqyiceqce69v5yp2e",
+      "documentId": "fc76dj5navboztxvcyp007yh",
       "locale": null
     },
     {
@@ -474,6 +498,7 @@
           "headerLinks.analyticsId",
           "pageHeaderSections",
           "sections",
+          "sidebar",
           "parentPage",
           "childPages",
           "relatedContents"
@@ -487,7 +512,7 @@
         "plugin::content-manager.document-admin-group-includes-starz"
       ],
       "actionParameters": {},
-      "documentId": "mz5blal820na2st6uv02d81w",
+      "documentId": "pgyfnol28i4bomtuewjv02z4",
       "locale": null
     },
     {

--- a/strapi/config/sync/admin-role.strapi-super-admin.json
+++ b/strapi/config/sync/admin-role.strapi-super-admin.json
@@ -1764,6 +1764,7 @@
           "headerLinks.analyticsId",
           "pageHeaderSections",
           "sections",
+          "sidebar",
           "parentPage",
           "childPages",
           "relatedContents",
@@ -1776,7 +1777,7 @@
       },
       "conditions": [],
       "actionParameters": {},
-      "documentId": "b7dlrwaqccaxzwjqsy6ov5qw",
+      "documentId": "b99uppcy68erob2r6habv9tz",
       "locale": null
     },
     {
@@ -1828,6 +1829,7 @@
           "headerLinks.analyticsId",
           "pageHeaderSections",
           "sections",
+          "sidebar",
           "parentPage",
           "childPages",
           "relatedContents",
@@ -1840,7 +1842,7 @@
       },
       "conditions": [],
       "actionParameters": {},
-      "documentId": "gdcb9az3hauce3zphrk1ck41",
+      "documentId": "q7bz0vv9p4nt6woamtg4i0e1",
       "locale": null
     },
     {
@@ -1864,6 +1866,7 @@
           "headerLinks.analyticsId",
           "pageHeaderSections",
           "sections",
+          "sidebar",
           "parentPage",
           "childPages",
           "relatedContents",
@@ -1876,7 +1879,7 @@
       },
       "conditions": [],
       "actionParameters": {},
-      "documentId": "aky1evudmp905ttko0kvix0y",
+      "documentId": "wdc4fha1qz3hns7kanlp4qwd",
       "locale": null
     },
     {

--- a/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sidebars.empty-sidebar.json
+++ b/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sidebars.empty-sidebar.json
@@ -1,0 +1,43 @@
+{
+  "key": "plugin_content_manager_configuration_components::sidebars.empty-sidebar",
+  "value": {
+    "settings": {
+      "bulkable": true,
+      "filterable": true,
+      "searchable": true,
+      "pageSize": 10,
+      "mainField": "documentId",
+      "defaultSortBy": "documentId",
+      "defaultSortOrder": "ASC"
+    },
+    "metadatas": {
+      "id": {
+        "edit": {},
+        "list": {
+          "label": "id",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "documentId": {
+        "edit": {},
+        "list": {
+          "label": "documentId",
+          "searchable": true,
+          "sortable": true
+        }
+      }
+    },
+    "layouts": {
+      "list": [
+        "id"
+      ],
+      "edit": []
+    },
+    "uid": "sidebars.empty-sidebar",
+    "isComponent": true
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/strapi/config/sync/core-store.plugin_content_manager_configuration_content_types##api##page.page.json
+++ b/strapi/config/sync/core-store.plugin_content_manager_configuration_content_types##api##page.page.json
@@ -153,7 +153,8 @@
           "description": "",
           "placeholder": "",
           "visible": true,
-          "editable": true
+          "editable": true,
+          "mainField": "label"
         },
         "list": {
           "label": "headerLinks",
@@ -185,6 +186,20 @@
         },
         "list": {
           "label": "sections",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "sidebar": {
+        "edit": {
+          "label": "Sidebar",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "sidebar",
           "searchable": false,
           "sortable": false
         }
@@ -317,12 +332,6 @@
       }
     },
     "layouts": {
-      "list": [
-        "slug",
-        "title",
-        "updatedAt",
-        "parentPage"
-      ],
       "edit": [
         [
           {
@@ -384,6 +393,12 @@
         ],
         [
           {
+            "name": "sidebar",
+            "size": 12
+          }
+        ],
+        [
+          {
             "name": "sections",
             "size": 12
           }
@@ -408,16 +423,22 @@
         ],
         [
           {
-            "name": "alias",
-            "size": 12
+            "name": "adminGroups",
+            "size": 6
           }
         ],
         [
           {
-            "name": "adminGroups",
-            "size": 6
+            "name": "alias",
+            "size": 12
           }
         ]
+      ],
+      "list": [
+        "slug",
+        "title",
+        "updatedAt",
+        "parentPage"
       ]
     }
   },

--- a/strapi/schema.graphql
+++ b/strapi/schema.graphql
@@ -1808,6 +1808,20 @@ input ComponentSectionsVideosInput {
   videos: [ComponentBlocksVideoInput]
 }
 
+type ComponentSidebarsEmptySidebar {
+  id: ID!
+}
+
+input ComponentSidebarsEmptySidebarFiltersInput {
+  and: [ComponentSidebarsEmptySidebarFiltersInput]
+  not: ComponentSidebarsEmptySidebarFiltersInput
+  or: [ComponentSidebarsEmptySidebarFiltersInput]
+}
+
+input ComponentSidebarsEmptySidebarInput {
+  id: ID
+}
+
 type ComponentTaxAdministratorsTaxAdministrator {
   email: String!
   id: ID!
@@ -2496,7 +2510,7 @@ type GeneralRelationResponseCollection {
   nodes: [General!]!
 }
 
-union GenericMorph = AdminGroup | Alert | Article | ArticleCategory | BlogPost | ComponentAccordionItemsFlatText | ComponentAccordionItemsInstitution | ComponentAccordionItemsInstitutionNarrow | ComponentBlocksColumnsItem | ComponentBlocksCommonLink | ComponentBlocksComparisonCard | ComponentBlocksComparisonItem | ComponentBlocksContactCard | ComponentBlocksContactPersonCard | ComponentBlocksFile | ComponentBlocksFileItem | ComponentBlocksFooterColumn | ComponentBlocksHomepageHighlightsItem | ComponentBlocksInBa | ComponentBlocksNumericalListItem | ComponentBlocksPageLink | ComponentBlocksPartner | ComponentBlocksProsAndConsCard | ComponentBlocksTopServicesItem | ComponentBlocksVideo | ComponentGeneralHeader | ComponentGeneralHeaderLink | ComponentMenuMenuItem | ComponentMenuMenuLink | ComponentMenuMenuSection | ComponentSectionsAccordion | ComponentSectionsArticles | ComponentSectionsBanner | ComponentSectionsCalculator | ComponentSectionsColumnedText | ComponentSectionsColumns | ComponentSectionsComparisonSection | ComponentSectionsContactsSection | ComponentSectionsDivider | ComponentSectionsDocuments | ComponentSectionsFaqCategories | ComponentSectionsFaqs | ComponentSectionsFileList | ComponentSectionsGallery | ComponentSectionsHomepageEvents | ComponentSectionsHomepageHighlights | ComponentSectionsHomepageMayorAndCouncil | ComponentSectionsHomepageTabs | ComponentSectionsIframe | ComponentSectionsInbaArticlesList | ComponentSectionsInbaReleases | ComponentSectionsLinks | ComponentSectionsNarrowText | ComponentSectionsNumericalList | ComponentSectionsOfficialBoard | ComponentSectionsOrganizationalStructure | ComponentSectionsPartners | ComponentSectionsProsAndConsSection | ComponentSectionsRegulations | ComponentSectionsRegulationsList | ComponentSectionsSubpageList | ComponentSectionsTextWithImage | ComponentSectionsTextWithImageOverlapped | ComponentSectionsTootootEvents | ComponentSectionsTopServices | ComponentSectionsVideos | ComponentTaxAdministratorsTaxAdministrator | Document | DocumentCategory | Faq | FaqCategory | Footer | General | Homepage | I18NLocale | InbaArticle | InbaRelease | InbaTag | Menu | Page | PageCategory | Regulation | ReviewWorkflowsWorkflow | ReviewWorkflowsWorkflowStage | Tag | TaxAdministratorsList | UploadFile | UsersPermissionsPermission | UsersPermissionsRole | UsersPermissionsUser
+union GenericMorph = AdminGroup | Alert | Article | ArticleCategory | BlogPost | ComponentAccordionItemsFlatText | ComponentAccordionItemsInstitution | ComponentAccordionItemsInstitutionNarrow | ComponentBlocksColumnsItem | ComponentBlocksCommonLink | ComponentBlocksComparisonCard | ComponentBlocksComparisonItem | ComponentBlocksContactCard | ComponentBlocksContactPersonCard | ComponentBlocksFile | ComponentBlocksFileItem | ComponentBlocksFooterColumn | ComponentBlocksHomepageHighlightsItem | ComponentBlocksInBa | ComponentBlocksNumericalListItem | ComponentBlocksPageLink | ComponentBlocksPartner | ComponentBlocksProsAndConsCard | ComponentBlocksTopServicesItem | ComponentBlocksVideo | ComponentGeneralHeader | ComponentGeneralHeaderLink | ComponentMenuMenuItem | ComponentMenuMenuLink | ComponentMenuMenuSection | ComponentSectionsAccordion | ComponentSectionsArticles | ComponentSectionsBanner | ComponentSectionsCalculator | ComponentSectionsColumnedText | ComponentSectionsColumns | ComponentSectionsComparisonSection | ComponentSectionsContactsSection | ComponentSectionsDivider | ComponentSectionsDocuments | ComponentSectionsFaqCategories | ComponentSectionsFaqs | ComponentSectionsFileList | ComponentSectionsGallery | ComponentSectionsHomepageEvents | ComponentSectionsHomepageHighlights | ComponentSectionsHomepageMayorAndCouncil | ComponentSectionsHomepageTabs | ComponentSectionsIframe | ComponentSectionsInbaArticlesList | ComponentSectionsInbaReleases | ComponentSectionsLinks | ComponentSectionsNarrowText | ComponentSectionsNumericalList | ComponentSectionsOfficialBoard | ComponentSectionsOrganizationalStructure | ComponentSectionsPartners | ComponentSectionsProsAndConsSection | ComponentSectionsRegulations | ComponentSectionsRegulationsList | ComponentSectionsSubpageList | ComponentSectionsTextWithImage | ComponentSectionsTextWithImageOverlapped | ComponentSectionsTootootEvents | ComponentSectionsTopServices | ComponentSectionsVideos | ComponentSidebarsEmptySidebar | ComponentTaxAdministratorsTaxAdministrator | Document | DocumentCategory | Faq | FaqCategory | Footer | General | Homepage | I18NLocale | InbaArticle | InbaRelease | InbaTag | Menu | Page | PageCategory | Regulation | ReviewWorkflowsWorkflow | ReviewWorkflowsWorkflowStage | Tag | TaxAdministratorsList | UploadFile | UsersPermissionsPermission | UsersPermissionsRole | UsersPermissionsUser
 
 type Homepage {
   createdAt: DateTime
@@ -3309,6 +3323,7 @@ type Page {
   relatedContents(filters: TagFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): [Tag]!
   relatedContents_connection(filters: TagFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): TagRelationResponseCollection
   sections: [PageSectionsDynamicZone]
+  sidebar: [PageSidebarDynamicZone]
   slug: String
   subtext: String
   title: String!
@@ -3429,6 +3444,7 @@ input PageInput {
   publishedAt: DateTime
   relatedContents: [ID]
   sections: [PageSectionsDynamicZoneInput!]
+  sidebar: [PageSidebarDynamicZoneInput!]
   slug: String
   subtext: String
   title: String
@@ -3445,6 +3461,10 @@ type PageRelationResponseCollection {
 union PageSectionsDynamicZone = ComponentSectionsAccordion | ComponentSectionsArticles | ComponentSectionsBanner | ComponentSectionsCalculator | ComponentSectionsColumnedText | ComponentSectionsColumns | ComponentSectionsComparisonSection | ComponentSectionsContactsSection | ComponentSectionsDivider | ComponentSectionsDocuments | ComponentSectionsFaqCategories | ComponentSectionsFaqs | ComponentSectionsFileList | ComponentSectionsGallery | ComponentSectionsIframe | ComponentSectionsInbaArticlesList | ComponentSectionsInbaReleases | ComponentSectionsLinks | ComponentSectionsNarrowText | ComponentSectionsNumericalList | ComponentSectionsOfficialBoard | ComponentSectionsOrganizationalStructure | ComponentSectionsPartners | ComponentSectionsProsAndConsSection | ComponentSectionsRegulations | ComponentSectionsRegulationsList | ComponentSectionsTextWithImage | ComponentSectionsTextWithImageOverlapped | ComponentSectionsTootootEvents | ComponentSectionsVideos | Error
 
 scalar PageSectionsDynamicZoneInput
+
+union PageSidebarDynamicZone = ComponentSidebarsEmptySidebar | Error
+
+scalar PageSidebarDynamicZoneInput
 
 type Pagination {
   page: Int!

--- a/strapi/src/api/page/content-types/page/schema.json
+++ b/strapi/src/api/page/content-types/page/schema.json
@@ -17,53 +17,53 @@
   },
   "attributes": {
     "title": {
+      "type": "string",
       "pluginOptions": {
         "i18n": {
           "localized": true
         }
       },
-      "type": "string",
       "required": true
     },
     "slug": {
+      "type": "string",
       "pluginOptions": {
         "i18n": {
           "localized": true
         }
-      },
-      "type": "string"
+      }
     },
     "alias": {
+      "type": "uid",
       "pluginOptions": {
         "i18n": {
           "localized": true
         }
-      },
-      "type": "uid"
+      }
     },
     "subtext": {
+      "type": "text",
       "pluginOptions": {
         "i18n": {
           "localized": true
         }
-      },
-      "type": "text"
+      }
     },
     "metaDiscription": {
+      "type": "text",
       "pluginOptions": {
         "i18n": {
           "localized": true
         }
-      },
-      "type": "text"
+      }
     },
     "keywords": {
+      "type": "string",
       "pluginOptions": {
         "i18n": {
           "localized": true
         }
-      },
-      "type": "string"
+      }
     },
     "pageCategory": {
       "type": "relation",
@@ -72,12 +72,12 @@
       "inversedBy": "pages"
     },
     "pageColor": {
+      "type": "enumeration",
       "pluginOptions": {
         "i18n": {
           "localized": true
         }
       },
-      "type": "enumeration",
       "enum": [
         "red",
         "blue",
@@ -89,6 +89,11 @@
     },
     "pageBackgroundImage": {
       "type": "media",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
       "multiple": false,
       "required": false,
       "allowedTypes": [
@@ -96,41 +101,36 @@
         "files",
         "videos",
         "audios"
-      ],
-      "pluginOptions": {
-        "i18n": {
-          "localized": true
-        }
-      }
+      ]
     },
     "headerLinks": {
       "type": "component",
-      "repeatable": true,
       "pluginOptions": {
         "i18n": {
           "localized": true
         }
       },
-      "component": "blocks.common-link"
+      "component": "blocks.common-link",
+      "repeatable": true
     },
     "pageHeaderSections": {
+      "type": "dynamiczone",
       "pluginOptions": {
         "i18n": {
           "localized": true
         }
       },
-      "type": "dynamiczone",
       "components": [
         "sections.subpage-list"
       ]
     },
     "sections": {
+      "type": "dynamiczone",
       "pluginOptions": {
         "i18n": {
           "localized": true
         }
       },
-      "type": "dynamiczone",
       "components": [
         "sections.accordion",
         "sections.articles",
@@ -163,6 +163,18 @@
         "sections.tootoot-events",
         "sections.videos"
       ]
+    },
+    "sidebar": {
+      "type": "dynamiczone",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "components": [
+        "sidebars.empty-sidebar"
+      ],
+      "max": 1
     },
     "parentPage": {
       "type": "relation",

--- a/strapi/src/components/sidebars/empty-sidebar.json
+++ b/strapi/src/components/sidebars/empty-sidebar.json
@@ -1,0 +1,9 @@
+{
+  "collectionName": "components_sidebars_empty_sidebars",
+  "info": {
+    "displayName": "Prázdny sidebar"
+  },
+  "options": {},
+  "attributes": {},
+  "config": {}
+}

--- a/strapi/types/generated/components.d.ts
+++ b/strapi/types/generated/components.d.ts
@@ -960,6 +960,14 @@ export interface SectionsVideos extends Struct.ComponentSchema {
   }
 }
 
+export interface SidebarsEmptySidebar extends Struct.ComponentSchema {
+  collectionName: 'components_sidebars_empty_sidebars'
+  info: {
+    displayName: 'Pr\u00E1zdny sidebar'
+  }
+  attributes: {}
+}
+
 export interface TaxAdministratorsTaxAdministrator extends Struct.ComponentSchema {
   collectionName: 'components_tax_administrators_tax_administrators'
   info: {
@@ -1039,6 +1047,7 @@ declare module '@strapi/strapi' {
       'sections.tootoot-events': SectionsTootootEvents
       'sections.top-services': SectionsTopServices
       'sections.videos': SectionsVideos
+      'sidebars.empty-sidebar': SidebarsEmptySidebar
       'tax-administrators.tax-administrator': TaxAdministratorsTaxAdministrator
     }
   }

--- a/strapi/types/generated/contentTypes.d.ts
+++ b/strapi/types/generated/contentTypes.d.ts
@@ -1299,6 +1299,18 @@ export interface ApiPagePage extends Struct.CollectionTypeSchema {
           localized: true
         }
       }>
+    sidebar: Schema.Attribute.DynamicZone<['sidebars.empty-sidebar']> &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }> &
+      Schema.Attribute.SetMinMax<
+        {
+          max: 1
+        },
+        number
+      >
     slug: Schema.Attribute.String &
       Schema.Attribute.SetPluginOptions<{
         i18n: {


### PR DESCRIPTION
## PR in progress
- [x] Add sidebar field and Empty sidebar component in Strapi
- [x] Implement sidebar layout for pages in Next
- [ ] Refactor page sections to look good in narrow layout (start with those needed for starz, decide if the rest should be done in separate PR)

## Screenshots (from wide to narrow screen)

### Width 1500px

<img width="958" height="509" alt="image" src="https://github.com/user-attachments/assets/119b5628-31ab-4263-9b2d-2fbd74546385" />

### Width 1190px

Sidebar shrinks, but stays in the right column until less than 288px wide.

<img width="931" height="484" alt="image" src="https://github.com/user-attachments/assets/157a3ca5-78d4-45ee-abfd-82a86bea5c83" />

### Width 1050px

Right column is less than 288px wide, so sidebar displays on top of the left column.

<img width="936" height="556" alt="image" src="https://github.com/user-attachments/assets/7fbadec4-cab7-4c2c-b92c-0ad8c30defe0" />

### Width 900px

<img width="938" height="442" alt="image" src="https://github.com/user-attachments/assets/7830f821-d03e-4b36-8e69-eddba2df3263" />

### Width 700px

<img width="925" height="415" alt="image" src="https://github.com/user-attachments/assets/26f6dba5-1678-484c-99f7-b200c3b295e5" />