### PR TITLE
#1664 Add titleLevel h2/h3 option to relevant sections

### DIFF
--- a/next/src/components/cards/DocumentRowCard.tsx
+++ b/next/src/components/cards/DocumentRowCard.tsx
@@ -5,11 +5,13 @@ import React, { Fragment } from 'react'
 import { ArrowRightIcon, AttachmentIcon, DownloadIcon } from '@/src/assets/icons'
 import { FolderIcon } from '@/src/assets/material-icons'
 import CardBase from '@/src/components/cards/CardBase'
+import { CardTitleLevel } from '@/src/components/cards/getCardTitleLevel'
 import Button from '@/src/components/common/Button/Button'
 
 export type DocumentRowCardProps = {
   variant: 'single-file' | 'multiple-files'
   title: string
+  cardTitleLevel?: CardTitleLevel
   linkHref: string
   metadata?: string[]
   className?: string
@@ -25,6 +27,7 @@ export type DocumentRowCardProps = {
 const DocumentRowCard = ({
   variant,
   title,
+  cardTitleLevel = 'h3',
   linkHref,
   metadata,
   className,
@@ -45,7 +48,7 @@ const DocumentRowCard = ({
               )}
             </div>
             <div className="flex grow flex-col gap-1">
-              <Typography variant="h6" as="h3" className="group-hover:underline">
+              <Typography variant="h6" as={cardTitleLevel} className="group-hover:underline">
                 {title}
               </Typography>
               {metadata?.length ? (

--- a/next/src/components/cards/VideoCard.tsx
+++ b/next/src/components/cards/VideoCard.tsx
@@ -2,6 +2,7 @@ import { Typography } from '@bratislava/component-library'
 import { useTranslation } from 'next-i18next'
 import React, { useState } from 'react'
 
+import { CardTitleLevel } from '@/src/components/cards/getCardTitleLevel'
 import MLink from '@/src/components/common/MLink/MLink'
 import { VideoBlockFragment } from '@/src/services/graphql'
 import cn from '@/src/utils/cn'
@@ -11,7 +12,11 @@ import { getVideoIframeSrc } from '@/src/utils/videoEmbedUtils'
  * TODO figma link
  */
 
-const VideoCard = ({ title, speaker, url: untrimmedUrl }: VideoBlockFragment) => {
+type Props = {
+  cardTitleLevel?: CardTitleLevel
+} & VideoBlockFragment
+
+const VideoCard = ({ title, speaker, url: untrimmedUrl, cardTitleLevel = 'h3' }: Props) => {
   const { t } = useTranslation()
   const [isLoaded, setLoaded] = useState(false)
 
@@ -47,7 +52,7 @@ const VideoCard = ({ title, speaker, url: untrimmedUrl }: VideoBlockFragment) =>
           rel="noreferrer"
           stretched
         >
-          <Typography variant="h5" as="h3">
+          <Typography variant="h5" as={cardTitleLevel}>
             {title}
           </Typography>
         </MLink>

--- a/next/src/components/cards/getCardTitleLevel.ts
+++ b/next/src/components/cards/getCardTitleLevel.ts
@@ -1,0 +1,11 @@
+export type SectionTitleLevel = 'h2' | 'h3'
+
+export type CardTitleLevel = 'h3' | 'h4'
+
+export const getCardTitleLevel = (
+  sectionTitleLevel: SectionTitleLevel | null | undefined,
+): CardTitleLevel => {
+  if (sectionTitleLevel === 'h3') return 'h4'
+
+  return 'h3'
+}

--- a/next/src/components/cards/getCardTitleLevel.ts
+++ b/next/src/components/cards/getCardTitleLevel.ts
@@ -2,6 +2,8 @@ export type SectionTitleLevel = 'h2' | 'h3'
 
 export type CardTitleLevel = 'h3' | 'h4'
 
+export type AccordionTitleLevel = 'h2' | 'h3' | 'h4'
+
 export const getCardTitleLevel = (
   sectionTitleLevel: SectionTitleLevel | null | undefined,
 ): CardTitleLevel => {

--- a/next/src/components/common/Accordion/Accordion.tsx
+++ b/next/src/components/common/Accordion/Accordion.tsx
@@ -2,6 +2,7 @@ import { Typography } from '@bratislava/component-library'
 import { ReactNode } from 'react'
 import { ChevronDownIcon } from 'src/assets/icons'
 
+import { AccordionTitleLevel } from '@/src/components/cards/getCardTitleLevel'
 import AnimateHeight from '@/src/components/formatting/AnimateHeight'
 import cn from '@/src/utils/cn'
 
@@ -9,6 +10,7 @@ export type AccordionProps = {
   variant?: 'boxed' | 'footer'
   title: string | ReactNode | null | undefined
   children?: ReactNode
+  accordionTitleLevel?: AccordionTitleLevel
 }
 
 /**
@@ -17,7 +19,12 @@ export type AccordionProps = {
  *
  * Note: Only size h4 is implemented and used - this is desired behaviour until we get better accordion design in figma.
  */
-const Accordion = ({ variant = 'boxed', title, children }: AccordionProps) => {
+const Accordion = ({
+  variant = 'boxed',
+  title,
+  children,
+  accordionTitleLevel = 'h3',
+}: AccordionProps) => {
   const borderStyles = cn('group flex w-full flex-col', {
     'rounded-xl border border-grey-200 bg-white open:border-grey-700 hover:border-grey-500 hover:open:border-grey-700':
       variant === 'boxed',
@@ -43,7 +50,7 @@ const Accordion = ({ variant = 'boxed', title, children }: AccordionProps) => {
       <details className={borderStyles}>
         <summary className={buttonStyles}>
           {/* TODO accordions often have no parent title, so they should act as h2 */}
-          <Typography variant="h4" as="h3" className="min-w-0 grow">
+          <Typography variant="h4" as={accordionTitleLevel} className="min-w-0 grow">
             {title}
           </Typography>
 

--- a/next/src/components/common/Contacts/Contacts.tsx
+++ b/next/src/components/common/Contacts/Contacts.tsx
@@ -19,17 +19,29 @@ const mapSection = (
  */
 
 const Contacts = ({ section }: ContactsProps) => {
+  const {
+    title,
+    description,
+    titleLevelContactsSection: titleLevel,
+    addressContacts,
+    openingHoursContacts,
+    emailContacts,
+    phoneContacts,
+    webContacts,
+    personContacts,
+  } = section
+
   const contacts = [
-    ...mapSection(section.addressContacts, ContactCtaCardType.Address),
-    ...mapSection(section.openingHoursContacts, ContactCtaCardType.OpeningHours),
-    ...mapSection(section.emailContacts, ContactCtaCardType.Email),
-    ...mapSection(section.phoneContacts, ContactCtaCardType.Phone),
-    ...mapSection(section.webContacts, ContactCtaCardType.Web),
+    ...mapSection(addressContacts, ContactCtaCardType.Address),
+    ...mapSection(openingHoursContacts, ContactCtaCardType.OpeningHours),
+    ...mapSection(emailContacts, ContactCtaCardType.Email),
+    ...mapSection(phoneContacts, ContactCtaCardType.Phone),
+    ...mapSection(webContacts, ContactCtaCardType.Web),
   ]
 
   return (
     <div className="flex flex-col gap-6 rounded-xl bg-gray-100 p-4 lg:gap-8 lg:p-8">
-      <SectionHeader title={section.title} text={section.description} asRichtext />
+      <SectionHeader title={title} titleLevel={titleLevel} text={description} asRichtext />
 
       <div className="flex flex-col gap-6 lg:gap-8">
         {contacts.map((contact, index) => (
@@ -39,7 +51,7 @@ const Contacts = ({ section }: ContactsProps) => {
             contact={contact}
           />
         ))}
-        {section.personContacts?.filter(isDefined).map((person, index) => (
+        {personContacts?.filter(isDefined).map((person, index) => (
           <ContactCtaCard
             // eslint-disable-next-line react/no-array-index-key
             key={index}

--- a/next/src/components/common/FaqsGroup/FaqsGroup.tsx
+++ b/next/src/components/common/FaqsGroup/FaqsGroup.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { AccordionTitleLevel } from '@/src/components/cards/getCardTitleLevel'
 import Accordion from '@/src/components/common/Accordion/Accordion'
 import Markdown from '@/src/components/formatting/Markdown/Markdown'
 import { FaqEntityFragment } from '@/src/services/graphql'
@@ -7,14 +8,15 @@ import { isDefined } from '@/src/utils/isDefined'
 
 export type FaqsGroupProps = {
   faqs: FaqEntityFragment[]
+  accordionTitleLevel?: AccordionTitleLevel
 }
 
-const FaqsGroup = ({ faqs }: FaqsGroupProps) => {
+const FaqsGroup = ({ faqs, accordionTitleLevel }: FaqsGroupProps) => {
   return (
     <div className="flex flex-col gap-4">
       {faqs.filter(isDefined).map((faq, index) => (
         // eslint-disable-next-line react/no-array-index-key
-        <Accordion key={index} title={faq.title}>
+        <Accordion key={index} title={faq.title} accordionTitleLevel={accordionTitleLevel}>
           <Markdown content={faq.body} variant="small" />
         </Accordion>
       ))}

--- a/next/src/components/common/FileList/FileList.tsx
+++ b/next/src/components/common/FileList/FileList.tsx
@@ -1,6 +1,7 @@
 import { Fragment } from 'react'
 
 import FileRowCardWrapper from '@/src/components/cards/FileRowCardWrapper'
+import { SectionTitleLevel } from '@/src/components/cards/getCardTitleLevel'
 import HorizontalDivider from '@/src/components/common/Divider/HorizontalDivider'
 import SectionHeader from '@/src/components/layouts/SectionHeader'
 import { FileBlockFragment, FileItemBlockFragment } from '@/src/services/graphql'
@@ -11,16 +12,17 @@ export type FileListProps = {
   text?: string | null | undefined
   className?: string
   files: FileItemBlockFragment[] | FileBlockFragment[]
+  titleLevel?: SectionTitleLevel | null | undefined
 }
 
 /**
  * Figma: https://www.figma.com/file/17wbd0MDQcMW9NbXl6UPs8/DS-ESBS%2BBK%3A-Component-library?type=design&node-id=7940-21473&mode=dev
  */
 
-const FileList = ({ className, title, text, files }: FileListProps) => {
+const FileList = ({ className, title, text, files, titleLevel }: FileListProps) => {
   return (
     <div className={cn('flex flex-col gap-4 lg:gap-6', className)}>
-      <SectionHeader title={title} text={text} />
+      <SectionHeader title={title} titleLevel={titleLevel} text={text} />
 
       <ul className="flex flex-col rounded-lg border py-2">
         {files.map((file, index) => (

--- a/next/src/components/common/Iframe/Iframe.tsx
+++ b/next/src/components/common/Iframe/Iframe.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 
+import { SectionTitleLevel } from '@/src/components/cards/getCardTitleLevel'
 import SectionHeader from '@/src/components/layouts/SectionHeader'
 
 export type IframeProps = {
@@ -12,6 +13,7 @@ export type IframeProps = {
   allowFullscreen: boolean
   allowGeolocation?: boolean | null
   css?: string | null
+  titleLevel?: SectionTitleLevel | null | undefined
 }
 
 const Iframe = ({
@@ -24,6 +26,7 @@ const Iframe = ({
   allowFullscreen,
   allowGeolocation = false,
   css,
+  titleLevel,
 }: IframeProps) => {
   const ref = useRef<HTMLIFrameElement>(null)
 
@@ -49,7 +52,7 @@ const Iframe = ({
 
   return (
     <div className="flex flex-col gap-4 lg:gap-6">
-      <SectionHeader title={title} text={text} />
+      <SectionHeader title={title} titleLevel={titleLevel} text={text} />
       <div
         style={{ height }}
         className={iframeWidth === 'container' ? 'w-full' : 'absolute inset-x-0'}

--- a/next/src/components/common/Links/Links.tsx
+++ b/next/src/components/common/Links/Links.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { ArrowRightIcon } from 'src/assets/icons'
 
+import { SectionTitleLevel } from '@/src/components/cards/getCardTitleLevel'
 import Button from '@/src/components/common/Button/Button'
 import SectionHeader from '@/src/components/layouts/SectionHeader'
 import { LinksSectionFragment } from '@/src/services/graphql'
@@ -10,6 +11,7 @@ import { isDefined } from '@/src/utils/isDefined'
 
 export type LinksProps = {
   title: string | null | undefined
+  titleLevel?: SectionTitleLevel | null | undefined
   pageLinks: LinksSectionFragment['pageLinks']
   className?: string
 }

--- a/next/src/components/common/Links/Links.tsx
+++ b/next/src/components/common/Links/Links.tsx
@@ -20,10 +20,10 @@ export type LinksProps = {
  * TODO Figma link
  */
 
-const Links = ({ title, pageLinks, className }: LinksProps) => {
+const Links = ({ title, titleLevel, pageLinks, className }: LinksProps) => {
   return (
     <div className={cn('flex w-full flex-col gap-6 md:w-10/12', className)}>
-      <SectionHeader title={title} />
+      <SectionHeader title={title} titleLevel={titleLevel} />
 
       <ul className="flex flex-col gap-4">
         {pageLinks?.filter(isDefined).map((pageLink, index) => (

--- a/next/src/components/layouts/SectionHeader.tsx
+++ b/next/src/components/layouts/SectionHeader.tsx
@@ -1,6 +1,7 @@
 import { Typography } from '@bratislava/component-library'
 import slugify from '@sindresorhus/slugify'
 
+import { SectionTitleLevel } from '@/src/components/cards/getCardTitleLevel'
 import Button from '@/src/components/common/Button/Button'
 import { TABLE_OF_CONTENTS_HEADING_ATTRIBUTE } from '@/src/components/common/TableOfContents/useHeadings'
 import Markdown from '@/src/components/formatting/Markdown/Markdown'
@@ -11,6 +12,7 @@ import { getLinkProps } from '@/src/utils/getLinkProps'
 type SectionHeaderProps = {
   title?: string | null | undefined
   titleId?: string
+  titleLevel?: SectionTitleLevel | null | undefined
   text?: string | null | undefined
   asRichtext?: boolean
   isFullWidth?: boolean
@@ -27,6 +29,7 @@ type SectionHeaderProps = {
 const SectionHeader = ({
   title,
   titleId,
+  titleLevel,
   text,
   asRichtext = false,
   isFullWidth = false,
@@ -58,7 +61,7 @@ const SectionHeader = ({
           )}
         >
           {title ? (
-            <Typography variant="h2" id={titleId ?? slugify(title)}>
+            <Typography variant="h2" as={titleLevel ?? 'h2'} id={titleId ?? slugify(title)}>
               {title}
             </Typography>
           ) : null}

--- a/next/src/components/layouts/SectionHeader.tsx
+++ b/next/src/components/layouts/SectionHeader.tsx
@@ -61,7 +61,7 @@ const SectionHeader = ({
           )}
         >
           {title ? (
-            <Typography variant="h2" as={titleLevel ?? 'h2'} id={titleId ?? slugify(title)}>
+            <Typography variant={titleLevel ?? 'h2'} id={titleId ?? slugify(title)}>
               {title}
             </Typography>
           ) : null}

--- a/next/src/components/sections/AccordionSection.tsx
+++ b/next/src/components/sections/AccordionSection.tsx
@@ -24,6 +24,7 @@ const AccordionSection = ({ section }: AccordionSectionProps) => {
     <SectionContainer>
       <SectionHeader
         title={section.title}
+        titleLevel={section.titleLevelAccordionSection}
         isCentered
         // TODO Correct spacing between SectionHeader and remaining content
         className="pb-6 lg:pb-8"

--- a/next/src/components/sections/AccordionSection.tsx
+++ b/next/src/components/sections/AccordionSection.tsx
@@ -1,3 +1,4 @@
+import { getCardTitleLevel } from '@/src/components/cards/getCardTitleLevel'
 import Accordion from '@/src/components/common/Accordion/Accordion'
 import Button from '@/src/components/common/Button/Button'
 import FileList from '@/src/components/common/FileList/FileList'
@@ -20,45 +21,59 @@ type AccordionSectionProps = {
  */
 
 const AccordionSection = ({ section }: AccordionSectionProps) => {
+  const {
+    title,
+    institutions,
+    flatText,
+    institutionsNarrow,
+    titleLevelAccordionSection: titleLevel,
+  } = section
+
+  // If no section title is provided, accordions act as h2, otherwise they accommodate to section titleLevel
+  const accordionTitleLevel = title ? getCardTitleLevel(titleLevel) : 'h2'
+
   return (
     <SectionContainer>
       <SectionHeader
-        title={section.title}
-        titleLevel={section.titleLevelAccordionSection}
+        title={title}
+        titleLevel={titleLevel}
         isCentered
         // TODO Correct spacing between SectionHeader and remaining content
         className="pb-6 lg:pb-8"
       />
       <div className="flex flex-col gap-4">
-        {groupByCategory(section.institutions?.filter(isPresent) ?? []).map(
-          (institution, index) => (
-            <Accordion
-              // eslint-disable-next-line react/no-array-index-key
-              key={`institution-${index}`}
-              title={institution.category}
-            >
-              <div className="flex flex-col gap-4">
-                {institution.items.filter(isPresent).map((file, itemIndex) => (
-                  <Institution
-                    // eslint-disable-next-line react/no-array-index-key
-                    key={itemIndex}
-                    title={file.title ?? undefined}
-                    subtitle={file.subtitle ?? undefined}
-                    content={[file.firstColumn, file.secondColumn, file.thirdColumn]
-                      .filter(Boolean)
-                      .filter(isDefined)}
-                    url={file.url ?? undefined}
-                    urlLabel={file.urlLabel ?? undefined}
-                  />
-                ))}
-              </div>
-            </Accordion>
-          ),
-        )}
+        {groupByCategory(institutions?.filter(isPresent) ?? []).map((institution, index) => (
+          <Accordion
+            // eslint-disable-next-line react/no-array-index-key
+            key={`institution-${index}`}
+            title={institution.category}
+            accordionTitleLevel={accordionTitleLevel}
+          >
+            <div className="flex flex-col gap-4">
+              {institution.items.filter(isPresent).map((file, itemIndex) => (
+                <Institution
+                  // eslint-disable-next-line react/no-array-index-key
+                  key={itemIndex}
+                  title={file.title ?? undefined}
+                  subtitle={file.subtitle ?? undefined}
+                  content={[file.firstColumn, file.secondColumn, file.thirdColumn]
+                    .filter(Boolean)
+                    .filter(isDefined)}
+                  url={file.url ?? undefined}
+                  urlLabel={file.urlLabel ?? undefined}
+                />
+              ))}
+            </div>
+          </Accordion>
+        ))}
 
-        {groupByCategory(section.flatText?.filter(isPresent) ?? []).map((text, index) => (
-          // eslint-disable-next-line react/no-array-index-key
-          <Accordion key={`flatText-${index}`} title={text.category}>
+        {groupByCategory(flatText?.filter(isPresent) ?? []).map((text, index) => (
+          <Accordion
+            // eslint-disable-next-line react/no-array-index-key
+            key={`flatText-${index}`}
+            title={text.category}
+            accordionTitleLevel={accordionTitleLevel}
+          >
             {text.items.filter(isPresent).map((item, itemIndex) => {
               return (
                 // eslint-disable-next-line react/no-array-index-key
@@ -83,12 +98,13 @@ const AccordionSection = ({ section }: AccordionSectionProps) => {
           </Accordion>
         ))}
 
-        {groupByCategory(section.institutionsNarrow?.filter(isPresent) ?? []).map((text, index) => (
+        {groupByCategory(institutionsNarrow?.filter(isPresent) ?? []).map((text, index) => (
           // eslint-disable-next-line react/no-array-index-key
           <Accordion
             // eslint-disable-next-line react/no-array-index-key
             key={`institutionsNarrow-${index}`}
             title={text.category}
+            accordionTitleLevel={accordionTitleLevel}
           >
             <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
               {text.items.filter(isPresent).map((file, fileIndex) => (

--- a/next/src/components/sections/DocumentsSection/DocumentsSection.tsx
+++ b/next/src/components/sections/DocumentsSection/DocumentsSection.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'next-i18next'
 import React, { Fragment } from 'react'
 
 import DocumentRowCard from '@/src/components/cards/DocumentRowCard'
+import { getCardTitleLevel } from '@/src/components/cards/getCardTitleLevel'
 import HorizontalDivider from '@/src/components/common/Divider/HorizontalDivider'
 import SectionContainer from '@/src/components/layouts/SectionContainer'
 import SectionHeader from '@/src/components/layouts/SectionHeader'
@@ -25,7 +26,7 @@ const DocumentsSection = ({ section }: Props) => {
   const { t } = useTranslation()
   const locale = useLocale()
 
-  const { title, text, documents, showAll } = section
+  const { title, text, documents, showAll, titleLevelDocumentsSection: titleLevel } = section
 
   if (showAll) {
     return (
@@ -40,7 +41,7 @@ const DocumentsSection = ({ section }: Props) => {
   return (
     <SectionContainer>
       <div className="flex flex-col gap-4 lg:gap-6">
-        <SectionHeader title={title} text={text} />
+        <SectionHeader title={title} titleLevel={titleLevel} text={text} />
 
         <ul className="flex flex-col rounded-lg border py-2">
           {filteredDocuments
@@ -66,6 +67,7 @@ const DocumentsSection = ({ section }: Props) => {
                     <DocumentRowCard
                       linkHref={isSingleFile ? (url ?? '#') : `/dokumenty/${slug}`}
                       title={documentTitle}
+                      cardTitleLevel={getCardTitleLevel(titleLevel)}
                       variant={isSingleFile ? 'single-file' : 'multiple-files'}
                       className="px-4 lg:px-6"
                       ariaLabel={

--- a/next/src/components/sections/FaqsSection.tsx
+++ b/next/src/components/sections/FaqsSection.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { getCardTitleLevel } from '@/src/components/cards/getCardTitleLevel'
 import FaqsGroup from '@/src/components/common/FaqsGroup/FaqsGroup'
 import SectionContainer from '@/src/components/layouts/SectionContainer'
 import SectionHeader from '@/src/components/layouts/SectionHeader'
@@ -15,16 +16,19 @@ type Props = {
  */
 
 const FaqsSection = ({ section }: Props) => {
-  const { title, text, faqs } = section ?? {}
+  const { title, text, faqs, titleLevelFaqsSection: titleLevel } = section ?? {}
 
   const filteredFaqs = faqs.filter(isDefined) ?? []
+
+  // If no section title is provided, accordions act as h2, otherwise they accommodate to section titleLevel
+  const accordionTitleLevel = title ? getCardTitleLevel(titleLevel) : 'h2'
 
   return (
     <SectionContainer>
       <div className="flex flex-col gap-6 lg:gap-12">
-        <SectionHeader title={title} text={text} />
+        <SectionHeader title={title} titleLevel={titleLevel} text={text} />
 
-        <FaqsGroup faqs={filteredFaqs} />
+        <FaqsGroup faqs={filteredFaqs} accordionTitleLevel={accordionTitleLevel} />
       </div>
     </SectionContainer>
   )

--- a/next/src/components/sections/FileListSection.tsx
+++ b/next/src/components/sections/FileListSection.tsx
@@ -20,6 +20,7 @@ const FileListSection = ({ section }: FileListSectionProps) => {
         title={section.title}
         text={section.text}
         files={section.fileList?.filter(isDefined) ?? []}
+        titleLevel={section.titleLevelFileListSection}
       />
     </SectionContainer>
   )

--- a/next/src/components/sections/GallerySection.tsx
+++ b/next/src/components/sections/GallerySection.tsx
@@ -10,11 +10,13 @@ export type GallerySectionProps = {
   section: GallerySectionFragment
 }
 
-const GallerySection = ({ section: { title, text, medias } }: GallerySectionProps) => {
+const GallerySection = ({
+  section: { title, text, medias, titleLevelGallerySection: titleLevel },
+}: GallerySectionProps) => {
   return (
     <SectionContainer>
       <div className="flex flex-col gap-6 lg:gap-12">
-        <SectionHeader title={title} text={text} />
+        <SectionHeader title={title} titleLevel={titleLevel} text={text} />
         <Gallery images={medias.filter(isDefined)} />
       </div>
     </SectionContainer>

--- a/next/src/components/sections/IframeSection.tsx
+++ b/next/src/components/sections/IframeSection.tsx
@@ -9,7 +9,7 @@ type IframeSectionProps = { section: IframeSectionFragment }
 const IframeSection = ({ section }: IframeSectionProps) => {
   return (
     <SectionContainer>
-      <Iframe {...section} />
+      <Iframe {...section} titleLevel={section.titleLevelIframeSection} />
     </SectionContainer>
   )
 }

--- a/next/src/components/sections/LinksSection.tsx
+++ b/next/src/components/sections/LinksSection.tsx
@@ -11,7 +11,11 @@ type LinksSectionProps = {
 const LinksSection = ({ section }: LinksSectionProps) => {
   return (
     <SectionContainer>
-      <Links title={section.title} pageLinks={section.pageLinks} />
+      <Links
+        title={section.title}
+        titleLevel={section.titleLevelLinksSection}
+        pageLinks={section.pageLinks}
+      />
     </SectionContainer>
   )
 }

--- a/next/src/components/sections/PartnersSection.tsx
+++ b/next/src/components/sections/PartnersSection.tsx
@@ -18,7 +18,7 @@ type Props = {
  */
 
 const PartnersSection = ({ section }: Props) => {
-  const { title, text, partners, logoRatio } = section
+  const { title, text, partners, logoRatio, titleLevelPartnersSection: titleLevel } = section
 
   const filteredPartners = partners.filter(isDefined)
   const count = filteredPartners.length
@@ -26,7 +26,7 @@ const PartnersSection = ({ section }: Props) => {
   return (
     <SectionContainer>
       <div className="flex flex-col gap-6 lg:gap-8">
-        <SectionHeader title={title} text={text} />
+        <SectionHeader title={title} titleLevel={titleLevel} text={text} />
 
         <div
           className={cn('grid gap-6 gap-y-4 lg:gap-12', {

--- a/next/src/components/sections/VideosSection.tsx
+++ b/next/src/components/sections/VideosSection.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { getCardTitleLevel } from '@/src/components/cards/getCardTitleLevel'
 import VideoCard from '@/src/components/cards/VideoCard'
 import { AllowedVisibleCount } from '@/src/components/common/Carousel/Carousel'
 import ResponsiveCarousel from '@/src/components/common/Carousel/ResponsiveCarousel'
@@ -13,7 +14,7 @@ type Props = {
 }
 
 const VideosSection = ({ section }: Props) => {
-  const { title, subtitle, videos } = section
+  const { title, subtitle, videos, titleLevelVideosSection: titleLevel } = section
 
   const filteredVideos = videos?.filter(isDefined) ?? []
   const videosCount = filteredVideos.length
@@ -21,13 +22,13 @@ const VideosSection = ({ section }: Props) => {
   return (
     <SectionContainer>
       <div className="flex flex-col gap-6 lg:gap-8">
-        <SectionHeader title={title} text={subtitle} />
+        <SectionHeader title={title} titleLevel={titleLevel} text={subtitle} />
 
         {/* Using carousel for simplicity, it'll "behave as carousel" on desktop only if there is more than 4 videos  */}
         <ResponsiveCarousel
           hasVerticalPadding={false}
           items={filteredVideos.map((video) => (
-            <VideoCard key={video.id} {...video} />
+            <VideoCard key={video.id} cardTitleLevel={getCardTitleLevel(titleLevel)} {...video} />
           ))}
           desktop={videosCount > 0 && videosCount <= 4 ? (videosCount as AllowedVisibleCount) : 4}
         />

--- a/next/src/services/graphql/index.ts
+++ b/next/src/services/graphql/index.ts
@@ -1511,6 +1511,7 @@ export type ComponentSectionsDocuments = {
   showAll?: Maybe<Scalars['Boolean']['output']>
   text?: Maybe<Scalars['String']['output']>
   title?: Maybe<Scalars['String']['output']>
+  titleLevel?: Maybe<Enum_Componentsectionsdocuments_Titlelevel>
 }
 
 export type ComponentSectionsDocumentsDocumentsArgs = {
@@ -1533,6 +1534,7 @@ export type ComponentSectionsDocumentsFiltersInput = {
   showAll?: InputMaybe<BooleanFilterInput>
   text?: InputMaybe<StringFilterInput>
   title?: InputMaybe<StringFilterInput>
+  titleLevel?: InputMaybe<StringFilterInput>
 }
 
 export type ComponentSectionsDocumentsInput = {
@@ -1541,6 +1543,7 @@ export type ComponentSectionsDocumentsInput = {
   showAll?: InputMaybe<Scalars['Boolean']['input']>
   text?: InputMaybe<Scalars['String']['input']>
   title?: InputMaybe<Scalars['String']['input']>
+  titleLevel?: InputMaybe<Enum_Componentsectionsdocuments_Titlelevel>
 }
 
 export type ComponentSectionsFaqCategories = {
@@ -1883,6 +1886,7 @@ export type ComponentSectionsLinks = {
   id: Scalars['ID']['output']
   pageLinks?: Maybe<Array<Maybe<ComponentBlocksPageLink>>>
   title?: Maybe<Scalars['String']['output']>
+  titleLevel?: Maybe<Enum_Componentsectionslinks_Titlelevel>
 }
 
 export type ComponentSectionsLinksPageLinksArgs = {
@@ -1897,12 +1901,14 @@ export type ComponentSectionsLinksFiltersInput = {
   or?: InputMaybe<Array<InputMaybe<ComponentSectionsLinksFiltersInput>>>
   pageLinks?: InputMaybe<ComponentBlocksPageLinkFiltersInput>
   title?: InputMaybe<StringFilterInput>
+  titleLevel?: InputMaybe<StringFilterInput>
 }
 
 export type ComponentSectionsLinksInput = {
   id?: InputMaybe<Scalars['ID']['input']>
   pageLinks?: InputMaybe<Array<InputMaybe<ComponentBlocksPageLinkInput>>>
   title?: InputMaybe<Scalars['String']['input']>
+  titleLevel?: InputMaybe<Enum_Componentsectionslinks_Titlelevel>
 }
 
 export type ComponentSectionsNarrowText = {
@@ -2640,9 +2646,19 @@ export enum Enum_Componentsectionsdivider_Style {
   Vzdelavanie = 'vzdelavanie',
 }
 
+export enum Enum_Componentsectionsdocuments_Titlelevel {
+  H2 = 'h2',
+  H3 = 'h3',
+}
+
 export enum Enum_Componentsectionsiframe_Iframewidth {
   Container = 'container',
   Full = 'full',
+}
+
+export enum Enum_Componentsectionslinks_Titlelevel {
+  H2 = 'h2',
+  H3 = 'h3',
 }
 
 export enum Enum_Componentsectionsnarrowtext_Width {
@@ -8493,6 +8509,7 @@ export type PageEntityFragment = {
         title?: string | null
         text?: string | null
         showAll?: boolean | null
+        titleLevelDocumentsSection?: Enum_Componentsectionsdocuments_Titlelevel | null
         documents: Array<{
           __typename: 'Document'
           publishedAt?: any | null
@@ -8604,6 +8621,7 @@ export type PageEntityFragment = {
     | {
         __typename: 'ComponentSectionsLinks'
         title?: string | null
+        titleLevelLinksSection?: Enum_Componentsectionslinks_Titlelevel | null
         pageLinks?: Array<{
           __typename?: 'ComponentBlocksPageLink'
           url?: string | null
@@ -9214,6 +9232,7 @@ export type PageBySlugQuery = {
           title?: string | null
           text?: string | null
           showAll?: boolean | null
+          titleLevelDocumentsSection?: Enum_Componentsectionsdocuments_Titlelevel | null
           documents: Array<{
             __typename: 'Document'
             publishedAt?: any | null
@@ -9325,6 +9344,7 @@ export type PageBySlugQuery = {
       | {
           __typename: 'ComponentSectionsLinks'
           title?: string | null
+          titleLevelLinksSection?: Enum_Componentsectionslinks_Titlelevel | null
           pageLinks?: Array<{
             __typename?: 'ComponentBlocksPageLink'
             url?: string | null
@@ -9961,6 +9981,7 @@ export type Dev_AllPagesQuery = {
           title?: string | null
           text?: string | null
           showAll?: boolean | null
+          titleLevelDocumentsSection?: Enum_Componentsectionsdocuments_Titlelevel | null
           documents: Array<{
             __typename: 'Document'
             publishedAt?: any | null
@@ -10072,6 +10093,7 @@ export type Dev_AllPagesQuery = {
       | {
           __typename: 'ComponentSectionsLinks'
           title?: string | null
+          titleLevelLinksSection?: Enum_Componentsectionslinks_Titlelevel | null
           pageLinks?: Array<{
             __typename?: 'ComponentBlocksPageLink'
             url?: string | null
@@ -11200,6 +11222,7 @@ export type NarrowTextSectionFragment = {
 export type LinksSectionFragment = {
   __typename?: 'ComponentSectionsLinks'
   title?: string | null
+  titleLevelLinksSection?: Enum_Componentsectionslinks_Titlelevel | null
   pageLinks?: Array<{
     __typename?: 'ComponentBlocksPageLink'
     url?: string | null
@@ -11730,6 +11753,7 @@ export type DocumentsSectionFragment = {
   title?: string | null
   text?: string | null
   showAll?: boolean | null
+  titleLevelDocumentsSection?: Enum_Componentsectionsdocuments_Titlelevel | null
   documents: Array<{
     __typename: 'Document'
     publishedAt?: any | null
@@ -11990,6 +12014,7 @@ type Sections_ComponentSectionsDocuments_Fragment = {
   title?: string | null
   text?: string | null
   showAll?: boolean | null
+  titleLevelDocumentsSection?: Enum_Componentsectionsdocuments_Titlelevel | null
   documents: Array<{
     __typename: 'Document'
     publishedAt?: any | null
@@ -12113,6 +12138,7 @@ type Sections_ComponentSectionsInbaReleases_Fragment = {
 type Sections_ComponentSectionsLinks_Fragment = {
   __typename: 'ComponentSectionsLinks'
   title?: string | null
+  titleLevelLinksSection?: Enum_Componentsectionslinks_Titlelevel | null
   pageLinks?: Array<{
     __typename?: 'ComponentBlocksPageLink'
     url?: string | null
@@ -13116,6 +13142,7 @@ export const LinksSectionFragmentDoc = gql`
     pageLinks(pagination: { limit: -1 }) {
       ...PageLink
     }
+    titleLevelLinksSection: titleLevel
   }
   ${PageLinkFragmentDoc}
 `
@@ -13533,6 +13560,7 @@ export const DocumentsSectionFragmentDoc = gql`
       ...DocumentEntity
     }
     showAll
+    titleLevelDocumentsSection: titleLevel
   }
   ${DocumentEntityFragmentDoc}
 `

--- a/next/src/services/graphql/index.ts
+++ b/next/src/services/graphql/index.ts
@@ -1193,6 +1193,7 @@ export type ComponentSectionsAccordion = {
   institutions?: Maybe<Array<Maybe<ComponentAccordionItemsInstitution>>>
   institutionsNarrow?: Maybe<Array<Maybe<ComponentAccordionItemsInstitutionNarrow>>>
   title?: Maybe<Scalars['String']['output']>
+  titleLevel?: Maybe<Enum_Componentsectionsaccordion_Titlelevel>
 }
 
 export type ComponentSectionsAccordionFlatTextArgs = {
@@ -1221,6 +1222,7 @@ export type ComponentSectionsAccordionFiltersInput = {
   not?: InputMaybe<ComponentSectionsAccordionFiltersInput>
   or?: InputMaybe<Array<InputMaybe<ComponentSectionsAccordionFiltersInput>>>
   title?: InputMaybe<StringFilterInput>
+  titleLevel?: InputMaybe<StringFilterInput>
 }
 
 export type ComponentSectionsAccordionInput = {
@@ -1229,6 +1231,7 @@ export type ComponentSectionsAccordionInput = {
   institutions?: InputMaybe<Array<InputMaybe<ComponentAccordionItemsInstitutionInput>>>
   institutionsNarrow?: InputMaybe<Array<InputMaybe<ComponentAccordionItemsInstitutionNarrowInput>>>
   title?: InputMaybe<Scalars['String']['input']>
+  titleLevel?: InputMaybe<Enum_Componentsectionsaccordion_Titlelevel>
 }
 
 export type ComponentSectionsArticles = {
@@ -1420,6 +1423,7 @@ export type ComponentSectionsContactsSection = {
   personContacts?: Maybe<Array<Maybe<ComponentBlocksContactPersonCard>>>
   phoneContacts?: Maybe<Array<Maybe<ComponentBlocksContactCard>>>
   title?: Maybe<Scalars['String']['output']>
+  titleLevel?: Maybe<Enum_Componentsectionscontactssection_Titlelevel>
   webContacts?: Maybe<Array<Maybe<ComponentBlocksContactCard>>>
 }
 
@@ -1470,6 +1474,7 @@ export type ComponentSectionsContactsSectionFiltersInput = {
   personContacts?: InputMaybe<ComponentBlocksContactPersonCardFiltersInput>
   phoneContacts?: InputMaybe<ComponentBlocksContactCardFiltersInput>
   title?: InputMaybe<StringFilterInput>
+  titleLevel?: InputMaybe<StringFilterInput>
   webContacts?: InputMaybe<ComponentBlocksContactCardFiltersInput>
 }
 
@@ -1482,6 +1487,7 @@ export type ComponentSectionsContactsSectionInput = {
   personContacts?: InputMaybe<Array<InputMaybe<ComponentBlocksContactPersonCardInput>>>
   phoneContacts?: InputMaybe<Array<InputMaybe<ComponentBlocksContactCardInput>>>
   title?: InputMaybe<Scalars['String']['input']>
+  titleLevel?: InputMaybe<Enum_Componentsectionscontactssection_Titlelevel>
   webContacts?: InputMaybe<Array<InputMaybe<ComponentBlocksContactCardInput>>>
 }
 
@@ -1590,6 +1596,7 @@ export type ComponentSectionsFaqs = {
   id: Scalars['ID']['output']
   text?: Maybe<Scalars['String']['output']>
   title?: Maybe<Scalars['String']['output']>
+  titleLevel?: Maybe<Enum_Componentsectionsfaqs_Titlelevel>
 }
 
 export type ComponentSectionsFaqsFaqsArgs = {
@@ -1611,6 +1618,7 @@ export type ComponentSectionsFaqsFiltersInput = {
   or?: InputMaybe<Array<InputMaybe<ComponentSectionsFaqsFiltersInput>>>
   text?: InputMaybe<StringFilterInput>
   title?: InputMaybe<StringFilterInput>
+  titleLevel?: InputMaybe<StringFilterInput>
 }
 
 export type ComponentSectionsFaqsInput = {
@@ -1618,6 +1626,7 @@ export type ComponentSectionsFaqsInput = {
   id?: InputMaybe<Scalars['ID']['input']>
   text?: InputMaybe<Scalars['String']['input']>
   title?: InputMaybe<Scalars['String']['input']>
+  titleLevel?: InputMaybe<Enum_Componentsectionsfaqs_Titlelevel>
 }
 
 export type ComponentSectionsFileList = {
@@ -1626,6 +1635,7 @@ export type ComponentSectionsFileList = {
   id: Scalars['ID']['output']
   text?: Maybe<Scalars['String']['output']>
   title?: Maybe<Scalars['String']['output']>
+  titleLevel?: Maybe<Enum_Componentsectionsfilelist_Titlelevel>
 }
 
 export type ComponentSectionsFileListFileListArgs = {
@@ -1641,6 +1651,7 @@ export type ComponentSectionsFileListFiltersInput = {
   or?: InputMaybe<Array<InputMaybe<ComponentSectionsFileListFiltersInput>>>
   text?: InputMaybe<StringFilterInput>
   title?: InputMaybe<StringFilterInput>
+  titleLevel?: InputMaybe<StringFilterInput>
 }
 
 export type ComponentSectionsFileListInput = {
@@ -1648,6 +1659,7 @@ export type ComponentSectionsFileListInput = {
   id?: InputMaybe<Scalars['ID']['input']>
   text?: InputMaybe<Scalars['String']['input']>
   title?: InputMaybe<Scalars['String']['input']>
+  titleLevel?: InputMaybe<Enum_Componentsectionsfilelist_Titlelevel>
 }
 
 export type ComponentSectionsGallery = {
@@ -1657,6 +1669,7 @@ export type ComponentSectionsGallery = {
   medias_connection: UploadFileRelationResponseCollection
   text?: Maybe<Scalars['String']['output']>
   title?: Maybe<Scalars['String']['output']>
+  titleLevel?: Maybe<Enum_Componentsectionsgallery_Titlelevel>
 }
 
 export type ComponentSectionsGalleryMediasArgs = {
@@ -1677,6 +1690,7 @@ export type ComponentSectionsGalleryFiltersInput = {
   or?: InputMaybe<Array<InputMaybe<ComponentSectionsGalleryFiltersInput>>>
   text?: InputMaybe<StringFilterInput>
   title?: InputMaybe<StringFilterInput>
+  titleLevel?: InputMaybe<StringFilterInput>
 }
 
 export type ComponentSectionsGalleryInput = {
@@ -1684,6 +1698,7 @@ export type ComponentSectionsGalleryInput = {
   medias?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>
   text?: InputMaybe<Scalars['String']['input']>
   title?: InputMaybe<Scalars['String']['input']>
+  titleLevel?: InputMaybe<Enum_Componentsectionsgallery_Titlelevel>
 }
 
 export type ComponentSectionsHomepageEvents = {
@@ -1808,6 +1823,7 @@ export type ComponentSectionsIframe = {
   iframeWidth: Enum_Componentsectionsiframe_Iframewidth
   text?: Maybe<Scalars['String']['output']>
   title?: Maybe<Scalars['String']['output']>
+  titleLevel?: Maybe<Enum_Componentsectionsiframe_Titlelevel>
   url: Scalars['String']['output']
 }
 
@@ -1823,6 +1839,7 @@ export type ComponentSectionsIframeFiltersInput = {
   or?: InputMaybe<Array<InputMaybe<ComponentSectionsIframeFiltersInput>>>
   text?: InputMaybe<StringFilterInput>
   title?: InputMaybe<StringFilterInput>
+  titleLevel?: InputMaybe<StringFilterInput>
   url?: InputMaybe<StringFilterInput>
 }
 
@@ -1836,6 +1853,7 @@ export type ComponentSectionsIframeInput = {
   iframeWidth?: InputMaybe<Enum_Componentsectionsiframe_Iframewidth>
   text?: InputMaybe<Scalars['String']['input']>
   title?: InputMaybe<Scalars['String']['input']>
+  titleLevel?: InputMaybe<Enum_Componentsectionsiframe_Titlelevel>
   url?: InputMaybe<Scalars['String']['input']>
 }
 
@@ -2008,6 +2026,7 @@ export type ComponentSectionsPartners = {
   partners: Array<Maybe<ComponentBlocksPartner>>
   text?: Maybe<Scalars['String']['output']>
   title?: Maybe<Scalars['String']['output']>
+  titleLevel?: Maybe<Enum_Componentsectionspartners_Titlelevel>
 }
 
 export type ComponentSectionsPartnersPartnersArgs = {
@@ -2024,6 +2043,7 @@ export type ComponentSectionsPartnersFiltersInput = {
   partners?: InputMaybe<ComponentBlocksPartnerFiltersInput>
   text?: InputMaybe<StringFilterInput>
   title?: InputMaybe<StringFilterInput>
+  titleLevel?: InputMaybe<StringFilterInput>
 }
 
 export type ComponentSectionsPartnersInput = {
@@ -2032,6 +2052,7 @@ export type ComponentSectionsPartnersInput = {
   partners?: InputMaybe<Array<InputMaybe<ComponentBlocksPartnerInput>>>
   text?: InputMaybe<Scalars['String']['input']>
   title?: InputMaybe<Scalars['String']['input']>
+  titleLevel?: InputMaybe<Enum_Componentsectionspartners_Titlelevel>
 }
 
 export type ComponentSectionsProsAndConsSection = {
@@ -2257,6 +2278,7 @@ export type ComponentSectionsVideos = {
   id: Scalars['ID']['output']
   subtitle?: Maybe<Scalars['String']['output']>
   title?: Maybe<Scalars['String']['output']>
+  titleLevel?: Maybe<Enum_Componentsectionsvideos_Titlelevel>
   videos?: Maybe<Array<Maybe<ComponentBlocksVideo>>>
 }
 
@@ -2272,6 +2294,7 @@ export type ComponentSectionsVideosFiltersInput = {
   or?: InputMaybe<Array<InputMaybe<ComponentSectionsVideosFiltersInput>>>
   subtitle?: InputMaybe<StringFilterInput>
   title?: InputMaybe<StringFilterInput>
+  titleLevel?: InputMaybe<StringFilterInput>
   videos?: InputMaybe<ComponentBlocksVideoFiltersInput>
 }
 
@@ -2279,6 +2302,7 @@ export type ComponentSectionsVideosInput = {
   id?: InputMaybe<Scalars['ID']['input']>
   subtitle?: InputMaybe<Scalars['String']['input']>
   title?: InputMaybe<Scalars['String']['input']>
+  titleLevel?: InputMaybe<Enum_Componentsectionsvideos_Titlelevel>
   videos?: InputMaybe<Array<InputMaybe<ComponentBlocksVideoInput>>>
 }
 
@@ -2603,6 +2627,11 @@ export enum Enum_Componentmenumenusection_Icon {
   ZivotneProstredie_03 = 'zivotne_prostredie_03',
 }
 
+export enum Enum_Componentsectionsaccordion_Titlelevel {
+  H2 = 'h2',
+  H3 = 'h3',
+}
+
 export enum Enum_Componentsectionsbanner_Contentposition {
   Left = 'left',
   Right = 'right',
@@ -2629,6 +2658,11 @@ export enum Enum_Componentsectionscomparisonsection_Textalign {
   Left = 'left',
 }
 
+export enum Enum_Componentsectionscontactssection_Titlelevel {
+  H2 = 'h2',
+  H3 = 'h3',
+}
+
 export enum Enum_Componentsectionsdivider_Style {
   Bicykel_02FullWidth = 'bicykel_02_full_width',
   Budovy_04FullWidth = 'budovy_04_full_width',
@@ -2651,9 +2685,29 @@ export enum Enum_Componentsectionsdocuments_Titlelevel {
   H3 = 'h3',
 }
 
+export enum Enum_Componentsectionsfaqs_Titlelevel {
+  H2 = 'h2',
+  H3 = 'h3',
+}
+
+export enum Enum_Componentsectionsfilelist_Titlelevel {
+  H2 = 'h2',
+  H3 = 'h3',
+}
+
+export enum Enum_Componentsectionsgallery_Titlelevel {
+  H2 = 'h2',
+  H3 = 'h3',
+}
+
 export enum Enum_Componentsectionsiframe_Iframewidth {
   Container = 'container',
   Full = 'full',
+}
+
+export enum Enum_Componentsectionsiframe_Titlelevel {
+  H2 = 'h2',
+  H3 = 'h3',
 }
 
 export enum Enum_Componentsectionslinks_Titlelevel {
@@ -2679,6 +2733,11 @@ export enum Enum_Componentsectionspartners_Logoratio {
   Ratio_4_3 = 'ratio_4_3',
 }
 
+export enum Enum_Componentsectionspartners_Titlelevel {
+  H2 = 'h2',
+  H3 = 'h3',
+}
+
 export enum Enum_Componentsectionsprosandconssection_Textalign {
   Center = 'center',
   Left = 'left',
@@ -2699,6 +2758,11 @@ export enum Enum_Componentsectionstextwithimage_Imageaspectratio {
 export enum Enum_Componentsectionstextwithimage_Imageposition {
   Left = 'left',
   Right = 'right',
+}
+
+export enum Enum_Componentsectionsvideos_Titlelevel {
+  H2 = 'h2',
+  H3 = 'h3',
 }
 
 export enum Enum_Pagecategory_Color {
@@ -8291,6 +8355,7 @@ export type PageEntityFragment = {
     | {
         __typename: 'ComponentSectionsAccordion'
         title?: string | null
+        titleLevelAccordionSection?: Enum_Componentsectionsaccordion_Titlelevel | null
         institutions?: Array<{
           __typename?: 'ComponentAccordionItemsInstitution'
           title?: string | null
@@ -8470,6 +8535,7 @@ export type PageEntityFragment = {
         id: string
         title?: string | null
         description?: string | null
+        titleLevelContactsSection?: Enum_Componentsectionscontactssection_Titlelevel | null
         addressContacts?: Array<{
           __typename?: 'ComponentBlocksContactCard'
           overrideLabel?: string | null
@@ -8558,6 +8624,7 @@ export type PageEntityFragment = {
         __typename: 'ComponentSectionsFaqs'
         title?: string | null
         text?: string | null
+        titleLevelFaqsSection?: Enum_Componentsectionsfaqs_Titlelevel | null
         faqs: Array<{
           __typename?: 'Faq'
           documentId: string
@@ -8569,6 +8636,7 @@ export type PageEntityFragment = {
         __typename: 'ComponentSectionsFileList'
         title?: string | null
         text?: string | null
+        titleLevelFileListSection?: Enum_Componentsectionsfilelist_Titlelevel | null
         fileList?: Array<{
           __typename?: 'ComponentBlocksFile'
           id: string
@@ -8589,6 +8657,7 @@ export type PageEntityFragment = {
         __typename: 'ComponentSectionsGallery'
         title?: string | null
         text?: string | null
+        titleLevelGallerySection?: Enum_Componentsectionsgallery_Titlelevel | null
         medias: Array<{
           __typename?: 'UploadFile'
           documentId: string
@@ -8611,6 +8680,7 @@ export type PageEntityFragment = {
         allowFullscreen: boolean
         css?: string | null
         allowGeolocation?: boolean | null
+        titleLevelIframeSection?: Enum_Componentsectionsiframe_Titlelevel | null
       }
     | {
         __typename: 'ComponentSectionsInbaArticlesList'
@@ -8660,6 +8730,7 @@ export type PageEntityFragment = {
         title?: string | null
         text?: string | null
         logoRatio: Enum_Componentsectionspartners_Logoratio
+        titleLevelPartnersSection?: Enum_Componentsectionspartners_Titlelevel | null
         partners: Array<{
           __typename?: 'ComponentBlocksPartner'
           title: string
@@ -8887,6 +8958,7 @@ export type PageEntityFragment = {
         id: string
         title?: string | null
         subtitle?: string | null
+        titleLevelVideosSection?: Enum_Componentsectionsvideos_Titlelevel | null
         videos?: Array<{
           __typename?: 'ComponentBlocksVideo'
           id: string
@@ -9011,6 +9083,7 @@ export type PageBySlugQuery = {
       | {
           __typename: 'ComponentSectionsAccordion'
           title?: string | null
+          titleLevelAccordionSection?: Enum_Componentsectionsaccordion_Titlelevel | null
           institutions?: Array<{
             __typename?: 'ComponentAccordionItemsInstitution'
             title?: string | null
@@ -9190,6 +9263,7 @@ export type PageBySlugQuery = {
           id: string
           title?: string | null
           description?: string | null
+          titleLevelContactsSection?: Enum_Componentsectionscontactssection_Titlelevel | null
           addressContacts?: Array<{
             __typename?: 'ComponentBlocksContactCard'
             overrideLabel?: string | null
@@ -9281,6 +9355,7 @@ export type PageBySlugQuery = {
           __typename: 'ComponentSectionsFaqs'
           title?: string | null
           text?: string | null
+          titleLevelFaqsSection?: Enum_Componentsectionsfaqs_Titlelevel | null
           faqs: Array<{
             __typename?: 'Faq'
             documentId: string
@@ -9292,6 +9367,7 @@ export type PageBySlugQuery = {
           __typename: 'ComponentSectionsFileList'
           title?: string | null
           text?: string | null
+          titleLevelFileListSection?: Enum_Componentsectionsfilelist_Titlelevel | null
           fileList?: Array<{
             __typename?: 'ComponentBlocksFile'
             id: string
@@ -9312,6 +9388,7 @@ export type PageBySlugQuery = {
           __typename: 'ComponentSectionsGallery'
           title?: string | null
           text?: string | null
+          titleLevelGallerySection?: Enum_Componentsectionsgallery_Titlelevel | null
           medias: Array<{
             __typename?: 'UploadFile'
             documentId: string
@@ -9334,6 +9411,7 @@ export type PageBySlugQuery = {
           allowFullscreen: boolean
           css?: string | null
           allowGeolocation?: boolean | null
+          titleLevelIframeSection?: Enum_Componentsectionsiframe_Titlelevel | null
         }
       | {
           __typename: 'ComponentSectionsInbaArticlesList'
@@ -9383,6 +9461,7 @@ export type PageBySlugQuery = {
           title?: string | null
           text?: string | null
           logoRatio: Enum_Componentsectionspartners_Logoratio
+          titleLevelPartnersSection?: Enum_Componentsectionspartners_Titlelevel | null
           partners: Array<{
             __typename?: 'ComponentBlocksPartner'
             title: string
@@ -9610,6 +9689,7 @@ export type PageBySlugQuery = {
           id: string
           title?: string | null
           subtitle?: string | null
+          titleLevelVideosSection?: Enum_Componentsectionsvideos_Titlelevel | null
           videos?: Array<{
             __typename?: 'ComponentBlocksVideo'
             id: string
@@ -9760,6 +9840,7 @@ export type Dev_AllPagesQuery = {
       | {
           __typename: 'ComponentSectionsAccordion'
           title?: string | null
+          titleLevelAccordionSection?: Enum_Componentsectionsaccordion_Titlelevel | null
           institutions?: Array<{
             __typename?: 'ComponentAccordionItemsInstitution'
             title?: string | null
@@ -9939,6 +10020,7 @@ export type Dev_AllPagesQuery = {
           id: string
           title?: string | null
           description?: string | null
+          titleLevelContactsSection?: Enum_Componentsectionscontactssection_Titlelevel | null
           addressContacts?: Array<{
             __typename?: 'ComponentBlocksContactCard'
             overrideLabel?: string | null
@@ -10030,6 +10112,7 @@ export type Dev_AllPagesQuery = {
           __typename: 'ComponentSectionsFaqs'
           title?: string | null
           text?: string | null
+          titleLevelFaqsSection?: Enum_Componentsectionsfaqs_Titlelevel | null
           faqs: Array<{
             __typename?: 'Faq'
             documentId: string
@@ -10041,6 +10124,7 @@ export type Dev_AllPagesQuery = {
           __typename: 'ComponentSectionsFileList'
           title?: string | null
           text?: string | null
+          titleLevelFileListSection?: Enum_Componentsectionsfilelist_Titlelevel | null
           fileList?: Array<{
             __typename?: 'ComponentBlocksFile'
             id: string
@@ -10061,6 +10145,7 @@ export type Dev_AllPagesQuery = {
           __typename: 'ComponentSectionsGallery'
           title?: string | null
           text?: string | null
+          titleLevelGallerySection?: Enum_Componentsectionsgallery_Titlelevel | null
           medias: Array<{
             __typename?: 'UploadFile'
             documentId: string
@@ -10083,6 +10168,7 @@ export type Dev_AllPagesQuery = {
           allowFullscreen: boolean
           css?: string | null
           allowGeolocation?: boolean | null
+          titleLevelIframeSection?: Enum_Componentsectionsiframe_Titlelevel | null
         }
       | {
           __typename: 'ComponentSectionsInbaArticlesList'
@@ -10132,6 +10218,7 @@ export type Dev_AllPagesQuery = {
           title?: string | null
           text?: string | null
           logoRatio: Enum_Componentsectionspartners_Logoratio
+          titleLevelPartnersSection?: Enum_Componentsectionspartners_Titlelevel | null
           partners: Array<{
             __typename?: 'ComponentBlocksPartner'
             title: string
@@ -10359,6 +10446,7 @@ export type Dev_AllPagesQuery = {
           id: string
           title?: string | null
           subtitle?: string | null
+          titleLevelVideosSection?: Enum_Componentsectionsvideos_Titlelevel | null
           videos?: Array<{
             __typename?: 'ComponentBlocksVideo'
             id: string
@@ -10987,6 +11075,7 @@ export type GallerySectionFragment = {
   __typename?: 'ComponentSectionsGallery'
   title?: string | null
   text?: string | null
+  titleLevelGallerySection?: Enum_Componentsectionsgallery_Titlelevel | null
   medias: Array<{
     __typename?: 'UploadFile'
     documentId: string
@@ -11113,6 +11202,7 @@ export type IframeSectionFragment = {
   allowFullscreen: boolean
   css?: string | null
   allowGeolocation?: boolean | null
+  titleLevelIframeSection?: Enum_Componentsectionsiframe_Titlelevel | null
 }
 
 export type FileBlockFragment = {
@@ -11135,6 +11225,7 @@ export type FileListSectionFragment = {
   __typename?: 'ComponentSectionsFileList'
   title?: string | null
   text?: string | null
+  titleLevelFileListSection?: Enum_Componentsectionsfilelist_Titlelevel | null
   fileList?: Array<{
     __typename?: 'ComponentBlocksFile'
     id: string
@@ -11292,6 +11383,7 @@ export type ComponentAccordionItemsInstitutionFragment = {
 export type AccordionSectionFragment = {
   __typename?: 'ComponentSectionsAccordion'
   title?: string | null
+  titleLevelAccordionSection?: Enum_Componentsectionsaccordion_Titlelevel | null
   institutions?: Array<{
     __typename?: 'ComponentAccordionItemsInstitution'
     title?: string | null
@@ -11362,6 +11454,7 @@ export type VideosSectionFragment = {
   id: string
   title?: string | null
   subtitle?: string | null
+  titleLevelVideosSection?: Enum_Componentsectionsvideos_Titlelevel | null
   videos?: Array<{
     __typename?: 'ComponentBlocksVideo'
     id: string
@@ -11525,6 +11618,7 @@ export type ContactsSectionFragment = {
   id: string
   title?: string | null
   description?: string | null
+  titleLevelContactsSection?: Enum_Componentsectionscontactssection_Titlelevel | null
   addressContacts?: Array<{
     __typename?: 'ComponentBlocksContactCard'
     overrideLabel?: string | null
@@ -11657,6 +11751,7 @@ export type FaqsSectionFragment = {
   __typename?: 'ComponentSectionsFaqs'
   title?: string | null
   text?: string | null
+  titleLevelFaqsSection?: Enum_Componentsectionsfaqs_Titlelevel | null
   faqs: Array<{
     __typename?: 'Faq'
     documentId: string
@@ -11731,6 +11826,7 @@ export type PartnersSectionFragment = {
   title?: string | null
   text?: string | null
   logoRatio: Enum_Componentsectionspartners_Logoratio
+  titleLevelPartnersSection?: Enum_Componentsectionspartners_Titlelevel | null
   partners: Array<{
     __typename?: 'ComponentBlocksPartner'
     title: string
@@ -11784,6 +11880,7 @@ export type DocumentsSectionFragment = {
 type Sections_ComponentSectionsAccordion_Fragment = {
   __typename: 'ComponentSectionsAccordion'
   title?: string | null
+  titleLevelAccordionSection?: Enum_Componentsectionsaccordion_Titlelevel | null
   institutions?: Array<{
     __typename?: 'ComponentAccordionItemsInstitution'
     title?: string | null
@@ -11970,6 +12067,7 @@ type Sections_ComponentSectionsContactsSection_Fragment = {
   id: string
   title?: string | null
   description?: string | null
+  titleLevelContactsSection?: Enum_Componentsectionscontactssection_Titlelevel | null
   addressContacts?: Array<{
     __typename?: 'ComponentBlocksContactCard'
     overrideLabel?: string | null
@@ -12065,6 +12163,7 @@ type Sections_ComponentSectionsFaqs_Fragment = {
   __typename: 'ComponentSectionsFaqs'
   title?: string | null
   text?: string | null
+  titleLevelFaqsSection?: Enum_Componentsectionsfaqs_Titlelevel | null
   faqs: Array<{
     __typename?: 'Faq'
     documentId: string
@@ -12077,6 +12176,7 @@ type Sections_ComponentSectionsFileList_Fragment = {
   __typename: 'ComponentSectionsFileList'
   title?: string | null
   text?: string | null
+  titleLevelFileListSection?: Enum_Componentsectionsfilelist_Titlelevel | null
   fileList?: Array<{
     __typename?: 'ComponentBlocksFile'
     id: string
@@ -12098,6 +12198,7 @@ type Sections_ComponentSectionsGallery_Fragment = {
   __typename: 'ComponentSectionsGallery'
   title?: string | null
   text?: string | null
+  titleLevelGallerySection?: Enum_Componentsectionsgallery_Titlelevel | null
   medias: Array<{
     __typename?: 'UploadFile'
     documentId: string
@@ -12121,6 +12222,7 @@ type Sections_ComponentSectionsIframe_Fragment = {
   allowFullscreen: boolean
   css?: string | null
   allowGeolocation?: boolean | null
+  titleLevelIframeSection?: Enum_Componentsectionsiframe_Titlelevel | null
 }
 
 type Sections_ComponentSectionsInbaArticlesList_Fragment = {
@@ -12187,6 +12289,7 @@ type Sections_ComponentSectionsPartners_Fragment = {
   title?: string | null
   text?: string | null
   logoRatio: Enum_Componentsectionspartners_Logoratio
+  titleLevelPartnersSection?: Enum_Componentsectionspartners_Titlelevel | null
   partners: Array<{
     __typename?: 'ComponentBlocksPartner'
     title: string
@@ -12423,6 +12526,7 @@ type Sections_ComponentSectionsVideos_Fragment = {
   id: string
   title?: string | null
   subtitle?: string | null
+  titleLevelVideosSection?: Enum_Componentsectionsvideos_Titlelevel | null
   videos?: Array<{
     __typename?: 'ComponentBlocksVideo'
     id: string
@@ -13069,6 +13173,7 @@ export const IframeSectionFragmentDoc = gql`
     allowFullscreen
     css
     allowGeolocation
+    titleLevelIframeSection: titleLevel
   }
 `
 export const GallerySectionFragmentDoc = gql`
@@ -13078,6 +13183,7 @@ export const GallerySectionFragmentDoc = gql`
     medias(pagination: { limit: -1 }) {
       ...UploadImageEntity
     }
+    titleLevelGallerySection: titleLevel
   }
   ${UploadImageEntityFragmentDoc}
 `
@@ -13088,6 +13194,7 @@ export const FileListSectionFragmentDoc = gql`
     fileList(pagination: { limit: -1 }) {
       ...FileBlock
     }
+    titleLevelFileListSection: titleLevel
   }
   ${FileBlockFragmentDoc}
 `
@@ -13205,6 +13312,7 @@ export const AccordionSectionFragmentDoc = gql`
     institutionsNarrow(pagination: { limit: -1 }) {
       ...ComponentAccordionItemsInstitutionNarrow
     }
+    titleLevelAccordionSection: titleLevel
   }
   ${ComponentAccordionItemsInstitutionFragmentDoc}
   ${ComponentAccordionItemsFlatTextFragmentDoc}
@@ -13233,6 +13341,7 @@ export const VideosSectionFragmentDoc = gql`
     videos {
       ...VideoBlock
     }
+    titleLevelVideosSection: titleLevel
   }
   ${VideoBlockFragmentDoc}
 `
@@ -13384,6 +13493,7 @@ export const ContactsSectionFragmentDoc = gql`
     personContacts {
       ...ContactPersonCardBlock
     }
+    titleLevelContactsSection: titleLevel
   }
   ${ContactCardBlockFragmentDoc}
   ${ContactPersonCardBlockFragmentDoc}
@@ -13474,6 +13584,7 @@ export const FaqsSectionFragmentDoc = gql`
     faqs {
       ...FaqEntity
     }
+    titleLevelFaqsSection: titleLevel
   }
   ${FaqEntityFragmentDoc}
 `
@@ -13517,6 +13628,7 @@ export const PartnersSectionFragmentDoc = gql`
       ...PartnerBlock
     }
     logoRatio
+    titleLevelPartnersSection: titleLevel
   }
   ${PartnerBlockFragmentDoc}
 `

--- a/next/src/services/graphql/queries/Sections.graphql
+++ b/next/src/services/graphql/queries/Sections.graphql
@@ -121,6 +121,7 @@ fragment LinksSection on ComponentSectionsLinks {
   pageLinks(pagination: { limit: -1 }) {
     ...PageLink
   }
+  titleLevelLinksSection: titleLevel
 }
 
 fragment ComponentAccordionItemsInstitutionNarrow on ComponentAccordionItemsInstitutionNarrow {
@@ -363,6 +364,7 @@ fragment DocumentsSection on ComponentSectionsDocuments {
     ...DocumentEntity
   }
   showAll
+  titleLevelDocumentsSection: titleLevel
 }
 
 fragment Sections on PageSectionsDynamicZone {

--- a/next/src/services/graphql/queries/Sections.graphql
+++ b/next/src/services/graphql/queries/Sections.graphql
@@ -4,6 +4,7 @@ fragment GallerySection on ComponentSectionsGallery {
   medias(pagination: { limit: -1 }) {
     ...UploadImageEntity
   }
+  titleLevelGallerySection: titleLevel
 }
 
 fragment ArticlesSection on ComponentSectionsArticles {
@@ -62,6 +63,7 @@ fragment IframeSection on ComponentSectionsIframe {
   allowFullscreen
   css
   allowGeolocation
+  titleLevelIframeSection: titleLevel
 }
 
 fragment FileBlock on ComponentBlocksFile {
@@ -78,6 +80,7 @@ fragment FileListSection on ComponentSectionsFileList {
   fileList(pagination: { limit: -1 }) {
     ...FileBlock
   }
+  titleLevelFileListSection: titleLevel
 }
 
 fragment FileItemBlock on ComponentBlocksFileItem {
@@ -167,6 +170,7 @@ fragment AccordionSection on ComponentSectionsAccordion {
   institutionsNarrow(pagination: { limit: -1 }) {
     ...ComponentAccordionItemsInstitutionNarrow
   }
+  titleLevelAccordionSection: titleLevel
 }
 
 fragment CalculatorSection on ComponentSectionsCalculator {
@@ -189,6 +193,7 @@ fragment VideosSection on ComponentSectionsVideos {
   videos {
     ...VideoBlock
   }
+  titleLevelVideosSection: titleLevel
 }
 
 fragment NumericalListItemBlock on ComponentBlocksNumericalListItem {
@@ -307,6 +312,7 @@ fragment ContactsSection on ComponentSectionsContactsSection {
   personContacts {
     ...ContactPersonCardBlock
   }
+  titleLevelContactsSection: titleLevel
 }
 
 fragment RegulationsSection on ComponentSectionsRegulations {
@@ -321,6 +327,7 @@ fragment FaqsSection on ComponentSectionsFaqs {
   faqs {
     ...FaqEntity
   }
+  titleLevelFaqsSection: titleLevel
 }
 
 fragment FaqCategoriesSection on ComponentSectionsFaqCategories {
@@ -355,6 +362,7 @@ fragment PartnersSection on ComponentSectionsPartners {
     ...PartnerBlock
   }
   logoRatio
+  titleLevelPartnersSection: titleLevel
 }
 
 fragment DocumentsSection on ComponentSectionsDocuments {

--- a/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.accordion.json
+++ b/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.accordion.json
@@ -20,13 +20,28 @@
           "sortable": false
         }
       },
+      "title": {
+        "edit": {
+          "label": "Nadpis",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "title",
+          "searchable": true,
+          "sortable": true
+        }
+      },
       "institutions": {
         "edit": {
           "label": "institutions",
           "description": "",
           "placeholder": "",
           "visible": true,
-          "editable": true
+          "editable": true,
+          "mainField": "title"
         },
         "list": {
           "label": "institutions",
@@ -40,7 +55,8 @@
           "description": "",
           "placeholder": "",
           "visible": true,
-          "editable": true
+          "editable": true,
+          "mainField": "category"
         },
         "list": {
           "label": "flatText",
@@ -54,7 +70,8 @@
           "description": "",
           "placeholder": "",
           "visible": true,
-          "editable": true
+          "editable": true,
+          "mainField": "title"
         },
         "list": {
           "label": "institutionsNarrow",
@@ -62,16 +79,16 @@
           "sortable": false
         }
       },
-      "title": {
+      "titleLevel": {
         "edit": {
-          "label": "title",
-          "description": "",
+          "label": "Úroveň nadpisu sekcie",
+          "description": "Úroveň nadpisu meníme na h3 iba ak je to potrebné sémanticky. Nikdy ju nemeníme len kvôli vizuálnej veľkosti nadpisu.",
           "placeholder": "",
           "visible": true,
           "editable": true
         },
         "list": {
-          "label": "title",
+          "label": "titleLevel",
           "searchable": true,
           "sortable": true
         }
@@ -86,16 +103,11 @@
       }
     },
     "layouts": {
-      "list": [
-        "id",
-        "title",
-        "documentId"
-      ],
       "edit": [
         [
           {
             "name": "title",
-            "size": 6
+            "size": 12
           }
         ],
         [
@@ -115,7 +127,19 @@
             "name": "institutionsNarrow",
             "size": 12
           }
+        ],
+        [
+          {
+            "name": "titleLevel",
+            "size": 6
+          }
         ]
+      ],
+      "list": [
+        "id",
+        "title",
+        "documentId",
+        "titleLevel"
       ]
     },
     "isComponent": true

--- a/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.contacts-section.json
+++ b/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.contacts-section.json
@@ -54,7 +54,8 @@
           "description": "",
           "placeholder": "",
           "visible": true,
-          "editable": true
+          "editable": true,
+          "mainField": "overrideLabel"
         },
         "list": {
           "label": "addressContacts",
@@ -68,7 +69,8 @@
           "description": "",
           "placeholder": "",
           "visible": true,
-          "editable": true
+          "editable": true,
+          "mainField": "overrideLabel"
         },
         "list": {
           "label": "openingHoursContacts",
@@ -82,7 +84,8 @@
           "description": "",
           "placeholder": "",
           "visible": true,
-          "editable": true
+          "editable": true,
+          "mainField": "overrideLabel"
         },
         "list": {
           "label": "emailContacts",
@@ -96,7 +99,8 @@
           "description": "",
           "placeholder": "",
           "visible": true,
-          "editable": true
+          "editable": true,
+          "mainField": "overrideLabel"
         },
         "list": {
           "label": "phoneContacts",
@@ -110,7 +114,8 @@
           "description": "",
           "placeholder": "",
           "visible": true,
-          "editable": true
+          "editable": true,
+          "mainField": "overrideLabel"
         },
         "list": {
           "label": "webContacts",
@@ -124,12 +129,27 @@
           "description": "",
           "placeholder": "",
           "visible": true,
-          "editable": true
+          "editable": true,
+          "mainField": "title"
         },
         "list": {
           "label": "personContacts",
           "searchable": false,
           "sortable": false
+        }
+      },
+      "titleLevel": {
+        "edit": {
+          "label": "Úroveň nadpisu sekcie",
+          "description": "Úroveň nadpisu meníme na h3 iba ak je to potrebné sémanticky. Nikdy ju nemeníme len kvôli vizuálnej veľkosti nadpisu.",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "titleLevel",
+          "searchable": true,
+          "sortable": true
         }
       },
       "documentId": {
@@ -142,12 +162,6 @@
       }
     },
     "layouts": {
-      "list": [
-        "id",
-        "title",
-        "addressContacts",
-        "documentId"
-      ],
       "edit": [
         [
           {
@@ -196,7 +210,19 @@
             "name": "personContacts",
             "size": 12
           }
+        ],
+        [
+          {
+            "name": "titleLevel",
+            "size": 6
+          }
         ]
+      ],
+      "list": [
+        "id",
+        "title",
+        "addressContacts",
+        "documentId"
       ]
     },
     "isComponent": true

--- a/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.documents.json
+++ b/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.documents.json
@@ -78,8 +78,8 @@
       },
       "titleLevel": {
         "edit": {
-          "label": "Úroveň nadpisu sekcie",
-          "description": "Úroveň nadpisu meníme na h3 iba ak je to potrebné sémanticky. Nikdy ju nemeníme len kvôli vizuálnej veľkosti nadpisu.",
+          "label": "titleLevel",
+          "description": "",
           "placeholder": "",
           "visible": true,
           "editable": true
@@ -100,6 +100,12 @@
       }
     },
     "layouts": {
+      "list": [
+        "id",
+        "title",
+        "text",
+        "documents"
+      ],
       "edit": [
         [
           {
@@ -131,12 +137,6 @@
             "size": 6
           }
         ]
-      ],
-      "list": [
-        "id",
-        "title",
-        "text",
-        "documents"
       ]
     },
     "uid": "sections.documents",

--- a/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.documents.json
+++ b/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.documents.json
@@ -76,6 +76,20 @@
           "sortable": true
         }
       },
+      "titleLevel": {
+        "edit": {
+          "label": "Úroveň nadpisu sekcie",
+          "description": "Úroveň nadpisu meníme na h3 iba ak je to potrebné sémanticky. Nikdy ju nemeníme len kvôli vizuálnej veľkosti nadpisu.",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "titleLevel",
+          "searchable": true,
+          "sortable": true
+        }
+      },
       "documentId": {
         "edit": {},
         "list": {
@@ -86,12 +100,6 @@
       }
     },
     "layouts": {
-      "list": [
-        "id",
-        "title",
-        "text",
-        "documents"
-      ],
       "edit": [
         [
           {
@@ -116,7 +124,19 @@
             "name": "showAll",
             "size": 12
           }
+        ],
+        [
+          {
+            "name": "titleLevel",
+            "size": 6
+          }
         ]
+      ],
+      "list": [
+        "id",
+        "title",
+        "text",
+        "documents"
       ]
     },
     "uid": "sections.documents",

--- a/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.documents.json
+++ b/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.documents.json
@@ -78,8 +78,8 @@
       },
       "titleLevel": {
         "edit": {
-          "label": "titleLevel",
-          "description": "",
+          "label": "Úroveň nadpisu sekcie",
+          "description": "Úroveň nadpisu meníme na h3 iba ak je to potrebné sémanticky. Nikdy ju nemeníme len kvôli vizuálnej veľkosti nadpisu.",
           "placeholder": "",
           "visible": true,
           "editable": true
@@ -100,12 +100,6 @@
       }
     },
     "layouts": {
-      "list": [
-        "id",
-        "title",
-        "text",
-        "documents"
-      ],
       "edit": [
         [
           {
@@ -137,6 +131,12 @@
             "size": 6
           }
         ]
+      ],
+      "list": [
+        "id",
+        "title",
+        "text",
+        "documents"
       ]
     },
     "uid": "sections.documents",

--- a/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.faqs.json
+++ b/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.faqs.json
@@ -22,7 +22,7 @@
       },
       "title": {
         "edit": {
-          "label": "title",
+          "label": "Nadpis",
           "description": "",
           "placeholder": "",
           "visible": true,
@@ -36,7 +36,7 @@
       },
       "text": {
         "edit": {
-          "label": "text",
+          "label": "Text",
           "description": "",
           "placeholder": "",
           "visible": true,
@@ -50,7 +50,7 @@
       },
       "faqs": {
         "edit": {
-          "label": "faqs",
+          "label": "FAQs",
           "description": "",
           "placeholder": "",
           "visible": true,
@@ -63,6 +63,20 @@
           "sortable": false
         }
       },
+      "titleLevel": {
+        "edit": {
+          "label": "Úroveň nadpisu sekcie",
+          "description": "Úroveň nadpisu meníme na h3 iba ak je to potrebné sémanticky. Nikdy ju nemeníme len kvôli vizuálnej veľkosti nadpisu.",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "titleLevel",
+          "searchable": true,
+          "sortable": true
+        }
+      },
       "documentId": {
         "edit": {},
         "list": {
@@ -73,29 +87,33 @@
       }
     },
     "layouts": {
-      "list": [
-        "id",
-        "title",
-        "text",
-        "faqs"
-      ],
       "edit": [
         [
           {
             "name": "title",
-            "size": 6
+            "size": 12
           },
           {
             "name": "text",
-            "size": 6
+            "size": 12
           }
         ],
         [
           {
             "name": "faqs",
+            "size": 12
+          },
+          {
+            "name": "titleLevel",
             "size": 6
           }
         ]
+      ],
+      "list": [
+        "id",
+        "title",
+        "text",
+        "faqs"
       ]
     },
     "isComponent": true

--- a/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.file-list.json
+++ b/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.file-list.json
@@ -54,12 +54,27 @@
           "description": "",
           "placeholder": "",
           "visible": true,
-          "editable": true
+          "editable": true,
+          "mainField": "title"
         },
         "list": {
           "label": "fileList",
           "searchable": false,
           "sortable": false
+        }
+      },
+      "titleLevel": {
+        "edit": {
+          "label": "Úroveň nadpisu sekcie",
+          "description": "Úroveň nadpisu meníme na h3 iba ak je to potrebné sémanticky. Nikdy ju nemeníme len kvôli vizuálnej veľkosti nadpisu.",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "titleLevel",
+          "searchable": true,
+          "sortable": true
         }
       },
       "documentId": {
@@ -72,12 +87,6 @@
       }
     },
     "layouts": {
-      "list": [
-        "id",
-        "title",
-        "text",
-        "documentId"
-      ],
       "edit": [
         [
           {
@@ -90,7 +99,19 @@
             "name": "fileList",
             "size": 12
           }
+        ],
+        [
+          {
+            "name": "titleLevel",
+            "size": 6
+          }
         ]
+      ],
+      "list": [
+        "id",
+        "title",
+        "text",
+        "documentId"
       ]
     },
     "isComponent": true

--- a/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.gallery.json
+++ b/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.gallery.json
@@ -62,6 +62,20 @@
           "sortable": false
         }
       },
+      "titleLevel": {
+        "edit": {
+          "label": "Úroveň nadpisu sekcie",
+          "description": "Úroveň nadpisu meníme na h3 iba ak je to potrebné sémanticky. Nikdy ju nemeníme len kvôli vizuálnej veľkosti nadpisu.",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "titleLevel",
+          "searchable": true,
+          "sortable": true
+        }
+      },
       "documentId": {
         "edit": {},
         "list": {
@@ -72,11 +86,6 @@
       }
     },
     "layouts": {
-      "list": [
-        "id",
-        "title",
-        "documentId"
-      ],
       "edit": [
         [
           {
@@ -95,7 +104,19 @@
             "name": "medias",
             "size": 12
           }
+        ],
+        [
+          {
+            "name": "titleLevel",
+            "size": 6
+          }
         ]
+      ],
+      "list": [
+        "id",
+        "title",
+        "documentId",
+        "titleLevel"
       ]
     },
     "isComponent": true

--- a/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.iframe.json
+++ b/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.iframe.json
@@ -50,7 +50,7 @@
       },
       "url": {
         "edit": {
-          "label": "url",
+          "label": "Url",
           "description": "",
           "placeholder": "",
           "visible": true,
@@ -146,6 +146,20 @@
           "sortable": true
         }
       },
+      "titleLevel": {
+        "edit": {
+          "label": "Úroveň nadpisu sekcie",
+          "description": "Úroveň nadpisu meníme na h3 iba ak je to potrebné sémanticky. Nikdy ju nemeníme len kvôli vizuálnej veľkosti nadpisu.",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "titleLevel",
+          "searchable": true,
+          "sortable": true
+        }
+      },
       "documentId": {
         "edit": {},
         "list": {
@@ -156,12 +170,6 @@
       }
     },
     "layouts": {
-      "list": [
-        "id",
-        "url",
-        "allowFullscreen",
-        "css"
-      ],
       "edit": [
         [
           {
@@ -178,7 +186,7 @@
         [
           {
             "name": "url",
-            "size": 6
+            "size": 12
           },
           {
             "name": "allowFullscreen",
@@ -187,11 +195,11 @@
         ],
         [
           {
-            "name": "css",
+            "name": "iframeWidth",
             "size": 6
           },
           {
-            "name": "iframeWidth",
+            "name": "css",
             "size": 6
           }
         ],
@@ -208,9 +216,19 @@
         [
           {
             "name": "allowGeolocation",
-            "size": 4
+            "size": 6
+          },
+          {
+            "name": "titleLevel",
+            "size": 6
           }
         ]
+      ],
+      "list": [
+        "id",
+        "url",
+        "allowFullscreen",
+        "css"
       ]
     },
     "isComponent": true

--- a/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.links.json
+++ b/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.links.json
@@ -40,7 +40,8 @@
           "description": "",
           "placeholder": "",
           "visible": true,
-          "editable": true
+          "editable": true,
+          "mainField": "title"
         },
         "list": {
           "label": "pageLinks",
@@ -50,8 +51,8 @@
       },
       "titleLevel": {
         "edit": {
-          "label": "titleLevel",
-          "description": "",
+          "label": "Úroveň nadpisu sekcie",
+          "description": "Úroveň nadpisu meníme na h3 iba ak je to potrebné sémanticky. Nikdy ju nemeníme len kvôli vizuálnej veľkosti nadpisu.",
           "placeholder": "",
           "visible": true,
           "editable": true
@@ -72,12 +73,6 @@
       }
     },
     "layouts": {
-      "list": [
-        "id",
-        "title",
-        "documentId",
-        "titleLevel"
-      ],
       "edit": [
         [
           {
@@ -97,6 +92,12 @@
             "size": 6
           }
         ]
+      ],
+      "list": [
+        "id",
+        "title",
+        "documentId",
+        "titleLevel"
       ]
     },
     "isComponent": true

--- a/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.links.json
+++ b/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.links.json
@@ -40,8 +40,7 @@
           "description": "",
           "placeholder": "",
           "visible": true,
-          "editable": true,
-          "mainField": "title"
+          "editable": true
         },
         "list": {
           "label": "pageLinks",
@@ -51,8 +50,8 @@
       },
       "titleLevel": {
         "edit": {
-          "label": "Úroveň nadpisu sekcie",
-          "description": "Úroveň nadpisu meníme na h3 iba ak je to potrebné sémanticky. Nikdy ju nemeníme len kvôli vizuálnej veľkosti nadpisu.",
+          "label": "titleLevel",
+          "description": "",
           "placeholder": "",
           "visible": true,
           "editable": true
@@ -73,6 +72,12 @@
       }
     },
     "layouts": {
+      "list": [
+        "id",
+        "title",
+        "documentId",
+        "titleLevel"
+      ],
       "edit": [
         [
           {
@@ -92,12 +97,6 @@
             "size": 6
           }
         ]
-      ],
-      "list": [
-        "id",
-        "title",
-        "documentId",
-        "titleLevel"
       ]
     },
     "isComponent": true

--- a/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.links.json
+++ b/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.links.json
@@ -22,7 +22,7 @@
       },
       "title": {
         "edit": {
-          "label": "title",
+          "label": "Nadpis",
           "description": "",
           "placeholder": "",
           "visible": true,
@@ -36,16 +36,31 @@
       },
       "pageLinks": {
         "edit": {
-          "label": "pageLinks",
+          "label": "Odkazy",
           "description": "",
           "placeholder": "",
           "visible": true,
-          "editable": true
+          "editable": true,
+          "mainField": "title"
         },
         "list": {
           "label": "pageLinks",
           "searchable": false,
           "sortable": false
+        }
+      },
+      "titleLevel": {
+        "edit": {
+          "label": "Úroveň nadpisu sekcie",
+          "description": "Úroveň nadpisu meníme na h3 iba ak je to potrebné sémanticky. Nikdy ju nemeníme len kvôli vizuálnej veľkosti nadpisu.",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "titleLevel",
+          "searchable": true,
+          "sortable": true
         }
       },
       "documentId": {
@@ -58,16 +73,11 @@
       }
     },
     "layouts": {
-      "list": [
-        "id",
-        "title",
-        "documentId"
-      ],
       "edit": [
         [
           {
             "name": "title",
-            "size": 6
+            "size": 12
           }
         ],
         [
@@ -75,7 +85,19 @@
             "name": "pageLinks",
             "size": 12
           }
+        ],
+        [
+          {
+            "name": "titleLevel",
+            "size": 6
+          }
         ]
+      ],
+      "list": [
+        "id",
+        "title",
+        "documentId",
+        "titleLevel"
       ]
     },
     "isComponent": true

--- a/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.partners.json
+++ b/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.partners.json
@@ -53,7 +53,8 @@
           "description": "",
           "placeholder": "",
           "visible": true,
-          "editable": true
+          "editable": true,
+          "mainField": "title"
         },
         "list": {
           "label": "partners",
@@ -75,6 +76,20 @@
           "sortable": true
         }
       },
+      "titleLevel": {
+        "edit": {
+          "label": "Úroveň nadpisu sekcie",
+          "description": "Úroveň nadpisu meníme na h3 iba ak je to potrebné sémanticky. Nikdy ju nemeníme len kvôli vizuálnej veľkosti nadpisu.",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "titleLevel",
+          "searchable": true,
+          "sortable": true
+        }
+      },
       "documentId": {
         "edit": {},
         "list": {
@@ -85,12 +100,6 @@
       }
     },
     "layouts": {
-      "list": [
-        "id",
-        "title",
-        "text",
-        "partners"
-      ],
       "edit": [
         [
           {
@@ -114,8 +123,18 @@
           {
             "name": "logoRatio",
             "size": 6
+          },
+          {
+            "name": "titleLevel",
+            "size": 6
           }
         ]
+      ],
+      "list": [
+        "id",
+        "title",
+        "text",
+        "partners"
       ]
     },
     "uid": "sections.partners",

--- a/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.videos.json
+++ b/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.videos.json
@@ -54,12 +54,27 @@
           "description": "",
           "placeholder": "",
           "visible": true,
-          "editable": true
+          "editable": true,
+          "mainField": "url"
         },
         "list": {
           "label": "videos",
           "searchable": false,
           "sortable": false
+        }
+      },
+      "titleLevel": {
+        "edit": {
+          "label": "Úroveň nadpisu sekcie",
+          "description": "Úroveň nadpisu meníme na h3 iba ak je to potrebné sémanticky. Nikdy ju nemeníme len kvôli vizuálnej veľkosti nadpisu.",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "titleLevel",
+          "searchable": true,
+          "sortable": true
         }
       },
       "documentId": {
@@ -72,12 +87,6 @@
       }
     },
     "layouts": {
-      "list": [
-        "id",
-        "title",
-        "subtitle",
-        "documentId"
-      ],
       "edit": [
         [
           {
@@ -94,7 +103,19 @@
             "name": "videos",
             "size": 12
           }
+        ],
+        [
+          {
+            "name": "titleLevel",
+            "size": 6
+          }
         ]
+      ],
+      "list": [
+        "id",
+        "title",
+        "subtitle",
+        "documentId"
       ]
     },
     "isComponent": true

--- a/strapi/schema.graphql
+++ b/strapi/schema.graphql
@@ -937,6 +937,7 @@ type ComponentSectionsAccordion {
   institutions(filters: ComponentAccordionItemsInstitutionFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): [ComponentAccordionItemsInstitution]
   institutionsNarrow(filters: ComponentAccordionItemsInstitutionNarrowFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): [ComponentAccordionItemsInstitutionNarrow]
   title: String
+  titleLevel: ENUM_COMPONENTSECTIONSACCORDION_TITLELEVEL
 }
 
 input ComponentSectionsAccordionFiltersInput {
@@ -947,6 +948,7 @@ input ComponentSectionsAccordionFiltersInput {
   not: ComponentSectionsAccordionFiltersInput
   or: [ComponentSectionsAccordionFiltersInput]
   title: StringFilterInput
+  titleLevel: StringFilterInput
 }
 
 input ComponentSectionsAccordionInput {
@@ -955,6 +957,7 @@ input ComponentSectionsAccordionInput {
   institutions: [ComponentAccordionItemsInstitutionInput]
   institutionsNarrow: [ComponentAccordionItemsInstitutionNarrowInput]
   title: String
+  titleLevel: ENUM_COMPONENTSECTIONSACCORDION_TITLELEVEL
 }
 
 type ComponentSectionsArticles {
@@ -1127,6 +1130,7 @@ type ComponentSectionsContactsSection {
   personContacts(filters: ComponentBlocksContactPersonCardFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): [ComponentBlocksContactPersonCard]
   phoneContacts(filters: ComponentBlocksContactCardFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): [ComponentBlocksContactCard]
   title: String
+  titleLevel: ENUM_COMPONENTSECTIONSCONTACTSSECTION_TITLELEVEL
   webContacts(filters: ComponentBlocksContactCardFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): [ComponentBlocksContactCard]
 }
 
@@ -1141,6 +1145,7 @@ input ComponentSectionsContactsSectionFiltersInput {
   personContacts: ComponentBlocksContactPersonCardFiltersInput
   phoneContacts: ComponentBlocksContactCardFiltersInput
   title: StringFilterInput
+  titleLevel: StringFilterInput
   webContacts: ComponentBlocksContactCardFiltersInput
 }
 
@@ -1153,6 +1158,7 @@ input ComponentSectionsContactsSectionInput {
   personContacts: [ComponentBlocksContactPersonCardInput]
   phoneContacts: [ComponentBlocksContactCardInput]
   title: String
+  titleLevel: ENUM_COMPONENTSECTIONSCONTACTSSECTION_TITLELEVEL
   webContacts: [ComponentBlocksContactCardInput]
 }
 
@@ -1233,6 +1239,7 @@ type ComponentSectionsFaqs {
   id: ID!
   text: String
   title: String
+  titleLevel: ENUM_COMPONENTSECTIONSFAQS_TITLELEVEL
 }
 
 input ComponentSectionsFaqsFiltersInput {
@@ -1242,6 +1249,7 @@ input ComponentSectionsFaqsFiltersInput {
   or: [ComponentSectionsFaqsFiltersInput]
   text: StringFilterInput
   title: StringFilterInput
+  titleLevel: StringFilterInput
 }
 
 input ComponentSectionsFaqsInput {
@@ -1249,6 +1257,7 @@ input ComponentSectionsFaqsInput {
   id: ID
   text: String
   title: String
+  titleLevel: ENUM_COMPONENTSECTIONSFAQS_TITLELEVEL
 }
 
 type ComponentSectionsFileList {
@@ -1256,6 +1265,7 @@ type ComponentSectionsFileList {
   id: ID!
   text: String
   title: String
+  titleLevel: ENUM_COMPONENTSECTIONSFILELIST_TITLELEVEL
 }
 
 input ComponentSectionsFileListFiltersInput {
@@ -1265,6 +1275,7 @@ input ComponentSectionsFileListFiltersInput {
   or: [ComponentSectionsFileListFiltersInput]
   text: StringFilterInput
   title: StringFilterInput
+  titleLevel: StringFilterInput
 }
 
 input ComponentSectionsFileListInput {
@@ -1272,6 +1283,7 @@ input ComponentSectionsFileListInput {
   id: ID
   text: String
   title: String
+  titleLevel: ENUM_COMPONENTSECTIONSFILELIST_TITLELEVEL
 }
 
 type ComponentSectionsGallery {
@@ -1280,6 +1292,7 @@ type ComponentSectionsGallery {
   medias_connection(filters: UploadFileFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): UploadFileRelationResponseCollection!
   text: String
   title: String
+  titleLevel: ENUM_COMPONENTSECTIONSGALLERY_TITLELEVEL
 }
 
 input ComponentSectionsGalleryFiltersInput {
@@ -1288,6 +1301,7 @@ input ComponentSectionsGalleryFiltersInput {
   or: [ComponentSectionsGalleryFiltersInput]
   text: StringFilterInput
   title: StringFilterInput
+  titleLevel: StringFilterInput
 }
 
 input ComponentSectionsGalleryInput {
@@ -1295,6 +1309,7 @@ input ComponentSectionsGalleryInput {
   medias: [ID]
   text: String
   title: String
+  titleLevel: ENUM_COMPONENTSECTIONSGALLERY_TITLELEVEL
 }
 
 type ComponentSectionsHomepageEvents {
@@ -1408,6 +1423,7 @@ type ComponentSectionsIframe {
   iframeWidth: ENUM_COMPONENTSECTIONSIFRAME_IFRAMEWIDTH!
   text: String
   title: String
+  titleLevel: ENUM_COMPONENTSECTIONSIFRAME_TITLELEVEL
   url: String!
 }
 
@@ -1423,6 +1439,7 @@ input ComponentSectionsIframeFiltersInput {
   or: [ComponentSectionsIframeFiltersInput]
   text: StringFilterInput
   title: StringFilterInput
+  titleLevel: StringFilterInput
   url: StringFilterInput
 }
 
@@ -1436,6 +1453,7 @@ input ComponentSectionsIframeInput {
   iframeWidth: ENUM_COMPONENTSECTIONSIFRAME_IFRAMEWIDTH
   text: String
   title: String
+  titleLevel: ENUM_COMPONENTSECTIONSIFRAME_TITLELEVEL
   url: String
 }
 
@@ -1588,6 +1606,7 @@ type ComponentSectionsPartners {
   partners(filters: ComponentBlocksPartnerFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): [ComponentBlocksPartner]!
   text: String
   title: String
+  titleLevel: ENUM_COMPONENTSECTIONSPARTNERS_TITLELEVEL
 }
 
 input ComponentSectionsPartnersFiltersInput {
@@ -1598,6 +1617,7 @@ input ComponentSectionsPartnersFiltersInput {
   partners: ComponentBlocksPartnerFiltersInput
   text: StringFilterInput
   title: StringFilterInput
+  titleLevel: StringFilterInput
 }
 
 input ComponentSectionsPartnersInput {
@@ -1606,6 +1626,7 @@ input ComponentSectionsPartnersInput {
   partners: [ComponentBlocksPartnerInput]
   text: String
   title: String
+  titleLevel: ENUM_COMPONENTSECTIONSPARTNERS_TITLELEVEL
 }
 
 type ComponentSectionsProsAndConsSection {
@@ -1786,6 +1807,7 @@ type ComponentSectionsVideos {
   id: ID!
   subtitle: String
   title: String
+  titleLevel: ENUM_COMPONENTSECTIONSVIDEOS_TITLELEVEL
   videos(filters: ComponentBlocksVideoFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): [ComponentBlocksVideo]
 }
 
@@ -1795,6 +1817,7 @@ input ComponentSectionsVideosFiltersInput {
   or: [ComponentSectionsVideosFiltersInput]
   subtitle: StringFilterInput
   title: StringFilterInput
+  titleLevel: StringFilterInput
   videos: ComponentBlocksVideoFiltersInput
 }
 
@@ -1802,6 +1825,7 @@ input ComponentSectionsVideosInput {
   id: ID
   subtitle: String
   title: String
+  titleLevel: ENUM_COMPONENTSECTIONSVIDEOS_TITLELEVEL
   videos: [ComponentBlocksVideoInput]
 }
 
@@ -2087,6 +2111,11 @@ enum ENUM_COMPONENTMENUMENUSECTION_ICON {
   zivotne_prostredie_03
 }
 
+enum ENUM_COMPONENTSECTIONSACCORDION_TITLELEVEL {
+  h2
+  h3
+}
+
 enum ENUM_COMPONENTSECTIONSBANNER_CONTENTPOSITION {
   left
   right
@@ -2113,6 +2142,11 @@ enum ENUM_COMPONENTSECTIONSCOMPARISONSECTION_TEXTALIGN {
   left
 }
 
+enum ENUM_COMPONENTSECTIONSCONTACTSSECTION_TITLELEVEL {
+  h2
+  h3
+}
+
 enum ENUM_COMPONENTSECTIONSDIVIDER_STYLE {
   bicykel_02_full_width
   budovy_04_full_width
@@ -2135,9 +2169,29 @@ enum ENUM_COMPONENTSECTIONSDOCUMENTS_TITLELEVEL {
   h3
 }
 
+enum ENUM_COMPONENTSECTIONSFAQS_TITLELEVEL {
+  h2
+  h3
+}
+
+enum ENUM_COMPONENTSECTIONSFILELIST_TITLELEVEL {
+  h2
+  h3
+}
+
+enum ENUM_COMPONENTSECTIONSGALLERY_TITLELEVEL {
+  h2
+  h3
+}
+
 enum ENUM_COMPONENTSECTIONSIFRAME_IFRAMEWIDTH {
   container
   full
+}
+
+enum ENUM_COMPONENTSECTIONSIFRAME_TITLELEVEL {
+  h2
+  h3
 }
 
 enum ENUM_COMPONENTSECTIONSLINKS_TITLELEVEL {
@@ -2163,6 +2217,11 @@ enum ENUM_COMPONENTSECTIONSPARTNERS_LOGORATIO {
   ratio_4_3
 }
 
+enum ENUM_COMPONENTSECTIONSPARTNERS_TITLELEVEL {
+  h2
+  h3
+}
+
 enum ENUM_COMPONENTSECTIONSPROSANDCONSSECTION_TEXTALIGN {
   center
   left
@@ -2183,6 +2242,11 @@ enum ENUM_COMPONENTSECTIONSTEXTWITHIMAGE_IMAGEASPECTRATIO {
 enum ENUM_COMPONENTSECTIONSTEXTWITHIMAGE_IMAGEPOSITION {
   left
   right
+}
+
+enum ENUM_COMPONENTSECTIONSVIDEOS_TITLELEVEL {
+  h2
+  h3
 }
 
 enum ENUM_PAGECATEGORY_COLOR {

--- a/strapi/schema.graphql
+++ b/strapi/schema.graphql
@@ -1180,6 +1180,7 @@ type ComponentSectionsDocuments {
   showAll: Boolean
   text: String
   title: String
+  titleLevel: ENUM_COMPONENTSECTIONSDOCUMENTS_TITLELEVEL
 }
 
 input ComponentSectionsDocumentsFiltersInput {
@@ -1190,6 +1191,7 @@ input ComponentSectionsDocumentsFiltersInput {
   showAll: BooleanFilterInput
   text: StringFilterInput
   title: StringFilterInput
+  titleLevel: StringFilterInput
 }
 
 input ComponentSectionsDocumentsInput {
@@ -1198,6 +1200,7 @@ input ComponentSectionsDocumentsInput {
   showAll: Boolean
   text: String
   title: String
+  titleLevel: ENUM_COMPONENTSECTIONSDOCUMENTS_TITLELEVEL
 }
 
 type ComponentSectionsFaqCategories {
@@ -1480,6 +1483,7 @@ type ComponentSectionsLinks {
   id: ID!
   pageLinks(filters: ComponentBlocksPageLinkFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): [ComponentBlocksPageLink]
   title: String
+  titleLevel: ENUM_COMPONENTSECTIONSLINKS_TITLELEVEL
 }
 
 input ComponentSectionsLinksFiltersInput {
@@ -1488,12 +1492,14 @@ input ComponentSectionsLinksFiltersInput {
   or: [ComponentSectionsLinksFiltersInput]
   pageLinks: ComponentBlocksPageLinkFiltersInput
   title: StringFilterInput
+  titleLevel: StringFilterInput
 }
 
 input ComponentSectionsLinksInput {
   id: ID
   pageLinks: [ComponentBlocksPageLinkInput]
   title: String
+  titleLevel: ENUM_COMPONENTSECTIONSLINKS_TITLELEVEL
 }
 
 type ComponentSectionsNarrowText {
@@ -2124,9 +2130,19 @@ enum ENUM_COMPONENTSECTIONSDIVIDER_STYLE {
   vzdelavanie
 }
 
+enum ENUM_COMPONENTSECTIONSDOCUMENTS_TITLELEVEL {
+  h2
+  h3
+}
+
 enum ENUM_COMPONENTSECTIONSIFRAME_IFRAMEWIDTH {
   container
   full
+}
+
+enum ENUM_COMPONENTSECTIONSLINKS_TITLELEVEL {
+  h2
+  h3
 }
 
 enum ENUM_COMPONENTSECTIONSNARROWTEXT_WIDTH {

--- a/strapi/src/components/sections/accordion.json
+++ b/strapi/src/components/sections/accordion.json
@@ -6,23 +6,31 @@
   },
   "options": {},
   "attributes": {
+    "title": {
+      "type": "string"
+    },
     "institutions": {
       "type": "component",
-      "repeatable": true,
-      "component": "accordion-items.institution"
+      "component": "accordion-items.institution",
+      "repeatable": true
     },
     "flatText": {
       "type": "component",
-      "repeatable": true,
-      "component": "accordion-items.flat-text"
+      "component": "accordion-items.flat-text",
+      "repeatable": true
     },
     "institutionsNarrow": {
       "type": "component",
-      "repeatable": true,
-      "component": "accordion-items.institution-narrow"
+      "component": "accordion-items.institution-narrow",
+      "repeatable": true
     },
-    "title": {
-      "type": "string"
+    "titleLevel": {
+      "type": "enumeration",
+      "default": "h2",
+      "enum": [
+        "h2",
+        "h3"
+      ]
     }
   }
 }

--- a/strapi/src/components/sections/contacts-section.json
+++ b/strapi/src/components/sections/contacts-section.json
@@ -14,33 +14,41 @@
     },
     "addressContacts": {
       "type": "component",
-      "repeatable": true,
-      "component": "blocks.contact-card"
+      "component": "blocks.contact-card",
+      "repeatable": true
     },
     "openingHoursContacts": {
       "type": "component",
-      "repeatable": true,
-      "component": "blocks.contact-card"
+      "component": "blocks.contact-card",
+      "repeatable": true
     },
     "emailContacts": {
       "type": "component",
-      "repeatable": true,
-      "component": "blocks.contact-card"
+      "component": "blocks.contact-card",
+      "repeatable": true
     },
     "phoneContacts": {
       "type": "component",
-      "repeatable": true,
-      "component": "blocks.contact-card"
+      "component": "blocks.contact-card",
+      "repeatable": true
     },
     "webContacts": {
       "type": "component",
-      "repeatable": true,
-      "component": "blocks.contact-card"
+      "component": "blocks.contact-card",
+      "repeatable": true
     },
     "personContacts": {
       "type": "component",
-      "repeatable": true,
-      "component": "blocks.contact-person-card"
+      "component": "blocks.contact-person-card",
+      "repeatable": true
+    },
+    "titleLevel": {
+      "type": "enumeration",
+      "default": "h2",
+      "enum": [
+        "h2",
+        "h3"
+      ]
     }
   }
 }

--- a/strapi/src/components/sections/documents.json
+++ b/strapi/src/components/sections/documents.json
@@ -21,6 +21,14 @@
     "showAll": {
       "type": "boolean",
       "default": false
+    },
+    "titleLevel": {
+      "type": "enumeration",
+      "default": "h2",
+      "enum": [
+        "h2",
+        "h3"
+      ]
     }
   }
 }

--- a/strapi/src/components/sections/faqs.json
+++ b/strapi/src/components/sections/faqs.json
@@ -16,6 +16,14 @@
       "type": "relation",
       "relation": "oneToMany",
       "target": "api::faq.faq"
+    },
+    "titleLevel": {
+      "type": "enumeration",
+      "default": "h2",
+      "enum": [
+        "h2",
+        "h3"
+      ]
     }
   }
 }

--- a/strapi/src/components/sections/file-list.json
+++ b/strapi/src/components/sections/file-list.json
@@ -14,8 +14,16 @@
     },
     "fileList": {
       "type": "component",
-      "repeatable": true,
-      "component": "blocks.file"
+      "component": "blocks.file",
+      "repeatable": true
+    },
+    "titleLevel": {
+      "type": "enumeration",
+      "default": "h2",
+      "enum": [
+        "h2",
+        "h3"
+      ]
     }
   }
 }

--- a/strapi/src/components/sections/gallery.json
+++ b/strapi/src/components/sections/gallery.json
@@ -20,6 +20,14 @@
       "allowedTypes": [
         "images"
       ]
+    },
+    "titleLevel": {
+      "type": "enumeration",
+      "default": "h2",
+      "enum": [
+        "h2",
+        "h3"
+      ]
     }
   }
 }

--- a/strapi/src/components/sections/iframe.json
+++ b/strapi/src/components/sections/iframe.json
@@ -14,27 +14,30 @@
     },
     "url": {
       "type": "string",
-      "required": true,
-      "default": "https://www.google.com"
+      "default": "https://www.google.com",
+      "required": true
     },
     "allowFullscreen": {
       "type": "boolean",
-      "default": true,
-      "required": true
+      "required": true,
+      "default": true
     },
     "css": {
       "type": "string"
     },
     "iframeWidth": {
       "type": "enumeration",
-      "enum": ["full", "container"],
+      "required": true,
       "default": "container",
-      "required": true
+      "enum": [
+        "full",
+        "container"
+      ]
     },
     "iframeHeight": {
       "type": "string",
-      "required": true,
-      "default": "600px"
+      "default": "600px",
+      "required": true
     },
     "fullHeight": {
       "type": "boolean",
@@ -44,6 +47,14 @@
     "allowGeolocation": {
       "type": "boolean",
       "default": false
+    },
+    "titleLevel": {
+      "type": "enumeration",
+      "default": "h2",
+      "enum": [
+        "h2",
+        "h3"
+      ]
     }
   }
 }

--- a/strapi/src/components/sections/links.json
+++ b/strapi/src/components/sections/links.json
@@ -10,8 +10,16 @@
     },
     "pageLinks": {
       "type": "component",
-      "repeatable": true,
-      "component": "blocks.page-link"
+      "component": "blocks.page-link",
+      "repeatable": true
+    },
+    "titleLevel": {
+      "type": "enumeration",
+      "default": "h2",
+      "enum": [
+        "h2",
+        "h3"
+      ]
     }
   }
 }

--- a/strapi/src/components/sections/partners.json
+++ b/strapi/src/components/sections/partners.json
@@ -14,18 +14,26 @@
     },
     "partners": {
       "type": "component",
-      "repeatable": true,
       "component": "blocks.partner",
+      "repeatable": true,
       "required": true
     },
     "logoRatio": {
       "type": "enumeration",
+      "required": true,
+      "default": "ratio 4:1",
       "enum": [
         "ratio 4:1",
         "ratio 4:3"
-      ],
-      "required": true,
-      "default": "ratio 4:1"
+      ]
+    },
+    "titleLevel": {
+      "type": "enumeration",
+      "default": "h2",
+      "enum": [
+        "h2",
+        "h3"
+      ]
     }
   }
 }

--- a/strapi/src/components/sections/videos.json
+++ b/strapi/src/components/sections/videos.json
@@ -10,12 +10,20 @@
       "type": "string"
     },
     "subtitle": {
-      "type": "text"
+      "type": "string"
     },
     "videos": {
       "type": "component",
       "component": "blocks.video",
       "repeatable": true
+    },
+    "titleLevel": {
+      "type": "enumeration",
+      "default": "h2",
+      "enum": [
+        "h2",
+        "h3"
+      ]
     }
   }
 }

--- a/strapi/src/components/sections/videos.json
+++ b/strapi/src/components/sections/videos.json
@@ -10,7 +10,7 @@
       "type": "string"
     },
     "subtitle": {
-      "type": "string"
+      "type": "text"
     },
     "videos": {
       "type": "component",

--- a/strapi/types/generated/components.d.ts
+++ b/strapi/types/generated/components.d.ts
@@ -961,7 +961,7 @@ export interface SectionsVideos extends Struct.ComponentSchema {
     displayName: 'Videos'
   }
   attributes: {
-    subtitle: Schema.Attribute.String
+    subtitle: Schema.Attribute.Text
     title: Schema.Attribute.String
     titleLevel: Schema.Attribute.Enumeration<['h2', 'h3']> & Schema.Attribute.DefaultTo<'h2'>
     videos: Schema.Attribute.Component<'blocks.video', true>

--- a/strapi/types/generated/components.d.ts
+++ b/strapi/types/generated/components.d.ts
@@ -414,6 +414,7 @@ export interface SectionsAccordion extends Struct.ComponentSchema {
     institutions: Schema.Attribute.Component<'accordion-items.institution', true>
     institutionsNarrow: Schema.Attribute.Component<'accordion-items.institution-narrow', true>
     title: Schema.Attribute.String
+    titleLevel: Schema.Attribute.Enumeration<['h2', 'h3']> & Schema.Attribute.DefaultTo<'h2'>
   }
 }
 
@@ -548,6 +549,7 @@ export interface SectionsContactsSection extends Struct.ComponentSchema {
     personContacts: Schema.Attribute.Component<'blocks.contact-person-card', true>
     phoneContacts: Schema.Attribute.Component<'blocks.contact-card', true>
     title: Schema.Attribute.String
+    titleLevel: Schema.Attribute.Enumeration<['h2', 'h3']> & Schema.Attribute.DefaultTo<'h2'>
     webContacts: Schema.Attribute.Component<'blocks.contact-card', true>
   }
 }
@@ -617,6 +619,7 @@ export interface SectionsFaqs extends Struct.ComponentSchema {
     faqs: Schema.Attribute.Relation<'oneToMany', 'api::faq.faq'>
     text: Schema.Attribute.Text
     title: Schema.Attribute.String
+    titleLevel: Schema.Attribute.Enumeration<['h2', 'h3']> & Schema.Attribute.DefaultTo<'h2'>
   }
 }
 
@@ -630,6 +633,7 @@ export interface SectionsFileList extends Struct.ComponentSchema {
     fileList: Schema.Attribute.Component<'blocks.file', true>
     text: Schema.Attribute.Text
     title: Schema.Attribute.String
+    titleLevel: Schema.Attribute.Enumeration<['h2', 'h3']> & Schema.Attribute.DefaultTo<'h2'>
   }
 }
 
@@ -644,6 +648,7 @@ export interface SectionsGallery extends Struct.ComponentSchema {
     medias: Schema.Attribute.Media<'images', true> & Schema.Attribute.Required
     text: Schema.Attribute.Text
     title: Schema.Attribute.String
+    titleLevel: Schema.Attribute.Enumeration<['h2', 'h3']> & Schema.Attribute.DefaultTo<'h2'>
   }
 }
 
@@ -723,6 +728,7 @@ export interface SectionsIframe extends Struct.ComponentSchema {
       Schema.Attribute.DefaultTo<'container'>
     text: Schema.Attribute.Text
     title: Schema.Attribute.String
+    titleLevel: Schema.Attribute.Enumeration<['h2', 'h3']> & Schema.Attribute.DefaultTo<'h2'>
     url: Schema.Attribute.String &
       Schema.Attribute.Required &
       Schema.Attribute.DefaultTo<'https://www.google.com'>
@@ -823,6 +829,7 @@ export interface SectionsPartners extends Struct.ComponentSchema {
     partners: Schema.Attribute.Component<'blocks.partner', true> & Schema.Attribute.Required
     text: Schema.Attribute.Text
     title: Schema.Attribute.String
+    titleLevel: Schema.Attribute.Enumeration<['h2', 'h3']> & Schema.Attribute.DefaultTo<'h2'>
   }
 }
 
@@ -954,8 +961,9 @@ export interface SectionsVideos extends Struct.ComponentSchema {
     displayName: 'Videos'
   }
   attributes: {
-    subtitle: Schema.Attribute.Text
+    subtitle: Schema.Attribute.String
     title: Schema.Attribute.String
+    titleLevel: Schema.Attribute.Enumeration<['h2', 'h3']> & Schema.Attribute.DefaultTo<'h2'>
     videos: Schema.Attribute.Component<'blocks.video', true>
   }
 }

--- a/strapi/types/generated/components.d.ts
+++ b/strapi/types/generated/components.d.ts
@@ -591,6 +591,7 @@ export interface SectionsDocuments extends Struct.ComponentSchema {
     showAll: Schema.Attribute.Boolean & Schema.Attribute.DefaultTo<false>
     text: Schema.Attribute.Text
     title: Schema.Attribute.String & Schema.Attribute.DefaultTo<'Dokumenty'>
+    titleLevel: Schema.Attribute.Enumeration<['h2', 'h3']> & Schema.Attribute.DefaultTo<'h2'>
   }
 }
 
@@ -759,6 +760,7 @@ export interface SectionsLinks extends Struct.ComponentSchema {
   attributes: {
     pageLinks: Schema.Attribute.Component<'blocks.page-link', true>
     title: Schema.Attribute.String
+    titleLevel: Schema.Attribute.Enumeration<['h2', 'h3']> & Schema.Attribute.DefaultTo<'h2'>
   }
 }
 


### PR DESCRIPTION
Sections that got option to choose titleLevel h2 or h3:

- Videos
- Gallery
- File list
- Documents
- FAQs
- Contacts
- Iframe
- Links
- Partners
- Accordion


Default is h2, but we don't make it required, because we would need to do some migrations to fill the field in all sections.

In these sections, "cards" that react to section title level:
- Documents 
- Videos
- Accordions
- FAQs