### PR TITLE
#1554 Improve layout in Videos section

### DIFF
--- a/next/src/components/cards/VideoCard.tsx
+++ b/next/src/components/cards/VideoCard.tsx
@@ -1,0 +1,72 @@
+import { Typography } from '@bratislava/component-library'
+import React, { useEffect } from 'react'
+
+import MLink from '@/src/components/common/MLink/MLink'
+import { VideoBlockFragment } from '@/src/services/graphql'
+import cn from '@/src/utils/cn'
+
+/**
+ * TODO revisit how url is handled
+ * TODO figma link
+ */
+
+const VideoCard = ({ title, speaker, url }: VideoBlockFragment) => {
+  const [embedUrl, setEmbedUrl] = React.useState('')
+  const [isLoaded, setLoaded] = React.useState(false)
+
+  useEffect(() => {
+    const parseYoutubeUrl = async () => {
+      if (url?.includes('fb.watch')) {
+        const fembedUrl = `https://www.facebook.com/plugins/video.php?href=${url}`
+        setEmbedUrl(fembedUrl)
+      } else {
+        const oembedUrl = `https://www.youtube.com/oembed?url=${url}&format=json`
+        const res = await fetch(oembedUrl)
+        const { html }: { html: string } = await res.json()
+
+        const substrStart = html.indexOf('src="') + 5
+        const substrEnd = html.indexOf('oembed') + 6
+        const embededUrl = html.slice(substrStart, substrEnd)
+
+        setEmbedUrl(embededUrl)
+      }
+    }
+
+    parseYoutubeUrl()
+  }, [url])
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="relative aspect-video w-full overflow-hidden rounded-lg">
+        <iframe
+          width="100%"
+          height="100%"
+          title={title ?? undefined}
+          src={embedUrl}
+          allow="accelerometer; encrypted-media; gyroscope; web-share"
+          className={cn('absolute top-0 left-0 size-full border-0', {
+            'animate-pulse bg-grey-300': !isLoaded,
+          })}
+          allowFullScreen
+          onLoad={() => setLoaded(true)}
+        />
+      </div>
+
+      <div className="relative flex grow flex-col gap-1">
+        <MLink
+          href={url ?? '#'}
+          variant="underlineOnHover"
+          target="_blank"
+          rel="noreferrer"
+          stretched
+        >
+          <Typography variant="h5" as="h3">
+            {title}
+          </Typography>
+        </MLink>
+        <Typography variant="p-default">{speaker}</Typography>
+      </div>
+    </div>
+  )
+}
+export default VideoCard

