### PR TITLE
#1739 Refactor page headers to allow more header types

### DIFF
--- a/next/src/components/common/PageHeader/PageHeader.tsx
+++ b/next/src/components/common/PageHeader/PageHeader.tsx
@@ -10,10 +10,10 @@ import cn from '@/src/utils/cn'
 import { generateImageSizes } from '@/src/utils/generateImageSizes'
 import { getLinkProps } from '@/src/utils/getLinkProps'
 
-type PageHeaderProps = {
+export type PageHeaderProps = {
   title?: string | null
   subtext?: string | null
-  buttons?: CommonLinkFragment[] | null
+  headerLinks?: CommonLinkFragment[] | null
   tag?: string | null
   className?: string | null
   imageSrc?: string | null
@@ -27,7 +27,7 @@ const PageHeader = ({
   title,
   subtext,
   breadcrumbs,
-  buttons,
+  headerLinks,
   imageSrc,
   tag,
   className,
@@ -77,10 +77,10 @@ const PageHeader = ({
               </div>
             )}
 
-            {buttons?.length ? (
+            {headerLinks?.length ? (
               // wrapping to flex-row earlier (md) to prevent too wide buttons on tablet
               <div className="flex max-w-[800px] flex-col gap-2 md:flex-row lg:gap-3">
-                {buttons.map((button, index) => (
+                {headerLinks.map((button, index) => (
                   <Button
                     // eslint-disable-next-line react/no-array-index-key
                     key={index}

--- a/next/src/components/layouts/PageHeaderSections.tsx
+++ b/next/src/components/layouts/PageHeaderSections.tsx
@@ -1,29 +1,52 @@
 import React from 'react'
 
+import { Breadcrumb } from '@/src/components/common/Breadcrumbs/Breadcrumbs'
+import PageHeader from '@/src/components/common/PageHeader/PageHeader'
 import SubpageListPageHeaderSection from '@/src/components/sections/headers/SubpageListPageHeaderSection_Deprecated'
-import { PageHeaderSectionsFragment } from '@/src/services/graphql'
-import { isPresent } from '@/src/utils/utils'
+import { PageEntityFragment, PageHeaderSectionsFragment } from '@/src/services/graphql'
+import { isDefined } from '@/src/utils/isDefined'
 
-type PageHeaderSectionsProps = {
-  sections: (PageHeaderSectionsFragment | null | undefined)[] | null | undefined
+type Props = Pick<
+  PageEntityFragment,
+  'title' | 'subtext' | 'headerLinks' | 'pageBackgroundImage'
+> & {
+  breadcrumbs: Breadcrumb[]
+  header: PageHeaderSectionsFragment | null | undefined
 }
 
-const PageHeaderSections = ({ sections }: PageHeaderSectionsProps) => {
-  return (
-    <>
-      {sections?.filter(isPresent).map((section, index) => {
-        // eslint-disable-next-line sonarjs/no-small-switch
-        switch (section.__typename) {
-          case 'ComponentSectionsSubpageList':
-            // eslint-disable-next-line react/no-array-index-key
-            return <SubpageListPageHeaderSection key={index} section={section} />
+const PageHeaderSections = ({
+  title,
+  subtext,
+  headerLinks,
+  pageBackgroundImage,
+  breadcrumbs,
+  header,
+}: Props) => {
+  // eslint-disable-next-line sonarjs/no-small-switch
+  switch (header?.__typename) {
+    case 'ComponentSectionsSubpageList':
+      return (
+        <SubpageListPageHeaderSection
+          title={title}
+          subtext={subtext}
+          breadcrumbs={breadcrumbs}
+          headerLinks={headerLinks?.filter(isDefined)}
+          imageSrc={pageBackgroundImage?.url}
+          header={header}
+        />
+      )
 
-          default:
-            return null
-        }
-      })}
-    </>
-  )
+    default:
+      return (
+        <PageHeader
+          title={title}
+          subtext={subtext}
+          breadcrumbs={breadcrumbs}
+          headerLinks={headerLinks?.filter(isDefined)}
+          imageSrc={pageBackgroundImage?.url}
+        />
+      )
+  }
 }
 
 export default PageHeaderSections

--- a/next/src/components/page-contents/GeneralPageContent.tsx
+++ b/next/src/components/page-contents/GeneralPageContent.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 import { useMemo } from 'react'
 
 import AliasInfoMessage from '@/src/components/common/AliasInfoMessage/AliasInfoMessage'
-import PageHeader from '@/src/components/common/PageHeader/PageHeader'
 import PageHeaderSections from '@/src/components/layouts/PageHeaderSections'
 import SectionContainer from '@/src/components/layouts/SectionContainer'
 import Sections from '@/src/components/layouts/Sections'
@@ -23,21 +22,21 @@ const GeneralPageContent = ({ page }: GeneralPageProps) => {
 
   const filteredSections = page.sections?.filter(isDefined) ?? []
 
-  // Sidebar has always max 1 element
+  // These fields have always max 1 element
+  const [header] = page.pageHeaderSections ?? []
   const [sidebar] = page.sidebar ?? []
 
   return (
     <>
       {/* Header */}
-      <PageHeader
+      <PageHeaderSections
+        header={header}
         title={page.title}
         subtext={page.subtext}
         breadcrumbs={breadcrumbs}
-        buttons={page.headerLinks?.filter(isDefined)}
-        imageSrc={page.pageBackgroundImage?.url}
-      >
-        <PageHeaderSections sections={page.pageHeaderSections} />
-      </PageHeader>
+        headerLinks={page.headerLinks?.filter(isDefined)}
+        pageBackgroundImage={page.pageBackgroundImage}
+      />
 
       {/* Sections & Sidebar */}
       <div

--- a/next/src/components/sections/headers/SubpageListPageHeaderSection_Deprecated.tsx
+++ b/next/src/components/sections/headers/SubpageListPageHeaderSection_Deprecated.tsx
@@ -1,14 +1,33 @@
 import React from 'react'
 
+import PageHeader, { PageHeaderProps } from '@/src/components/common/PageHeader/PageHeader'
 import SubpageList from '@/src/components/common/SubpageList_Deprecated/SubpageList_Deprecated'
 import { SubpageListPageHeaderSectionFragment } from '@/src/services/graphql'
+import { isDefined } from '@/src/utils/isDefined'
 
-type SubpageListPageHeaderSectionProps = {
-  section: SubpageListPageHeaderSectionFragment
+type Props = PageHeaderProps & {
+  header: SubpageListPageHeaderSectionFragment
 }
 
-const SubpageListPageHeaderSection = ({ section }: SubpageListPageHeaderSectionProps) => {
-  return <SubpageList subpageList={section?.subpageList} />
+const SubpageListPageHeaderSection = ({
+  title,
+  subtext,
+  breadcrumbs,
+  headerLinks,
+  imageSrc,
+  header,
+}: Props) => {
+  return (
+    <PageHeader
+      title={title}
+      subtext={subtext}
+      breadcrumbs={breadcrumbs}
+      headerLinks={headerLinks?.filter(isDefined)}
+      imageSrc={imageSrc}
+    >
+      <SubpageList subpageList={header?.subpageList} />
+    </PageHeader>
+  )
 }
 
 export default SubpageListPageHeaderSection

--- a/strapi/src/api/page/content-types/page/schema.json
+++ b/strapi/src/api/page/content-types/page/schema.json
@@ -133,7 +133,8 @@
       },
       "components": [
         "sections.subpage-list"
-      ]
+      ],
+      "max": 1
     },
     "sections": {
       "type": "dynamiczone",

--- a/strapi/types/generated/contentTypes.d.ts
+++ b/strapi/types/generated/contentTypes.d.ts
@@ -1259,7 +1259,13 @@ export interface ApiPagePage extends Struct.CollectionTypeSchema {
         i18n: {
           localized: true
         }
-      }>
+      }> &
+      Schema.Attribute.SetMinMax<
+        {
+          max: 1
+        },
+        number
+      >
     parentPage: Schema.Attribute.Relation<'manyToOne', 'api::page.page'>
     publishedAt: Schema.Attribute.DateTime
     relatedContents: Schema.Attribute.Relation<'oneToMany', 'api::tag.tag'>


### PR DESCRIPTION
## Description
PageHeaderSections was restructured to allow for more page header types needed in STARZ.

Some caveats:
- some fields used in headers (headerLinks, pageBackgroundImage) can be filled directly from the page entry, however they are used only in some headers - in future, they may be moved to a specific header so it is clear for the content admin that these fields are relevant only for some headers

## Testing
No visible changes - everything should stay as before