### PR TITLE
#1696 Link cards section

### DIFF
--- a/next/src/components/cards/CardBase.tsx
+++ b/next/src/components/cards/CardBase.tsx
@@ -13,7 +13,9 @@ const CardBase = ({ variant = 'border', children, className, ...rest }: CardBase
       className={cn(
         'group relative flex flex-col overflow-hidden bg-white',
         {
-          'rounded-2xl border border-grey-200 hover:border-grey-400': variant === 'border',
+          // only change border color on hover if link is present among children
+          'rounded-2xl border border-grey-200 has-[[href]]:hover:border-grey-400':
+            variant === 'border',
         },
         className,
       )}

--- a/next/src/components/cards/ListingCard.tsx
+++ b/next/src/components/cards/ListingCard.tsx
@@ -1,0 +1,93 @@
+import { Typography } from '@bratislava/component-library'
+import React, { useId } from 'react'
+
+import { ArrowRightIcon, ExportIcon } from '@/src/assets/icons'
+import CardBase, { CardBaseProps } from '@/src/components/cards/CardBase'
+import { CardTitleLevel } from '@/src/components/cards/getCardTitleLevel'
+import Button from '@/src/components/common/Button/Button'
+import ImagePlaceholder from '@/src/components/common/Image/ImagePlaceholder'
+import StrapiImage, { StrapiUploadImage } from '@/src/components/common/Image/StrapiImage'
+import cn from '@/src/utils/cn'
+import { CommonLinkProps } from '@/src/utils/getLinkProps'
+
+export type ListingCardProps = {
+  title: string
+  cardTitleLevel?: CardTitleLevel
+  image?: StrapiUploadImage
+  imageSizes?: string
+  showImagePlaceholder?: boolean
+  text?: string | null | undefined
+  linkProps?: CommonLinkProps
+} & CardBaseProps
+
+/**
+ * Figma: https://www.figma.com/design/17wbd0MDQcMW9NbXl6UPs8/DS--Component-library?node-id=16846-734&m=dev
+ * Loosely based on OLO: https://github.com/bratislava/olo.sk/blob/master/next/src/components/cards/ListingCard.tsx
+ */
+
+const ListingCard = ({
+  title,
+  cardTitleLevel = 'h3',
+  image,
+  imageSizes,
+  showImagePlaceholder = false,
+  text,
+  linkProps,
+  className,
+  ...rest
+}: ListingCardProps) => {
+  const titleId = useId()
+
+  const shouldShowImage = image || showImagePlaceholder
+  const imageToShow = image ? (
+    <StrapiImage alt="" image={image} sizes={imageSizes} className="object-cover" fill />
+  ) : (
+    <ImagePlaceholder />
+  )
+
+  return (
+    <CardBase
+      variant="border"
+      className={cn('h-full bg-background-passive-base', className)}
+      {...rest}
+    >
+      {/* TODO create CardImage component, see OLO */}
+      {shouldShowImage && (
+        <div className="relative aspect-280/158 shrink-0 overflow-hidden">{imageToShow}</div>
+      )}
+      <div className="flex grow flex-col justify-between gap-4 p-4">
+        <div className="flex flex-col gap-2">
+          <div className="flex flex-col gap-2">
+            {/* TODO: title level based on section */}
+            <Typography
+              id={titleId}
+              as={cardTitleLevel}
+              variant="h5"
+              className="group-hover:underline"
+            >
+              {title}
+            </Typography>
+
+            {text ? <Typography variant="p-small">{text}</Typography> : null}
+          </div>
+        </div>
+        {linkProps ? (
+          <div className="flex w-full items-center justify-between gap-2">
+            <Button
+              variant="link"
+              stretched
+              {...linkProps}
+              hasLinkIcon={false}
+              aria-labelledby={titleId}
+            />
+            <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-background-passive-secondary p-1.5">
+              {linkProps.href?.startsWith('http') ? <ExportIcon /> : <ArrowRightIcon />}
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </CardBase>
+  )
+}
+
+export default ListingCard

--- a/next/src/components/cards/ListingCard.tsx
+++ b/next/src/components/cards/ListingCard.tsx
@@ -58,12 +58,11 @@ const ListingCard = ({
       <div className="flex grow flex-col justify-between gap-4 p-4">
         <div className="flex flex-col gap-2">
           <div className="flex flex-col gap-2">
-            {/* TODO: title level based on section */}
             <Typography
               id={titleId}
               as={cardTitleLevel}
               variant="h5"
-              className="group-hover:underline"
+              className={cn({ 'group-hover:underline': linkProps })}
             >
               {title}
             </Typography>

--- a/next/src/components/common/LinkCards/LinkCards.tsx
+++ b/next/src/components/common/LinkCards/LinkCards.tsx
@@ -1,0 +1,43 @@
+import { getCardTitleLevel } from '@/src/components/cards/getCardTitleLevel'
+import ListingCard from '@/src/components/cards/ListingCard'
+import SectionHeader from '@/src/components/layouts/SectionHeader'
+import { LinkCardsSectionFragment } from '@/src/services/graphql'
+import { getLinkProps } from '@/src/utils/getLinkProps'
+import { isDefined } from '@/src/utils/isDefined'
+
+export type LinkCardsProps = {
+  section: LinkCardsSectionFragment
+}
+
+/**
+ * Figma: https://www.figma.com/design/17wbd0MDQcMW9NbXl6UPs8/DS--Component-library?node-id=18052-16738&t=WYqf0QbVs3yYwwAP-4
+ * TODO - Check when final design is ready
+ */
+
+const LinkCards = ({ section }: LinkCardsProps) => {
+  const { title, text, linkCardsItems: items, titleLevelLinkCardsSection: titleLevel } = section
+
+  const filteredItems = items?.filter(isDefined) ?? []
+
+  return (
+    <div className="flex flex-col gap-6 lg:gap-12">
+      <SectionHeader title={title} text={text} titleLevel={titleLevel} />
+      <ul className="grid grid-cols-1 gap-4 sm:grid-cols-3 lg:@page-wide:grid-cols-4">
+        {filteredItems.map((item) => {
+          return (
+            <li key={item.id} className="h-full">
+              <ListingCard
+                title={item.title}
+                cardTitleLevel={getCardTitleLevel(titleLevel)}
+                text={item.text}
+                linkProps={getLinkProps(item.link)}
+              />
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}
+
+export default LinkCards

--- a/next/src/components/layouts/Sections.tsx
+++ b/next/src/components/layouts/Sections.tsx
@@ -17,6 +17,7 @@ import GallerySection from '@/src/components/sections/GallerySection'
 import IframeSection from '@/src/components/sections/IframeSection'
 import InbaArticlesListSection from '@/src/components/sections/InbaArticlesListSection'
 import InbaReleasesSection from '@/src/components/sections/InbaReleasesSection'
+import LinkCardsSection from '@/src/components/sections/LinkCardsSection'
 import LinksSection from '@/src/components/sections/LinksSection'
 import NarrowTextSection from '@/src/components/sections/NarrowTextSection'
 import NumericalListSection from '@/src/components/sections/NumericalListSection'
@@ -129,6 +130,9 @@ const SectionContent = ({ section }: { section: SectionsFragment }) => {
 
     case 'ComponentSectionsNumericalList':
       return <NumericalListSection section={section} />
+
+    case 'ComponentSectionsLinkCards':
+      return <LinkCardsSection section={section} />
 
     default:
       return null

--- a/next/src/components/sections/LinkCardsSection.tsx
+++ b/next/src/components/sections/LinkCardsSection.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+
+import LinkCards from '@/src/components/common/LinkCards/LinkCards'
+import SectionContainer from '@/src/components/layouts/SectionContainer'
+import { LinkCardsSectionFragment } from '@/src/services/graphql'
+
+type LinkCardsSectionProps = {
+  section: LinkCardsSectionFragment
+}
+
+/**
+ * https://www.figma.com/design/17wbd0MDQcMW9NbXl6UPs8/DS--Component-library?node-id=18052-16738&t=WYqf0QbVs3yYwwAP-4
+ */
+
+const LinkCardsSection = ({ section }: LinkCardsSectionProps) => {
+  return (
+    <SectionContainer className="py-6 lg:py-12">
+      <LinkCards section={section} />
+    </SectionContainer>
+  )
+}
+
+export default LinkCardsSection

--- a/next/src/components/sections/LinkCardsSection.tsx
+++ b/next/src/components/sections/LinkCardsSection.tsx
@@ -9,7 +9,7 @@ type LinkCardsSectionProps = {
 }
 
 /**
- * https://www.figma.com/design/17wbd0MDQcMW9NbXl6UPs8/DS--Component-library?node-id=18052-16738&t=WYqf0QbVs3yYwwAP-4
+ * Figma: https://www.figma.com/design/17wbd0MDQcMW9NbXl6UPs8/DS--Component-library?node-id=18052-16738&t=WYqf0QbVs3yYwwAP-4
  */
 
 const LinkCardsSection = ({ section }: LinkCardsSectionProps) => {

--- a/next/src/services/graphql/index.ts
+++ b/next/src/services/graphql/index.ts
@@ -890,6 +890,30 @@ export type ComponentBlocksInBaInput = {
   title?: InputMaybe<Scalars['String']['input']>
 }
 
+export type ComponentBlocksLinkCardsItem = {
+  __typename?: 'ComponentBlocksLinkCardsItem'
+  id: Scalars['ID']['output']
+  link?: Maybe<ComponentBlocksCommonLink>
+  text?: Maybe<Scalars['String']['output']>
+  title?: Maybe<Scalars['String']['output']>
+}
+
+export type ComponentBlocksLinkCardsItemFiltersInput = {
+  and?: InputMaybe<Array<InputMaybe<ComponentBlocksLinkCardsItemFiltersInput>>>
+  link?: InputMaybe<ComponentBlocksCommonLinkFiltersInput>
+  not?: InputMaybe<ComponentBlocksLinkCardsItemFiltersInput>
+  or?: InputMaybe<Array<InputMaybe<ComponentBlocksLinkCardsItemFiltersInput>>>
+  text?: InputMaybe<StringFilterInput>
+  title?: InputMaybe<StringFilterInput>
+}
+
+export type ComponentBlocksLinkCardsItemInput = {
+  id?: InputMaybe<Scalars['ID']['input']>
+  link?: InputMaybe<ComponentBlocksCommonLinkInput>
+  text?: InputMaybe<Scalars['String']['input']>
+  title?: InputMaybe<Scalars['String']['input']>
+}
+
 export type ComponentBlocksNumericalListItem = {
   __typename?: 'ComponentBlocksNumericalListItem'
   id: Scalars['ID']['output']
@@ -1899,6 +1923,39 @@ export type ComponentSectionsInbaReleasesInput = {
   title?: InputMaybe<Scalars['String']['input']>
 }
 
+export type ComponentSectionsLinkCards = {
+  __typename?: 'ComponentSectionsLinkCards'
+  id: Scalars['ID']['output']
+  linkCardsItems?: Maybe<Array<Maybe<ComponentBlocksLinkCardsItem>>>
+  text?: Maybe<Scalars['String']['output']>
+  title?: Maybe<Scalars['String']['output']>
+  titleLevel?: Maybe<Enum_Componentsectionslinkcards_Titlelevel>
+}
+
+export type ComponentSectionsLinkCardsLinkCardsItemsArgs = {
+  filters?: InputMaybe<ComponentBlocksLinkCardsItemFiltersInput>
+  pagination?: InputMaybe<PaginationArg>
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>
+}
+
+export type ComponentSectionsLinkCardsFiltersInput = {
+  and?: InputMaybe<Array<InputMaybe<ComponentSectionsLinkCardsFiltersInput>>>
+  linkCardsItems?: InputMaybe<ComponentBlocksLinkCardsItemFiltersInput>
+  not?: InputMaybe<ComponentSectionsLinkCardsFiltersInput>
+  or?: InputMaybe<Array<InputMaybe<ComponentSectionsLinkCardsFiltersInput>>>
+  text?: InputMaybe<StringFilterInput>
+  title?: InputMaybe<StringFilterInput>
+  titleLevel?: InputMaybe<StringFilterInput>
+}
+
+export type ComponentSectionsLinkCardsInput = {
+  id?: InputMaybe<Scalars['ID']['input']>
+  linkCardsItems?: InputMaybe<Array<InputMaybe<ComponentBlocksLinkCardsItemInput>>>
+  text?: InputMaybe<Scalars['String']['input']>
+  title?: InputMaybe<Scalars['String']['input']>
+  titleLevel?: InputMaybe<Enum_Componentsectionslinkcards_Titlelevel>
+}
+
 export type ComponentSectionsLinks = {
   __typename?: 'ComponentSectionsLinks'
   id: Scalars['ID']['output']
@@ -2710,6 +2767,11 @@ export enum Enum_Componentsectionsiframe_Titlelevel {
   H3 = 'h3',
 }
 
+export enum Enum_Componentsectionslinkcards_Titlelevel {
+  H2 = 'h2',
+  H3 = 'h3',
+}
+
 export enum Enum_Componentsectionslinks_Titlelevel {
   H2 = 'h2',
   H3 = 'h3',
@@ -3174,6 +3236,7 @@ export type GenericMorph =
   | ComponentBlocksFooterColumn
   | ComponentBlocksHomepageHighlightsItem
   | ComponentBlocksInBa
+  | ComponentBlocksLinkCardsItem
   | ComponentBlocksNumericalListItem
   | ComponentBlocksPageLink
   | ComponentBlocksPartner
@@ -3206,6 +3269,7 @@ export type GenericMorph =
   | ComponentSectionsIframe
   | ComponentSectionsInbaArticlesList
   | ComponentSectionsInbaReleases
+  | ComponentSectionsLinkCards
   | ComponentSectionsLinks
   | ComponentSectionsNarrowText
   | ComponentSectionsNumericalList
@@ -4544,6 +4608,7 @@ export type PageSectionsDynamicZone =
   | ComponentSectionsIframe
   | ComponentSectionsInbaArticlesList
   | ComponentSectionsInbaReleases
+  | ComponentSectionsLinkCards
   | ComponentSectionsLinks
   | ComponentSectionsNarrowText
   | ComponentSectionsNumericalList
@@ -8689,6 +8754,38 @@ export type PageEntityFragment = {
       }
     | { __typename: 'ComponentSectionsInbaReleases'; title?: string | null; text?: string | null }
     | {
+        __typename: 'ComponentSectionsLinkCards'
+        title?: string | null
+        text?: string | null
+        titleLevelLinkCardsSection?: Enum_Componentsectionslinkcards_Titlelevel | null
+        linkCardsItems?: Array<{
+          __typename?: 'ComponentBlocksLinkCardsItem'
+          id: string
+          title?: string | null
+          text?: string | null
+          link?: {
+            __typename?: 'ComponentBlocksCommonLink'
+            label?: string | null
+            url?: string | null
+            analyticsId?: string | null
+            page?: {
+              __typename?: 'Page'
+              documentId: string
+              slug?: string | null
+              title: string
+              locale?: string | null
+            } | null
+            article?: {
+              __typename: 'Article'
+              documentId: string
+              slug: string
+              title: string
+              locale?: string | null
+            } | null
+          } | null
+        } | null> | null
+      }
+    | {
         __typename: 'ComponentSectionsLinks'
         title?: string | null
         titleLevelLinksSection?: Enum_Componentsectionslinks_Titlelevel | null
@@ -9419,6 +9516,38 @@ export type PageBySlugQuery = {
           text?: string | null
         }
       | { __typename: 'ComponentSectionsInbaReleases'; title?: string | null; text?: string | null }
+      | {
+          __typename: 'ComponentSectionsLinkCards'
+          title?: string | null
+          text?: string | null
+          titleLevelLinkCardsSection?: Enum_Componentsectionslinkcards_Titlelevel | null
+          linkCardsItems?: Array<{
+            __typename?: 'ComponentBlocksLinkCardsItem'
+            id: string
+            title?: string | null
+            text?: string | null
+            link?: {
+              __typename?: 'ComponentBlocksCommonLink'
+              label?: string | null
+              url?: string | null
+              analyticsId?: string | null
+              page?: {
+                __typename?: 'Page'
+                documentId: string
+                slug?: string | null
+                title: string
+                locale?: string | null
+              } | null
+              article?: {
+                __typename: 'Article'
+                documentId: string
+                slug: string
+                title: string
+                locale?: string | null
+              } | null
+            } | null
+          } | null> | null
+        }
       | {
           __typename: 'ComponentSectionsLinks'
           title?: string | null
@@ -10176,6 +10305,38 @@ export type Dev_AllPagesQuery = {
           text?: string | null
         }
       | { __typename: 'ComponentSectionsInbaReleases'; title?: string | null; text?: string | null }
+      | {
+          __typename: 'ComponentSectionsLinkCards'
+          title?: string | null
+          text?: string | null
+          titleLevelLinkCardsSection?: Enum_Componentsectionslinkcards_Titlelevel | null
+          linkCardsItems?: Array<{
+            __typename?: 'ComponentBlocksLinkCardsItem'
+            id: string
+            title?: string | null
+            text?: string | null
+            link?: {
+              __typename?: 'ComponentBlocksCommonLink'
+              label?: string | null
+              url?: string | null
+              analyticsId?: string | null
+              page?: {
+                __typename?: 'Page'
+                documentId: string
+                slug?: string | null
+                title: string
+                locale?: string | null
+              } | null
+              article?: {
+                __typename: 'Article'
+                documentId: string
+                slug: string
+                title: string
+                locale?: string | null
+              } | null
+            } | null
+          } | null> | null
+        }
       | {
           __typename: 'ComponentSectionsLinks'
           title?: string | null
@@ -11877,6 +12038,66 @@ export type DocumentsSectionFragment = {
   } | null>
 }
 
+export type LinkCardsItemBlockFragment = {
+  __typename?: 'ComponentBlocksLinkCardsItem'
+  id: string
+  title?: string | null
+  text?: string | null
+  link?: {
+    __typename?: 'ComponentBlocksCommonLink'
+    label?: string | null
+    url?: string | null
+    analyticsId?: string | null
+    page?: {
+      __typename?: 'Page'
+      documentId: string
+      slug?: string | null
+      title: string
+      locale?: string | null
+    } | null
+    article?: {
+      __typename: 'Article'
+      documentId: string
+      slug: string
+      title: string
+      locale?: string | null
+    } | null
+  } | null
+}
+
+export type LinkCardsSectionFragment = {
+  __typename?: 'ComponentSectionsLinkCards'
+  title?: string | null
+  text?: string | null
+  titleLevelLinkCardsSection?: Enum_Componentsectionslinkcards_Titlelevel | null
+  linkCardsItems?: Array<{
+    __typename?: 'ComponentBlocksLinkCardsItem'
+    id: string
+    title?: string | null
+    text?: string | null
+    link?: {
+      __typename?: 'ComponentBlocksCommonLink'
+      label?: string | null
+      url?: string | null
+      analyticsId?: string | null
+      page?: {
+        __typename?: 'Page'
+        documentId: string
+        slug?: string | null
+        title: string
+        locale?: string | null
+      } | null
+      article?: {
+        __typename: 'Article'
+        documentId: string
+        slug: string
+        title: string
+        locale?: string | null
+      } | null
+    } | null
+  } | null> | null
+}
+
 type Sections_ComponentSectionsAccordion_Fragment = {
   __typename: 'ComponentSectionsAccordion'
   title?: string | null
@@ -12237,6 +12458,39 @@ type Sections_ComponentSectionsInbaReleases_Fragment = {
   text?: string | null
 }
 
+type Sections_ComponentSectionsLinkCards_Fragment = {
+  __typename: 'ComponentSectionsLinkCards'
+  title?: string | null
+  text?: string | null
+  titleLevelLinkCardsSection?: Enum_Componentsectionslinkcards_Titlelevel | null
+  linkCardsItems?: Array<{
+    __typename?: 'ComponentBlocksLinkCardsItem'
+    id: string
+    title?: string | null
+    text?: string | null
+    link?: {
+      __typename?: 'ComponentBlocksCommonLink'
+      label?: string | null
+      url?: string | null
+      analyticsId?: string | null
+      page?: {
+        __typename?: 'Page'
+        documentId: string
+        slug?: string | null
+        title: string
+        locale?: string | null
+      } | null
+      article?: {
+        __typename: 'Article'
+        documentId: string
+        slug: string
+        title: string
+        locale?: string | null
+      } | null
+    } | null
+  } | null> | null
+}
+
 type Sections_ComponentSectionsLinks_Fragment = {
   __typename: 'ComponentSectionsLinks'
   title?: string | null
@@ -12556,6 +12810,7 @@ export type SectionsFragment =
   | Sections_ComponentSectionsIframe_Fragment
   | Sections_ComponentSectionsInbaArticlesList_Fragment
   | Sections_ComponentSectionsInbaReleases_Fragment
+  | Sections_ComponentSectionsLinkCards_Fragment
   | Sections_ComponentSectionsLinks_Fragment
   | Sections_ComponentSectionsNarrowText_Fragment
   | Sections_ComponentSectionsNumericalList_Fragment
@@ -13676,6 +13931,28 @@ export const DocumentsSectionFragmentDoc = gql`
   }
   ${DocumentEntityFragmentDoc}
 `
+export const LinkCardsItemBlockFragmentDoc = gql`
+  fragment LinkCardsItemBlock on ComponentBlocksLinkCardsItem {
+    id
+    title
+    text
+    link {
+      ...CommonLink
+    }
+  }
+  ${CommonLinkFragmentDoc}
+`
+export const LinkCardsSectionFragmentDoc = gql`
+  fragment LinkCardsSection on ComponentSectionsLinkCards {
+    title
+    text
+    linkCardsItems {
+      ...LinkCardsItemBlock
+    }
+    titleLevelLinkCardsSection: titleLevel
+  }
+  ${LinkCardsItemBlockFragmentDoc}
+`
 export const SectionsFragmentDoc = gql`
   fragment Sections on PageSectionsDynamicZone {
     __typename
@@ -13763,6 +14040,9 @@ export const SectionsFragmentDoc = gql`
     ... on ComponentSectionsDocuments {
       ...DocumentsSection
     }
+    ... on ComponentSectionsLinkCards {
+      ...LinkCardsSection
+    }
   }
   ${DividerSectionFragmentDoc}
   ${TextWithImageSectionFragmentDoc}
@@ -13792,6 +14072,7 @@ export const SectionsFragmentDoc = gql`
   ${TootootEventsSectionFragmentDoc}
   ${PartnersSectionFragmentDoc}
   ${DocumentsSectionFragmentDoc}
+  ${LinkCardsSectionFragmentDoc}
 `
 export const SidebarsFragmentDoc = gql`
   fragment Sidebars on PageSidebarDynamicZone {

--- a/next/src/services/graphql/index.ts
+++ b/next/src/services/graphql/index.ts
@@ -893,9 +893,9 @@ export type ComponentBlocksInBaInput = {
 export type ComponentBlocksLinkCardsItem = {
   __typename?: 'ComponentBlocksLinkCardsItem'
   id: Scalars['ID']['output']
-  link?: Maybe<ComponentBlocksCommonLink>
+  link: ComponentBlocksCommonLink
   text?: Maybe<Scalars['String']['output']>
-  title?: Maybe<Scalars['String']['output']>
+  title: Scalars['String']['output']
 }
 
 export type ComponentBlocksLinkCardsItemFiltersInput = {
@@ -8761,9 +8761,9 @@ export type PageEntityFragment = {
         linkCardsItems?: Array<{
           __typename?: 'ComponentBlocksLinkCardsItem'
           id: string
-          title?: string | null
+          title: string
           text?: string | null
-          link?: {
+          link: {
             __typename?: 'ComponentBlocksCommonLink'
             label?: string | null
             url?: string | null
@@ -8782,7 +8782,7 @@ export type PageEntityFragment = {
               title: string
               locale?: string | null
             } | null
-          } | null
+          }
         } | null> | null
       }
     | {
@@ -9524,9 +9524,9 @@ export type PageBySlugQuery = {
           linkCardsItems?: Array<{
             __typename?: 'ComponentBlocksLinkCardsItem'
             id: string
-            title?: string | null
+            title: string
             text?: string | null
-            link?: {
+            link: {
               __typename?: 'ComponentBlocksCommonLink'
               label?: string | null
               url?: string | null
@@ -9545,7 +9545,7 @@ export type PageBySlugQuery = {
                 title: string
                 locale?: string | null
               } | null
-            } | null
+            }
           } | null> | null
         }
       | {
@@ -10313,9 +10313,9 @@ export type Dev_AllPagesQuery = {
           linkCardsItems?: Array<{
             __typename?: 'ComponentBlocksLinkCardsItem'
             id: string
-            title?: string | null
+            title: string
             text?: string | null
-            link?: {
+            link: {
               __typename?: 'ComponentBlocksCommonLink'
               label?: string | null
               url?: string | null
@@ -10334,7 +10334,7 @@ export type Dev_AllPagesQuery = {
                 title: string
                 locale?: string | null
               } | null
-            } | null
+            }
           } | null> | null
         }
       | {
@@ -12041,9 +12041,9 @@ export type DocumentsSectionFragment = {
 export type LinkCardsItemBlockFragment = {
   __typename?: 'ComponentBlocksLinkCardsItem'
   id: string
-  title?: string | null
+  title: string
   text?: string | null
-  link?: {
+  link: {
     __typename?: 'ComponentBlocksCommonLink'
     label?: string | null
     url?: string | null
@@ -12062,7 +12062,7 @@ export type LinkCardsItemBlockFragment = {
       title: string
       locale?: string | null
     } | null
-  } | null
+  }
 }
 
 export type LinkCardsSectionFragment = {
@@ -12073,9 +12073,9 @@ export type LinkCardsSectionFragment = {
   linkCardsItems?: Array<{
     __typename?: 'ComponentBlocksLinkCardsItem'
     id: string
-    title?: string | null
+    title: string
     text?: string | null
-    link?: {
+    link: {
       __typename?: 'ComponentBlocksCommonLink'
       label?: string | null
       url?: string | null
@@ -12094,7 +12094,7 @@ export type LinkCardsSectionFragment = {
         title: string
         locale?: string | null
       } | null
-    } | null
+    }
   } | null> | null
 }
 
@@ -12466,9 +12466,9 @@ type Sections_ComponentSectionsLinkCards_Fragment = {
   linkCardsItems?: Array<{
     __typename?: 'ComponentBlocksLinkCardsItem'
     id: string
-    title?: string | null
+    title: string
     text?: string | null
-    link?: {
+    link: {
       __typename?: 'ComponentBlocksCommonLink'
       label?: string | null
       url?: string | null
@@ -12487,7 +12487,7 @@ type Sections_ComponentSectionsLinkCards_Fragment = {
         title: string
         locale?: string | null
       } | null
-    } | null
+    }
   } | null> | null
 }
 

--- a/next/src/services/graphql/queries/Sections.graphql
+++ b/next/src/services/graphql/queries/Sections.graphql
@@ -375,6 +375,24 @@ fragment DocumentsSection on ComponentSectionsDocuments {
   titleLevelDocumentsSection: titleLevel
 }
 
+fragment LinkCardsItemBlock on ComponentBlocksLinkCardsItem {
+  id
+  title
+  text
+  link {
+    ...CommonLink
+  }
+}
+
+fragment LinkCardsSection on ComponentSectionsLinkCards {
+  title
+  text
+  linkCardsItems {
+    ...LinkCardsItemBlock
+  }
+  titleLevelLinkCardsSection: titleLevel
+}
+
 fragment Sections on PageSectionsDynamicZone {
   __typename
 
@@ -492,6 +510,10 @@ fragment Sections on PageSectionsDynamicZone {
 
   ... on ComponentSectionsDocuments {
     ...DocumentsSection
+  }
+  
+  ... on ComponentSectionsLinkCards {
+    ...LinkCardsSection
   }
 }
 

--- a/strapi/config/sync/core-store.plugin_content_manager_configuration_components##blocks.link-cards-item.json
+++ b/strapi/config/sync/core-store.plugin_content_manager_configuration_components##blocks.link-cards-item.json
@@ -1,0 +1,106 @@
+{
+  "key": "plugin_content_manager_configuration_components::blocks.link-cards-item",
+  "value": {
+    "settings": {
+      "bulkable": true,
+      "filterable": true,
+      "searchable": true,
+      "pageSize": 10,
+      "mainField": "title",
+      "defaultSortBy": "title",
+      "defaultSortOrder": "ASC"
+    },
+    "metadatas": {
+      "id": {
+        "edit": {},
+        "list": {
+          "label": "id",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "title": {
+        "edit": {
+          "label": "Nadpis",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "title",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "text": {
+        "edit": {
+          "label": "Text",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "text",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "link": {
+        "edit": {
+          "label": "Link",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "label"
+        },
+        "list": {
+          "label": "link",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "documentId": {
+        "edit": {},
+        "list": {
+          "label": "documentId",
+          "searchable": true,
+          "sortable": true
+        }
+      }
+    },
+    "layouts": {
+      "edit": [
+        [
+          {
+            "name": "title",
+            "size": 6
+          },
+          {
+            "name": "text",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "link",
+            "size": 12
+          }
+        ]
+      ],
+      "list": [
+        "id",
+        "title",
+        "text",
+        "link"
+      ]
+    },
+    "uid": "blocks.link-cards-item",
+    "isComponent": true
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.link-cards.json
+++ b/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.link-cards.json
@@ -1,0 +1,126 @@
+{
+  "key": "plugin_content_manager_configuration_components::sections.link-cards",
+  "value": {
+    "settings": {
+      "bulkable": true,
+      "filterable": true,
+      "searchable": true,
+      "pageSize": 10,
+      "mainField": "title",
+      "defaultSortBy": "title",
+      "defaultSortOrder": "ASC"
+    },
+    "metadatas": {
+      "id": {
+        "edit": {},
+        "list": {
+          "label": "id",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "title": {
+        "edit": {
+          "label": "Nadpis",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "title",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "text": {
+        "edit": {
+          "label": "Text",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "text",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "linkCardsItems": {
+        "edit": {
+          "label": "Odkazy",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "title"
+        },
+        "list": {
+          "label": "linkCardsItems",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "titleLevel": {
+        "edit": {
+          "label": "Úroveň nadpisu sekcie",
+          "description": "Úroveň nadpisu meníme na h3 iba ak je to potrebné sémanticky. Nikdy ju nemeníme len kvôli vizuálnej veľkosti nadpisu.",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "titleLevel",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "documentId": {
+        "edit": {},
+        "list": {
+          "label": "documentId",
+          "searchable": true,
+          "sortable": true
+        }
+      }
+    },
+    "layouts": {
+      "edit": [
+        [
+          {
+            "name": "title",
+            "size": 6
+          },
+          {
+            "name": "text",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "linkCardsItems",
+            "size": 12
+          }
+        ],
+        [
+          {
+            "name": "titleLevel",
+            "size": 6
+          }
+        ]
+      ],
+      "list": [
+        "id",
+        "title",
+        "text",
+        "linkCardsItems"
+      ]
+    },
+    "uid": "sections.link-cards",
+    "isComponent": true
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/strapi/schema.graphql
+++ b/strapi/schema.graphql
@@ -672,9 +672,9 @@ input ComponentBlocksInBaInput {
 
 type ComponentBlocksLinkCardsItem {
   id: ID!
-  link: ComponentBlocksCommonLink
+  link: ComponentBlocksCommonLink!
   text: String
-  title: String
+  title: String!
 }
 
 input ComponentBlocksLinkCardsItemFiltersInput {

--- a/strapi/schema.graphql
+++ b/strapi/schema.graphql
@@ -670,6 +670,29 @@ input ComponentBlocksInBaInput {
   title: String
 }
 
+type ComponentBlocksLinkCardsItem {
+  id: ID!
+  link: ComponentBlocksCommonLink
+  text: String
+  title: String
+}
+
+input ComponentBlocksLinkCardsItemFiltersInput {
+  and: [ComponentBlocksLinkCardsItemFiltersInput]
+  link: ComponentBlocksCommonLinkFiltersInput
+  not: ComponentBlocksLinkCardsItemFiltersInput
+  or: [ComponentBlocksLinkCardsItemFiltersInput]
+  text: StringFilterInput
+  title: StringFilterInput
+}
+
+input ComponentBlocksLinkCardsItemInput {
+  id: ID
+  link: ComponentBlocksCommonLinkInput
+  text: String
+  title: String
+}
+
 type ComponentBlocksNumericalListItem {
   id: ID!
   text: String
@@ -1497,6 +1520,32 @@ input ComponentSectionsInbaReleasesInput {
   title: String
 }
 
+type ComponentSectionsLinkCards {
+  id: ID!
+  linkCardsItems(filters: ComponentBlocksLinkCardsItemFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): [ComponentBlocksLinkCardsItem]
+  text: String
+  title: String
+  titleLevel: ENUM_COMPONENTSECTIONSLINKCARDS_TITLELEVEL
+}
+
+input ComponentSectionsLinkCardsFiltersInput {
+  and: [ComponentSectionsLinkCardsFiltersInput]
+  linkCardsItems: ComponentBlocksLinkCardsItemFiltersInput
+  not: ComponentSectionsLinkCardsFiltersInput
+  or: [ComponentSectionsLinkCardsFiltersInput]
+  text: StringFilterInput
+  title: StringFilterInput
+  titleLevel: StringFilterInput
+}
+
+input ComponentSectionsLinkCardsInput {
+  id: ID
+  linkCardsItems: [ComponentBlocksLinkCardsItemInput]
+  text: String
+  title: String
+  titleLevel: ENUM_COMPONENTSECTIONSLINKCARDS_TITLELEVEL
+}
+
 type ComponentSectionsLinks {
   id: ID!
   pageLinks(filters: ComponentBlocksPageLinkFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): [ComponentBlocksPageLink]
@@ -2194,6 +2243,11 @@ enum ENUM_COMPONENTSECTIONSIFRAME_TITLELEVEL {
   h3
 }
 
+enum ENUM_COMPONENTSECTIONSLINKCARDS_TITLELEVEL {
+  h2
+  h3
+}
+
 enum ENUM_COMPONENTSECTIONSLINKS_TITLELEVEL {
   h2
   h3
@@ -2563,7 +2617,7 @@ type GeneralRelationResponseCollection {
   nodes: [General!]!
 }
 
-union GenericMorph = AdminGroup | Alert | Article | ArticleCategory | BlogPost | ComponentAccordionItemsFlatText | ComponentAccordionItemsInstitution | ComponentAccordionItemsInstitutionNarrow | ComponentBlocksColumnsItem | ComponentBlocksCommonLink | ComponentBlocksComparisonCard | ComponentBlocksComparisonItem | ComponentBlocksContactCard | ComponentBlocksContactPersonCard | ComponentBlocksFile | ComponentBlocksFileItem | ComponentBlocksFooterColumn | ComponentBlocksHomepageHighlightsItem | ComponentBlocksInBa | ComponentBlocksNumericalListItem | ComponentBlocksPageLink | ComponentBlocksPartner | ComponentBlocksProsAndConsCard | ComponentBlocksTopServicesItem | ComponentBlocksVideo | ComponentGeneralHeader | ComponentGeneralHeaderLink | ComponentMenuMenuItem | ComponentMenuMenuLink | ComponentMenuMenuSection | ComponentSectionsAccordion | ComponentSectionsArticles | ComponentSectionsBanner | ComponentSectionsCalculator | ComponentSectionsColumnedText | ComponentSectionsColumns | ComponentSectionsComparisonSection | ComponentSectionsContactsSection | ComponentSectionsDivider | ComponentSectionsDocuments | ComponentSectionsFaqCategories | ComponentSectionsFaqs | ComponentSectionsFileList | ComponentSectionsGallery | ComponentSectionsHomepageEvents | ComponentSectionsHomepageHighlights | ComponentSectionsHomepageMayorAndCouncil | ComponentSectionsHomepageTabs | ComponentSectionsIframe | ComponentSectionsInbaArticlesList | ComponentSectionsInbaReleases | ComponentSectionsLinks | ComponentSectionsNarrowText | ComponentSectionsNumericalList | ComponentSectionsOfficialBoard | ComponentSectionsOrganizationalStructure | ComponentSectionsPartners | ComponentSectionsProsAndConsSection | ComponentSectionsRegulations | ComponentSectionsRegulationsList | ComponentSectionsSubpageList | ComponentSectionsTextWithImage | ComponentSectionsTextWithImageOverlapped | ComponentSectionsTootootEvents | ComponentSectionsTopServices | ComponentSectionsVideos | ComponentSidebarsEmptySidebar | ComponentTaxAdministratorsTaxAdministrator | Document | DocumentCategory | Faq | FaqCategory | Footer | General | Homepage | I18NLocale | InbaArticle | InbaRelease | InbaTag | Menu | Page | PageCategory | Regulation | ReviewWorkflowsWorkflow | ReviewWorkflowsWorkflowStage | Tag | TaxAdministratorsList | UploadFile | UsersPermissionsPermission | UsersPermissionsRole | UsersPermissionsUser
+union GenericMorph = AdminGroup | Alert | Article | ArticleCategory | BlogPost | ComponentAccordionItemsFlatText | ComponentAccordionItemsInstitution | ComponentAccordionItemsInstitutionNarrow | ComponentBlocksColumnsItem | ComponentBlocksCommonLink | ComponentBlocksComparisonCard | ComponentBlocksComparisonItem | ComponentBlocksContactCard | ComponentBlocksContactPersonCard | ComponentBlocksFile | ComponentBlocksFileItem | ComponentBlocksFooterColumn | ComponentBlocksHomepageHighlightsItem | ComponentBlocksInBa | ComponentBlocksLinkCardsItem | ComponentBlocksNumericalListItem | ComponentBlocksPageLink | ComponentBlocksPartner | ComponentBlocksProsAndConsCard | ComponentBlocksTopServicesItem | ComponentBlocksVideo | ComponentGeneralHeader | ComponentGeneralHeaderLink | ComponentMenuMenuItem | ComponentMenuMenuLink | ComponentMenuMenuSection | ComponentSectionsAccordion | ComponentSectionsArticles | ComponentSectionsBanner | ComponentSectionsCalculator | ComponentSectionsColumnedText | ComponentSectionsColumns | ComponentSectionsComparisonSection | ComponentSectionsContactsSection | ComponentSectionsDivider | ComponentSectionsDocuments | ComponentSectionsFaqCategories | ComponentSectionsFaqs | ComponentSectionsFileList | ComponentSectionsGallery | ComponentSectionsHomepageEvents | ComponentSectionsHomepageHighlights | ComponentSectionsHomepageMayorAndCouncil | ComponentSectionsHomepageTabs | ComponentSectionsIframe | ComponentSectionsInbaArticlesList | ComponentSectionsInbaReleases | ComponentSectionsLinkCards | ComponentSectionsLinks | ComponentSectionsNarrowText | ComponentSectionsNumericalList | ComponentSectionsOfficialBoard | ComponentSectionsOrganizationalStructure | ComponentSectionsPartners | ComponentSectionsProsAndConsSection | ComponentSectionsRegulations | ComponentSectionsRegulationsList | ComponentSectionsSubpageList | ComponentSectionsTextWithImage | ComponentSectionsTextWithImageOverlapped | ComponentSectionsTootootEvents | ComponentSectionsTopServices | ComponentSectionsVideos | ComponentSidebarsEmptySidebar | ComponentTaxAdministratorsTaxAdministrator | Document | DocumentCategory | Faq | FaqCategory | Footer | General | Homepage | I18NLocale | InbaArticle | InbaRelease | InbaTag | Menu | Page | PageCategory | Regulation | ReviewWorkflowsWorkflow | ReviewWorkflowsWorkflowStage | Tag | TaxAdministratorsList | UploadFile | UsersPermissionsPermission | UsersPermissionsRole | UsersPermissionsUser
 
 type Homepage {
   createdAt: DateTime
@@ -3514,7 +3568,7 @@ type PageRelationResponseCollection {
   nodes: [Page!]!
 }
 
-union PageSectionsDynamicZone = ComponentSectionsAccordion | ComponentSectionsArticles | ComponentSectionsBanner | ComponentSectionsCalculator | ComponentSectionsColumnedText | ComponentSectionsColumns | ComponentSectionsComparisonSection | ComponentSectionsContactsSection | ComponentSectionsDivider | ComponentSectionsDocuments | ComponentSectionsFaqCategories | ComponentSectionsFaqs | ComponentSectionsFileList | ComponentSectionsGallery | ComponentSectionsIframe | ComponentSectionsInbaArticlesList | ComponentSectionsInbaReleases | ComponentSectionsLinks | ComponentSectionsNarrowText | ComponentSectionsNumericalList | ComponentSectionsOfficialBoard | ComponentSectionsOrganizationalStructure | ComponentSectionsPartners | ComponentSectionsProsAndConsSection | ComponentSectionsRegulations | ComponentSectionsRegulationsList | ComponentSectionsTextWithImage | ComponentSectionsTextWithImageOverlapped | ComponentSectionsTootootEvents | ComponentSectionsVideos | Error
+union PageSectionsDynamicZone = ComponentSectionsAccordion | ComponentSectionsArticles | ComponentSectionsBanner | ComponentSectionsCalculator | ComponentSectionsColumnedText | ComponentSectionsColumns | ComponentSectionsComparisonSection | ComponentSectionsContactsSection | ComponentSectionsDivider | ComponentSectionsDocuments | ComponentSectionsFaqCategories | ComponentSectionsFaqs | ComponentSectionsFileList | ComponentSectionsGallery | ComponentSectionsIframe | ComponentSectionsInbaArticlesList | ComponentSectionsInbaReleases | ComponentSectionsLinkCards | ComponentSectionsLinks | ComponentSectionsNarrowText | ComponentSectionsNumericalList | ComponentSectionsOfficialBoard | ComponentSectionsOrganizationalStructure | ComponentSectionsPartners | ComponentSectionsProsAndConsSection | ComponentSectionsRegulations | ComponentSectionsRegulationsList | ComponentSectionsTextWithImage | ComponentSectionsTextWithImageOverlapped | ComponentSectionsTootootEvents | ComponentSectionsVideos | Error
 
 scalar PageSectionsDynamicZoneInput
 

--- a/strapi/src/api/page/content-types/page/schema.json
+++ b/strapi/src/api/page/content-types/page/schema.json
@@ -160,6 +160,7 @@
         "sections.iframe",
         "sections.inba-articles-list",
         "sections.inba-releases",
+        "sections.link-cards",
         "sections.links",
         "sections.narrow-text",
         "sections.numerical-list",

--- a/strapi/src/components/blocks/link-cards-item.json
+++ b/strapi/src/components/blocks/link-cards-item.json
@@ -1,0 +1,21 @@
+{
+  "collectionName": "components_blocks_link_cards_items",
+  "info": {
+    "displayName": "Link Cards Item"
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "text": {
+      "type": "string"
+    },
+    "link": {
+      "type": "component",
+      "component": "blocks.common-link",
+      "repeatable": false
+    }
+  },
+  "config": {}
+}

--- a/strapi/src/components/blocks/link-cards-item.json
+++ b/strapi/src/components/blocks/link-cards-item.json
@@ -6,7 +6,8 @@
   "options": {},
   "attributes": {
     "title": {
-      "type": "string"
+      "type": "string",
+      "required": true
     },
     "text": {
       "type": "string"
@@ -14,7 +15,8 @@
     "link": {
       "type": "component",
       "component": "blocks.common-link",
-      "repeatable": false
+      "repeatable": false,
+      "required": true
     }
   },
   "config": {}

--- a/strapi/src/components/sections/link-cards.json
+++ b/strapi/src/components/sections/link-cards.json
@@ -1,0 +1,30 @@
+{
+  "collectionName": "components_sections_link_cards",
+  "info": {
+    "displayName": "Link Cards"
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "text": {
+      "type": "text"
+    },
+    "linkCardsItems": {
+      "type": "component",
+      "component": "blocks.link-cards-item",
+      "repeatable": true,
+      "min": 1
+    },
+    "titleLevel": {
+      "type": "enumeration",
+      "default": "h2",
+      "enum": [
+        "h2",
+        "h3"
+      ]
+    }
+  },
+  "config": {}
+}

--- a/strapi/types/generated/components.d.ts
+++ b/strapi/types/generated/components.d.ts
@@ -191,9 +191,9 @@ export interface BlocksLinkCardsItem extends Struct.ComponentSchema {
     displayName: 'Link Cards Item'
   }
   attributes: {
-    link: Schema.Attribute.Component<'blocks.common-link', false>
+    link: Schema.Attribute.Component<'blocks.common-link', false> & Schema.Attribute.Required
     text: Schema.Attribute.String
-    title: Schema.Attribute.String
+    title: Schema.Attribute.String & Schema.Attribute.Required
   }
 }
 

--- a/strapi/types/generated/components.d.ts
+++ b/strapi/types/generated/components.d.ts
@@ -185,6 +185,18 @@ export interface BlocksInBa extends Struct.ComponentSchema {
   }
 }
 
+export interface BlocksLinkCardsItem extends Struct.ComponentSchema {
+  collectionName: 'components_blocks_link_cards_items'
+  info: {
+    displayName: 'Link Cards Item'
+  }
+  attributes: {
+    link: Schema.Attribute.Component<'blocks.common-link', false>
+    text: Schema.Attribute.String
+    title: Schema.Attribute.String
+  }
+}
+
 export interface BlocksNumericalListItem extends Struct.ComponentSchema {
   collectionName: 'components_blocks_numerical_list_items'
   info: {
@@ -758,6 +770,25 @@ export interface SectionsInbaReleases extends Struct.ComponentSchema {
   }
 }
 
+export interface SectionsLinkCards extends Struct.ComponentSchema {
+  collectionName: 'components_sections_link_cards'
+  info: {
+    displayName: 'Link Cards'
+  }
+  attributes: {
+    linkCardsItems: Schema.Attribute.Component<'blocks.link-cards-item', true> &
+      Schema.Attribute.SetMinMax<
+        {
+          min: 1
+        },
+        number
+      >
+    text: Schema.Attribute.Text
+    title: Schema.Attribute.String
+    titleLevel: Schema.Attribute.Enumeration<['h2', 'h3']> & Schema.Attribute.DefaultTo<'h2'>
+  }
+}
+
 export interface SectionsLinks extends Struct.ComponentSchema {
   collectionName: 'components_sections_links'
   info: {
@@ -1008,6 +1039,7 @@ declare module '@strapi/strapi' {
       'blocks.footer-column': BlocksFooterColumn
       'blocks.homepage-highlights-item': BlocksHomepageHighlightsItem
       'blocks.in-ba': BlocksInBa
+      'blocks.link-cards-item': BlocksLinkCardsItem
       'blocks.numerical-list-item': BlocksNumericalListItem
       'blocks.page-link': BlocksPageLink
       'blocks.partner': BlocksPartner
@@ -1040,6 +1072,7 @@ declare module '@strapi/strapi' {
       'sections.iframe': SectionsIframe
       'sections.inba-articles-list': SectionsInbaArticlesList
       'sections.inba-releases': SectionsInbaReleases
+      'sections.link-cards': SectionsLinkCards
       'sections.links': SectionsLinks
       'sections.narrow-text': SectionsNarrowText
       'sections.numerical-list': SectionsNumericalList

--- a/strapi/types/generated/contentTypes.d.ts
+++ b/strapi/types/generated/contentTypes.d.ts
@@ -1282,6 +1282,7 @@ export interface ApiPagePage extends Struct.CollectionTypeSchema {
         'sections.iframe',
         'sections.inba-articles-list',
         'sections.inba-releases',
+        'sections.link-cards',
         'sections.links',
         'sections.narrow-text',
         'sections.numerical-list',


### PR DESCRIPTION
## Notes

Listing card as a base for Link Cards section
- a ListingCard was made as a base for this section to unify Category and Subcategory cards in Figma - I based the name of similar card in OLO, didn't want to spend eternity on naming (Category card or Subcategory Card seems even less informative for me): https://www.figma.com/design/17wbd0MDQcMW9NbXl6UPs8/DS--Component-library?node-id=16846-734&t=bQjNB6VUBd43vxII-4
- ListingCard can display several variants for many use cases (only title, title & text, title & link, title & text & link, with combination of image, image with placeholder, or no image)
- if no link is present, the border of ListingCard doesn't change color on hover (CardBase was adjusted to support this)

Link Cards section
- this PR diverges from figma only in the size of card heading when used in Link Cards section - figma says H6, now it is H5 - this was done to unify figma designs of CategoryCard and SubcategoryCard
- titleLevel field included, also card headings react to it

## Screenshots

### ListingCard - variants determined by presence of props
<img width="1275" height="363" alt="image" src="https://github.com/user-attachments/assets/871ca576-0da2-489e-9a48-f857c7520e67" />
<img width="1273" height="364" alt="image" src="https://github.com/user-attachments/assets/18886e7f-bbe5-4f4c-99e7-0f1245afa7ae" />

### LinkCardsSection - uses ListingCard, (text optional, image never)

Large display - wide layout
<img width="912" height="642" alt="image" src="https://github.com/user-attachments/assets/0d04f30c-ac0e-4670-aa92-e380d158f76b" />

Large display - narrow layout (sidebar)
<img width="917" height="712" alt="image" src="https://github.com/user-attachments/assets/bb2182cf-5410-4d4c-8264-f449d7300f78" />

Tablet
<img width="929" height="543" alt="image" src="https://github.com/user-attachments/assets/69a1c04e-76cd-4c07-b553-cab4c5f7a18e" />

Mobile
<img width="928" height="772" alt="image" src="https://github.com/user-attachments/assets/7048c388-7e62-401d-b975-b34907e01d3a" />