--- a/next/src/components/common/Carousel/Carousel.tsx
+++ b/next/src/components/common/Carousel/Carousel.tsx
@@ -91,7 +91,7 @@ const Carousel = ({
                     // 1rem represents 1 gap-4, if gap is changed, also change card width
                     'w-[calc(100%-1rem)] snap-center': visibleCount === 1,
                     'snap-start': visibleCount > 1,
-                    'w-[calc((100%-0.75rem)/2)]': visibleCount === 2,
+                    'w-[calc((100%-2rem)/2)]': visibleCount === 2,
                     'w-[calc((100%-4rem)/3)]': visibleCount === 3,
                     'w-[calc((100%-6rem)/4)]': visibleCount === 4,
                   },

--- a/next/src/components/common/Videos_Deprecated/Videos_Deprecated.tsx
+++ b/next/src/components/common/Videos_Deprecated/Videos_Deprecated.tsx
@@ -1,81 +1,17 @@
-import { Typography } from '@bratislava/component-library'
-import React, { useEffect } from 'react'
+import React from 'react'
 
+import VideoCard from '@/src/components/cards/VideoCard'
 import { AllowedVisibleCount } from '@/src/components/common/Carousel/Carousel'
 import ResponsiveCarousel from '@/src/components/common/Carousel/ResponsiveCarousel'
-import MLink from '@/src/components/common/MLink/MLink'
 import SectionHeader from '@/src/components/layouts/SectionHeader'
-import { VideoBlockFragment, VideosSectionFragment } from '@/src/services/graphql'
-import cn from '@/src/utils/cn'
+import { VideosSectionFragment } from '@/src/services/graphql'
 import { isDefined } from '@/src/utils/isDefined'
-
-// TODO split into separate components
-
-const VideoCard = ({ title, speaker, url }: VideoBlockFragment) => {
-  const [embedUrl, setEmbedUrl] = React.useState('')
-  const [isLoaded, setLoaded] = React.useState(false)
-
-  useEffect(() => {
-    const parseYoutubeUrl = async () => {
-      if (url?.includes('fb.watch')) {
-        const fembedUrl = `https://www.facebook.com/plugins/video.php?href=${url}`
-        setEmbedUrl(fembedUrl)
-      } else {
-        const oembedUrl = `https://www.youtube.com/oembed?url=${url}&format=json`
-        const res = await fetch(oembedUrl)
-        const { html }: { html: string } = await res.json()
-
-        const substrStart = html.indexOf('src="') + 5
-        const substrEnd = html.indexOf('oembed') + 6
-        const embededUrl = html.slice(substrStart, substrEnd)
-
-        setEmbedUrl(embededUrl)
-      }
-    }
-
-    parseYoutubeUrl()
-  }, [url])
-
-  return (
-    <div className="flex flex-col gap-4">
-      <div className="relative aspect-video w-full overflow-hidden rounded-lg">
-        <iframe
-          width="100%"
-          height="100%"
-          title={title ?? undefined}
-          src={embedUrl}
-          allow="accelerometer; encrypted-media; gyroscope; web-share"
-          className={cn('absolute top-0 left-0 size-full border-0', {
-            'animate-pulse bg-grey-300': !isLoaded,
-          })}
-          allowFullScreen
-          onLoad={() => setLoaded(true)}
-        />
-      </div>
-
-      <div className="relative flex grow flex-col gap-1">
-        <MLink
-          href={url ?? '#'}
-          variant="underlineOnHover"
-          target="_blank"
-          rel="noreferrer"
-          stretched
-        >
-          <Typography variant="h5" as="h3">
-            {title}
-          </Typography>
-        </MLink>
-        <Typography variant="p-default">{speaker}</Typography>
-      </div>
-    </div>
-  )
-}
 
 /**
  * TODO Figma link
  */
 
-export const Videos = ({ title, subtitle, videos }: VideosSectionFragment) => {
+const Videos = ({ title, subtitle, videos }: VideosSectionFragment) => {
   if (!videos) {
     return null
   }
@@ -100,3 +36,5 @@ export const Videos = ({ title, subtitle, videos }: VideosSectionFragment) => {
     </div>
   )
 }
+
+export default Videos

--- a/next/src/components/common/Videos_Deprecated/Videos_Deprecated.tsx
+++ b/next/src/components/common/Videos_Deprecated/Videos_Deprecated.tsx
@@ -1,25 +1,21 @@
 import { Typography } from '@bratislava/component-library'
-import React from 'react'
+import React, { useEffect } from 'react'
 
+import { AllowedVisibleCount } from '@/src/components/common/Carousel/Carousel'
 import ResponsiveCarousel from '@/src/components/common/Carousel/ResponsiveCarousel'
 import MLink from '@/src/components/common/MLink/MLink'
 import SectionHeader from '@/src/components/layouts/SectionHeader'
 import { VideoBlockFragment, VideosSectionFragment } from '@/src/services/graphql'
 import cn from '@/src/utils/cn'
-import { isPresent } from '@/src/utils/utils'
+import { isDefined } from '@/src/utils/isDefined'
 
 // TODO split into separate components
 
-const Video = ({
-  title,
-  speaker,
-  url,
-  size = 'default',
-}: VideoBlockFragment & { size?: 'default' | 'small' }) => {
+const VideoCard = ({ title, speaker, url }: VideoBlockFragment) => {
   const [embedUrl, setEmbedUrl] = React.useState('')
   const [isLoaded, setLoaded] = React.useState(false)
 
-  React.useEffect(() => {
+  useEffect(() => {
     const parseYoutubeUrl = async () => {
       if (url?.includes('fb.watch')) {
         const fembedUrl = `https://www.facebook.com/plugins/video.php?href=${url}`
@@ -41,26 +37,36 @@ const Video = ({
   }, [url])
 
   return (
-    <div className="mb-8 w-full lg:mb-0 xl:w-88">
-      <iframe
-        className={cn('w-full rounded-[5]', {
-          'animate-pulse bg-grey-300': !isLoaded,
-        })}
-        title={title ?? undefined}
-        // width={size === 'default' ? '350' : '280'}
-        height={size === 'default' ? '196' : '157'}
-        src={embedUrl}
-        allowFullScreen
-        onLoad={() => setLoaded(true)}
-      />
-      <MLink href={url ?? '#'} variant="underlineOnHover" target="_blank" rel="noreferrer">
-        <Typography variant="h5" as="h3" className="mt-8 cursor-pointer hover:underline">
-          {title}
-        </Typography>
-      </MLink>
-      <Typography variant="p-default" className="mt-5">
-        {speaker}
-      </Typography>
+    <div className="flex flex-col gap-4">
+      <div className="relative aspect-video w-full overflow-hidden rounded-lg">
+        <iframe
+          width="100%"
+          height="100%"
+          title={title ?? undefined}
+          src={embedUrl}
+          allow="accelerometer; encrypted-media; gyroscope; web-share"
+          className={cn('absolute top-0 left-0 size-full border-0', {
+            'animate-pulse bg-grey-300': !isLoaded,
+          })}
+          allowFullScreen
+          onLoad={() => setLoaded(true)}
+        />
+      </div>
+
+      <div className="relative flex grow flex-col gap-1">
+        <MLink
+          href={url ?? '#'}
+          variant="underlineOnHover"
+          target="_blank"
+          rel="noreferrer"
+          stretched
+        >
+          <Typography variant="h5" as="h3">
+            {title}
+          </Typography>
+        </MLink>
+        <Typography variant="p-default">{speaker}</Typography>
+      </div>
     </div>
   )
 }
@@ -74,27 +80,23 @@ export const Videos = ({ title, subtitle, videos }: VideosSectionFragment) => {
     return null
   }
 
+  const filteredVideos = videos.filter(isDefined) ?? []
+  const videosCount = filteredVideos.length
+
   return (
     <div>
       <div className="py-8 md:pt-0">
         <SectionHeader title={title} text={subtitle} />
       </div>
 
-      {/* Mobile */}
+      {/* Using carousel for simplicity, it'll "behave as carousel" on desktop only if there is more than 4 videos  */}
       <ResponsiveCarousel
-        className="lg:hidden"
         hasVerticalPadding={false}
-        items={videos.filter(isPresent).map((video) => (
-          <Video key={video.url} size="small" {...video} />
+        items={filteredVideos.map((video) => (
+          <VideoCard key={video.url} {...video} />
         ))}
+        desktop={videosCount > 0 && videosCount <= 4 ? (videosCount as AllowedVisibleCount) : 4}
       />
-
-      {/* Desktop */}
-      <div className="hidden gap-8 lg:grid lg:grid-cols-3">
-        {videos.filter(isPresent).map((video) => (
-          <Video key={video.url} {...video} />
-        ))}
-      </div>
     </div>
   )
 }

--- a/next/src/components/sections/VideosSection.tsx
+++ b/next/src/components/sections/VideosSection.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { Videos } from '@/src/components/common/Videos_Deprecated/Videos_Deprecated'
+import Videos from '@/src/components/common/Videos_Deprecated/Videos_Deprecated'
 import SectionContainer from '@/src/components/layouts/SectionContainer'
 import { VideosSectionFragment } from '@/src/services/graphql'
 import { isDefined } from '@/src/utils/isDefined'

--- a/next/src/components/sections/VideosSection.tsx
+++ b/next/src/components/sections/VideosSection.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { Videos } from '@/src/components/common/Videos_Deprecated/Videos_Deprecated'
 import SectionContainer from '@/src/components/layouts/SectionContainer'
 import { VideosSectionFragment } from '@/src/services/graphql'
-import { isPresent } from '@/src/utils/utils'
+import { isDefined } from '@/src/utils/isDefined'
 
 type VideosSectionProps = { section: VideosSectionFragment }
 
@@ -14,7 +14,7 @@ const VideosSection = ({ section }: VideosSectionProps) => {
         id={section.id}
         title={section.title}
         subtitle={section.subtitle}
-        videos={section?.videos?.filter(isPresent) ?? null}
+        videos={section?.videos?.filter(isDefined) ?? null}
       />
     </SectionContainer>
   )

--- a/next/src/utils/dev/strapiHelper.ts
+++ b/next/src/utils/dev/strapiHelper.ts
@@ -77,11 +77,10 @@ export async function listPages() {
     // .filter((page) => !page.slug?.includes('/'))
     .filter((page) => {
       const sections =
-        page.sections?.filter((section) => section?.__typename === 'ComponentSectionsNarrowText') ??
-        []
+        page.sections?.filter((section) => section?.__typename === 'ComponentSectionsVideos') ?? []
 
       return sections.some(
-        (section) => section?.__typename === 'ComponentSectionsNarrowText' && !section.width,
+        (section) => section?.__typename === 'ComponentSectionsVideos',
         // section.width === 'wide',
       )
     })
@@ -91,7 +90,14 @@ export async function listPages() {
   console.log('Number of filteredPages:', filteredPages.length)
   console.log(
     filteredPages.map((page) => {
-      return `${page.documentId} ${page.slug}`
+      const length = page.sections
+        ?.filter(isDefined)
+        .filter((section) => section.__typename === 'ComponentSectionsVideos')
+        .map((section) =>
+          section.__typename === 'ComponentSectionsVideos' ? section.videos?.length : -1,
+        )
+
+      return `${page.documentId} ${length} ${page.slug}`
     }),
   )
 }
@@ -176,7 +182,10 @@ export async function logAllSectionsByType({
       console.log('\n')
     } else {
       console.log(
-        `${entityLog.length}x ${sectionName?.replace('ComponentSections', '')} found at ${nextEntityLinkProd} ${CONSOLE_GREY}${strapiEntityLink}${CONSOLE_WHITE}`,
+        `${entityLog.length}x ${sectionName?.replace(
+          'ComponentSections',
+          '',
+        )} found at ${nextEntityLinkProd} ${CONSOLE_GREY}${strapiEntityLink}${CONSOLE_WHITE}`,
       )
     }
   })


### PR DESCRIPTION
### Description

- use `Carousel` for layout - it'll work as carousel  on desktop only for more than 4 videos, so it's nice way to get the correct grid
- style iframe as in OLO, cleanup the card layout
- fix carousel width with 2 items (it was wider than the parent container)
- split `VideoCard` to separate component
- use `isDefined` instead of `isPresent`

### Notes

Not part of this PR:
- url handling
- strapi check/cleanup for this section, config sync...

### Screenshots && testing

http://localhost:3000/socialne-sluzby-a-byvanie/aktivity-v-socialnej-oblasti/komunitny-plan-socialnych-sluzieb

<img width="800" height="427" alt="image" src="https://github.com/user-attachments/assets/cd7b55bb-e1d2-46a5-87c2-b10c4eea51b4" />

http://localhost:3000/zivotne-prostredie-a-vystavba/zelen/udrzba-a-tvorba-zelene/stromy-v-meste/ake-stromy-sadime

<img width="800" height="310" alt="image" src="https://github.com/user-attachments/assets/e963ee14-bb8b-433f-9106-2ab4cc4b95e9" />

http://localhost:3000/socialne-sluzby-a-byvanie/aktivity-v-socialnej-oblasti/celozivotne-vzdelavanie

<img width="800" height="469" alt="image" src="https://github.com/user-attachments/assets/7b868809-35c9-4a92-bb36-1d6589e5e555" />

http://localhost:3000/doprava-a-mapy/doprava/dopravne-projekty/dunajska

<img width="800" height="782" alt="image" src="https://github.com/user-attachments/assets/0d0cdb2c-2121-4266-9d9f-89d98be2403a" />

