### PR TITLE
#1690 Patch strapi-plugin-meilisearch to not using incorrect numberOf…

### DIFF
--- a/strapi/patches/strapi-plugin-meilisearch+0.13.2.patch
+++ b/strapi/patches/strapi-plugin-meilisearch+0.13.2.patch
@@ -1,8 +1,50 @@
 diff --git a/node_modules/strapi-plugin-meilisearch/dist/server/index.js b/node_modules/strapi-plugin-meilisearch/dist/server/index.js
-index 20af84a..fa10912 100644
+index 20af84a..22487bc 100644
 --- a/node_modules/strapi-plugin-meilisearch/dist/server/index.js
 +++ b/node_modules/strapi-plugin-meilisearch/dist/server/index.js
-@@ -1823,15 +1823,20 @@ const lifecycleService = ({ strapi: strapi2 }) => {
+@@ -808,22 +808,31 @@ const contentTypeService = ({ strapi: strapi2 }) => ({
+     entriesQuery = {}
+   }) {
+     const batchSize = entriesQuery.limit || 500;
+-    const entries_count = await this.numberOfEntries({
+-      contentType: contentType2,
+-      ...entriesQuery
+-    });
+-    const cbResponse = [];
+-    for (let index2 = 0; index2 < entries_count; index2 += batchSize) {
++
++    // The problem is that `numberOfEntries()` does not return etries from all locales, but only the default locale, so the count of all entries is not correct.
++    // So we iterate over the entries using while loop, and break when there are no more entries.
++    // https://github.com/meilisearch/strapi-plugin-meilisearch/issues/1026#issuecomment-3105684670
++
++    const cbResponse = []
++    let index2 = 0
++
++    while (true) {
+       const entries = await this.getEntries({
+         start: index2,
+         contentType: contentType2,
+         ...entriesQuery
+       }) || [];
+-      if (entries.length > 0) {
+-        const info = await callback({ entries, contentType: contentType2 });
+-        if (Array.isArray(info)) cbResponse.push(...info);
+-        else if (info) cbResponse.push(info);
++
++      // If no entries returned, we've reached the end
++      if (entries.length === 0) {
++        break
+       }
++
++      const info = await callback({ entries, contentType: contentType2 });
++      if (Array.isArray(info)) cbResponse.push(...info);
++      else if (info) cbResponse.push(info);
++
++      index2 += batchSize
+     }
+     return cbResponse;
+   }
+@@ -1823,15 +1832,20 @@ const lifecycleService = ({ strapi: strapi2 }) => {
        });
        await strapi2.db.lifecycles.subscribe({
          models: [contentTypeUid],
@@ -29,7 +71,7 @@ index 20af84a..fa10912 100644
              contentType: contentTypeUid,
              entries: [entry]
            }).catch((e) => {
-@@ -1869,17 +1874,14 @@ const lifecycleService = ({ strapi: strapi2 }) => {
+@@ -1869,17 +1883,14 @@ const lifecycleService = ({ strapi: strapi2 }) => {
              );
            });
          },


### PR DESCRIPTION
…Entries() but to use while loop to index all entries

Hopefully fixes #1690.

Note: There are probably more bugs everywhere the function `numberOfEntries()` is used, because it still returns only default locale entries count, e.g. the total number of entries is still incorrect etc.
