### PR TITLE
1681 fix articles fetching after strapi v5 upgrade

### DIFF
--- a/next/src/components/sections/ArticlesSection/ArticlesAll.tsx
+++ b/next/src/components/sections/ArticlesSection/ArticlesAll.tsx
@@ -73,10 +73,6 @@ const ArticlesAll = ({ section }: Props) => {
         // TODO Correct spacing between SectionHeader and remaining content
         className="pb-6 lg:pb-8"
       />
-      {/* {JSON.stringify(filters)} */}
-      {/* {JSON.stringify(pageCategoriesData)} */}
-      {/* {JSON.stringify(tagsData)} */}
-      {/* {JSON.stringify(data)} */}
       <div className="flex flex-col gap-8">
         <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
           {data?.hits.map((card) => (

--- a/next/src/components/sections/ArticlesSection/ArticlesAll.tsx
+++ b/next/src/components/sections/ArticlesSection/ArticlesAll.tsx
@@ -57,7 +57,7 @@ const ArticlesAll = ({ section }: Props) => {
   }
 
   const handleTagsChange = (tags: string[]) => {
-    setFilters({ ...filters, tagIds: tags })
+    setFilters({ ...filters, tagDocumentIds: tags })
   }
 
   return (
@@ -73,6 +73,10 @@ const ArticlesAll = ({ section }: Props) => {
         // TODO Correct spacing between SectionHeader and remaining content
         className="pb-6 lg:pb-8"
       />
+      {/* {JSON.stringify(filters)} */}
+      {/* {JSON.stringify(pageCategoriesData)} */}
+      {/* {JSON.stringify(tagsData)} */}
+      {/* {JSON.stringify(data)} */}
       <div className="flex flex-col gap-8">
         <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
           {data?.hits.map((card) => (

--- a/next/src/components/sections/ArticlesSection/ArticlesByCategory.tsx
+++ b/next/src/components/sections/ArticlesSection/ArticlesByCategory.tsx
@@ -39,7 +39,7 @@ const ArticlesByCategory = ({ section }: Props) => {
     staleTime: Infinity,
   })
 
-  const tagIds =
+  const tagDocumentIds =
     tagsData?.tags
       .filter((tag) => {
         return tag?.pageCategory?.documentId === category?.documentId
@@ -48,7 +48,7 @@ const ArticlesByCategory = ({ section }: Props) => {
       .filter(isDefined) ?? []
 
   useEffect(() => {
-    setFilters({ ...filters, tagIds })
+    setFilters({ ...filters, tagDocumentIds })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tagsData])
 
@@ -57,7 +57,7 @@ const ArticlesByCategory = ({ section }: Props) => {
     queryKey: getArticlesQueryKey(filters, locale),
     queryFn: () => articlesFetcher(filters, locale),
     placeholderData: keepPreviousData,
-    enabled: filters.tagIds.length > 0,
+    enabled: filters.tagDocumentIds.length > 0,
   })
 
   const handlePageChange = (page: number) => {

--- a/next/src/components/sections/InbaArticlesListSection.tsx
+++ b/next/src/components/sections/InbaArticlesListSection.tsx
@@ -105,7 +105,7 @@ const InbaArticlesListSection = ({ section }: Props) => {
     setFilters((previousState) => ({
       ...previousState,
       page: 1,
-      tagIds: selection === 'all' ? [] : [selection],
+      tagDocumentIds: selection === 'all' ? [] : [selection],
     }))
   }, [selection, setFilters])
 

--- a/next/src/components/sections/SearchSection/GlobalSearchSectionContent.tsx
+++ b/next/src/components/sections/SearchSection/GlobalSearchSectionContent.tsx
@@ -190,8 +190,8 @@ const GlobalSearchSectionContent = ({ variant, searchOption }: Props) => {
     search: searchValue,
     page: currentPage,
     pageSize: 12,
-    // tagIds need to be here for now, because Articles and InbaArticle fetchers filter by tagIds
-    tagIds: [],
+    // tagDocumentIds need to be here for now, because Articles and InbaArticle fetchers filter by tagDocumentIds
+    tagDocumentIds: [],
     // Official board category id
     categoryId: !categoryId || categoryId === 'all' ? undefined : categoryId,
     publicationState: publicationState ?? undefined,

--- a/next/src/services/meili/fetchers/articlesFetcher.ts
+++ b/next/src/services/meili/fetchers/articlesFetcher.ts
@@ -6,14 +6,14 @@ export type ArticlesFilters = {
   search: string
   pageSize: number
   page: number
-  tagIds: string[]
+  tagDocumentIds: string[]
 }
 
 export const articlesDefaultFilters: ArticlesFilters = {
   search: '',
   pageSize: 6,
   page: 1,
-  tagIds: [],
+  tagDocumentIds: [],
 }
 
 export const getArticlesQueryKey = (filters: ArticlesFilters, locale: string) => [
@@ -31,23 +31,11 @@ export const articlesFetcher = (filters: ArticlesFilters, locale: string) => {
       filter: [
         'type = "article"',
         `locale = ${locale}`,
-        filters.tagIds.length > 0 ? `article.tag.id IN [${filters.tagIds.join(',')}]` : '',
+        filters.tagDocumentIds.length > 0
+          ? `article.tag.documentId IN [${filters.tagDocumentIds.join(',')}]`
+          : '',
       ],
       sort: ['article.addedAtTimestamp:desc'],
-      attributesToRetrieve: [
-        // Only properties that are required to display listing are retrieved
-        'article.id',
-        'article.title',
-        'article.perex',
-        'article.content',
-        'article.slug',
-        'article.coverMedia.url',
-        'article.addedAt',
-        'article.tag.title',
-        'article.tag.pageCategory.color',
-        'article.tag.pageCategory.shortTitle',
-        'article.articleCategory.title',
-      ],
     })
     .then(unwrapFromSearchIndex('article'))
     .then((response) => {

--- a/next/src/services/meili/fetchers/inbaArticlesFetcher.ts
+++ b/next/src/services/meili/fetchers/inbaArticlesFetcher.ts
@@ -6,14 +6,14 @@ export type InbaArticlesFilters = {
   search: string
   pageSize: number
   page: number
-  tagIds: string[]
+  tagDocumentIds: string[]
 }
 
 export const inbaArticlesDefaultFilters: InbaArticlesFilters = {
   search: '',
   pageSize: 9,
   page: 1,
-  tagIds: [],
+  tagDocumentIds: [],
 }
 
 export const getInbaArticlesQueryKey = (filters: InbaArticlesFilters, locale: string) => [
@@ -31,7 +31,9 @@ export const inbaArticlesFetcher = (filters: InbaArticlesFilters, locale: string
       filter: [
         'type = "inba-article"',
         `locale = ${locale}`,
-        filters.tagIds.length > 0 ? `inba-article.inbaTag.id IN [${filters.tagIds.join(',')}]` : '',
+        filters.tagDocumentIds.length > 0
+          ? `inba-article.inbaTag.documentId IN [${filters.tagDocumentIds.join(',')}]`
+          : '',
       ],
       sort: ['inba-article.publishedAtTimestamp:desc'],
     })

--- a/next/src/services/meili/fetchers/inbaReleasesFetcher.ts
+++ b/next/src/services/meili/fetchers/inbaReleasesFetcher.ts
@@ -28,7 +28,7 @@ export const inbaReleasesFetcher = (filters: InbaReleasesFilters) => {
     .then((response) => {
       const hits = response.hits.map((inbaRelease) => {
         return {
-          id: inbaRelease.id,
+          documentId: inbaRelease.documentId,
           title: inbaRelease.title,
           slug: inbaRelease.slug,
           perex: inbaRelease.perex,

--- a/next/src/services/meili/fetchers/relatedArticlesFetcher.ts
+++ b/next/src/services/meili/fetchers/relatedArticlesFetcher.ts
@@ -12,7 +12,7 @@ const extractTags = (page: PageEntityFragment) => {
 
 const relatedArticlesFilters = (page: PageEntityFragment) => ({
   ...articlesDefaultFilters,
-  tagIds: extractTags(page),
+  tagDocumentIds: extractTags(page),
   pageSize: 9,
 })
 

--- a/strapi/config/plugins.meilisearch.config.ts
+++ b/strapi/config/plugins.meilisearch.config.ts
@@ -40,10 +40,10 @@ const searchIndexSettings = {
   filterableAttributes: [
     'type',
     'locale',
-    'article.tag.id',
-    'blog-post.tag.id',
-    'document.documentCategory.id',
-    'inba-article.inbaTag.id',
+    'article.tag.documentId',
+    'blog-post.tag.documentId',
+    'document.documentCategory.documentId',
+    'inba-article.inbaTag.documentId',
     'regulation.category',
   ],
   sortableAttributes: [


### PR DESCRIPTION
## Description
- in articlesFetcher and inbaArticlesFetcher, we still filtered by id, but this clashed with some graphql queries which returned documentIds as values for these filters.
- in this PR, all fetchers now filter by documentIds

## How to test

- on the [Aktuality](https://bratislava-next.staging.bratislava.sk/mesto-bratislava/transparentne-mesto/aktuality) page, selected other than "Všetky správy" - correct articles should be displayed
- Inba articles should be filterable by tag - try selecting some in [Inba archive](https://bratislava-next.staging.bratislava.sk/inba/archiv)
- check that related articles section at the bottom of pages display correctly - for example try the page [Pomoc a podpora](https://bratislava-next.staging.bratislava.sk/socialne-sluzby-a-byvanie/pomoc-a-podpora) which should display related articles to _Školstvo, Podujatia, Bývanie a ubytovanie_)