### PR TITLE
#1569 Fetch articles with meilisearch in Inba Release detail page

### DIFF
--- a/next/src/components/page-contents/InbaReleasePageContent.tsx
+++ b/next/src/components/page-contents/InbaReleasePageContent.tsx
@@ -1,6 +1,8 @@
 import { Typography } from '@bratislava/component-library'
+import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import * as React from 'react'
-import { Fragment, useMemo } from 'react'
+import { Fragment, useEffect, useMemo, useRef, useState } from 'react'
+import { useDebounceValue } from 'usehooks-ts'
 
 import { Breadcrumb } from '@/src/components/common/Breadcrumbs/Breadcrumbs'
 import Button from '@/src/components/common/Button/Button'
@@ -8,17 +10,27 @@ import HorizontalDivider from '@/src/components/common/Divider/HorizontalDivider
 import FileList from '@/src/components/common/FileList/FileList'
 import ImagePlaceholder from '@/src/components/common/Image/ImagePlaceholder'
 import StrapiImage from '@/src/components/common/Image/StrapiImage'
+import LoadingSpinner from '@/src/components/common/LoadingSpinner/LoadingSpinner'
 import PageHeader from '@/src/components/common/PageHeader/PageHeader'
+import Pagination from '@/src/components/common/Pagination/Pagination'
 import Markdown from '@/src/components/formatting/Markdown/Markdown'
 import SectionContainer from '@/src/components/layouts/SectionContainer'
 import { useGeneralContext } from '@/src/components/providers/GeneralContextProvider'
+import SearchBar from '@/src/components/sections/SearchSection/SearchBar'
 import SearchResultCard from '@/src/components/sections/SearchSection/SearchResultCard'
 import { SearchResult } from '@/src/components/sections/SearchSection/useQueryBySearchOption'
 import ShareButtons from '@/src/components/sections/ShareButtons_Deprecated'
 import { InbaReleaseEntityFragment } from '@/src/services/graphql'
+import {
+  getInbaArticlesQueryKey,
+  inbaArticlesDefaultFilters,
+  inbaArticlesFetcher,
+} from '@/src/services/meili/fetchers/inbaArticlesFetcher'
 import { formatDate } from '@/src/utils/formatDate'
 import { isDefined } from '@/src/utils/isDefined'
 import { getPageBreadcrumbs } from '@/src/utils/pageUtils_Deprecated'
+import { useLocale } from '@/src/utils/useLocale'
+import { useRoutePreservedState } from '@/src/utils/useRoutePreservedState'
 import { useTranslation } from '@/src/utils/useTranslation'
 
 type Props = {
@@ -31,10 +43,9 @@ type Props = {
 
 const InbaReleasePageContent = ({ inbaRelease }: Props) => {
   const { t } = useTranslation()
+  const locale = useLocale()
 
-  const { title, coverImage, perex, releaseDate, files, inbaArticles } = inbaRelease
-
-  const filteredInbaArticles = inbaArticles.filter(isDefined) ?? []
+  const { title, coverImage, perex, releaseDate, files } = inbaRelease
 
   const { general } = useGeneralContext()
   const parentBreadcrumbPageEntity = general?.inbaReleasesPage
@@ -45,6 +56,33 @@ const InbaReleasePageContent = ({ inbaRelease }: Props) => {
       { title, path: null } as Breadcrumb,
     ]
   }, [parentBreadcrumbPageEntity, title])
+
+  const [filters, setFilters] = useRoutePreservedState({
+    ...inbaArticlesDefaultFilters,
+    // eslint-disable-next-line unicorn/consistent-destructuring
+    releaseDocumentIds: [inbaRelease.documentId],
+  })
+  const [input, setInput] = useState('')
+  const [debouncedInput] = useDebounceValue(input, 300)
+  const searchRef = useRef<null | HTMLInputElement>(null)
+
+  const { data, isPending, isError, error, isFetching } = useQuery({
+    queryKey: getInbaArticlesQueryKey(filters, locale),
+    queryFn: () => inbaArticlesFetcher(filters, locale),
+    placeholderData: keepPreviousData,
+  })
+
+  useEffect(() => {
+    searchRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [filters.page, filters.pageSize])
+
+  useEffect(() => {
+    setFilters((previousState) => ({ ...previousState, search: debouncedInput, page: 1 }))
+  }, [debouncedInput, setFilters])
+
+  const handlePageChange = (page: number) => {
+    setFilters({ ...filters, page })
+  }
 
   return (
     <>
@@ -92,37 +130,63 @@ const InbaReleasePageContent = ({ inbaRelease }: Props) => {
         </div>
       </SectionContainer>
 
-      {/* TODO pagination - replace by meilisearch fetcher + useQuery and prefetch? */}
-      {filteredInbaArticles.length > 0 ? (
+      {isError ? (
+        <Typography variant="p-default">{error.message}</Typography>
+      ) : isPending ? (
+        <LoadingSpinner />
+      ) : (
         <SectionContainer className="pt-10 md:pt-18">
           <div className="flex flex-col gap-5 lg:gap-6">
             <Typography variant="h3" as="h2" id="clanky-v-tomto-cisle">
               {t('InbaRelease.articlesInThisRelease')}
             </Typography>
 
-            <ul className="flex flex-col rounded-lg border">
-              {filteredInbaArticles.map((article, index) => {
-                const cardData: SearchResult = {
-                  title: article.title,
-                  uniqueId: article.slug,
-                  linkHref: `/inba/clanky/${article.slug}`,
-                  coverImageSrc: article.coverImage?.url,
-                  metadata: [article.inbaTag?.title].filter(isDefined),
-                }
+            <SearchBar
+              ref={searchRef}
+              input={input}
+              setInput={setInput}
+              setSearchQuery={(value) =>
+                setFilters((previousState) => ({ ...previousState, search: value, page: 1 }))
+              }
+              isLoading={isFetching}
+            />
 
-                return (
-                  <Fragment key={article.slug}>
-                    {index > 0 ? <HorizontalDivider asListItem className="mx-4 lg:mx-5" /> : null}
-                    <li>
-                      <SearchResultCard data={cardData} />
-                    </li>
-                  </Fragment>
-                )
-              })}
-            </ul>
+            {data.hits.length > 0 ? (
+              <ul className="flex flex-col rounded-lg border">
+                {data.hits.map((article, index) => {
+                  const cardData: SearchResult = {
+                    title: article.title,
+                    uniqueId: article.slug,
+                    linkHref: `/inba/clanky/${article.slug}`,
+                    coverImageSrc: article.coverImage?.url,
+                    metadata: [article.inbaTag?.title].filter(isDefined),
+                  }
+
+                  return (
+                    <Fragment key={article.slug}>
+                      {index > 0 ? <HorizontalDivider asListItem className="mx-4 lg:mx-5" /> : null}
+                      <li>
+                        <SearchResultCard data={cardData} />
+                      </li>
+                    </Fragment>
+                  )
+                })}
+              </ul>
+            ) : null}
+
+            {data.estimatedTotalHits ? (
+              <Pagination
+                key={filters.search}
+                totalCount={Math.ceil(data.estimatedTotalHits / filters.pageSize)}
+                currentPage={filters.page}
+                onPageChange={handlePageChange}
+              />
+            ) : (
+              <Typography>{t('SearchPage.noResults')}</Typography>
+            )}
           </div>
         </SectionContainer>
-      ) : null}
+      )}
 
       <SectionContainer className="pt-10 pb-8 md:pt-18">
         <ShareButtons twitterTitle={title} />

--- a/next/src/pages/inba/vydania/[slug].tsx
+++ b/next/src/pages/inba/vydania/[slug].tsx
@@ -1,3 +1,4 @@
+import { dehydrate, DehydratedState, HydrationBoundary, QueryClient } from '@tanstack/react-query'
 import { GetStaticPaths, GetStaticProps } from 'next'
 import Head from 'next/head'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
@@ -8,12 +9,18 @@ import InbaReleasePageContent from '@/src/components/page-contents/InbaReleasePa
 import { GeneralContextProvider } from '@/src/components/providers/GeneralContextProvider'
 import { GeneralQuery, InbaReleaseEntityFragment } from '@/src/services/graphql'
 import { client } from '@/src/services/graphql/gql'
+import {
+  getInbaArticlesQueryKey,
+  inbaArticlesDefaultFilters,
+  inbaArticlesFetcher,
+} from '@/src/services/meili/fetchers/inbaArticlesFetcher'
 import { NOT_FOUND } from '@/src/utils/consts'
 import { useTitle } from '@/src/utils/useTitle'
 
 type PageProps = {
   general: GeneralQuery
   inbaRelease: InbaReleaseEntityFragment
+  dehydratedState: DehydratedState
 }
 
 type StaticParams = {
@@ -62,32 +69,50 @@ export const getStaticProps: GetStaticProps<PageProps, StaticParams> = async ({
     return NOT_FOUND
   }
 
+  // Prefetch data
+  const queryClient = new QueryClient()
+
+  const filters = {
+    ...inbaArticlesDefaultFilters,
+    releaseDocumentIds: [inbaRelease.documentId],
+  }
+
+  await queryClient.prefetchQuery({
+    queryKey: getInbaArticlesQueryKey(filters, locale),
+    queryFn: () => inbaArticlesFetcher(filters, locale),
+  })
+
+  const dehydratedState = dehydrate(queryClient)
+
   return {
     props: {
       general,
       slug,
       inbaRelease,
       ...translations,
+      dehydratedState,
     },
     revalidate: 10,
   }
 }
 
-const Page = ({ general, inbaRelease }: PageProps) => {
+const Page = ({ general, inbaRelease, dehydratedState }: PageProps) => {
   const { title: inbaReleaseTitle, perex } = inbaRelease
 
   const title = useTitle(inbaReleaseTitle)
 
   return (
-    <GeneralContextProvider general={general}>
-      <Head>
-        <title>{title}</title>
-        {perex && <meta name="description" content={perex} />}
-      </Head>
-      <PageLayout>
-        <InbaReleasePageContent inbaRelease={inbaRelease} />
-      </PageLayout>
-    </GeneralContextProvider>
+    <HydrationBoundary state={dehydratedState}>
+      <GeneralContextProvider general={general}>
+        <Head>
+          <title>{title}</title>
+          {perex && <meta name="description" content={perex} />}
+        </Head>
+        <PageLayout>
+          <InbaReleasePageContent inbaRelease={inbaRelease} />
+        </PageLayout>
+      </GeneralContextProvider>
+    </HydrationBoundary>
   )
 }
 

--- a/next/src/services/meili/fetchers/inbaArticlesFetcher.ts
+++ b/next/src/services/meili/fetchers/inbaArticlesFetcher.ts
@@ -7,6 +7,7 @@ export type InbaArticlesFilters = {
   pageSize: number
   page: number
   tagDocumentIds: string[]
+  releaseDocumentIds: string[]
 }
 
 export const inbaArticlesDefaultFilters: InbaArticlesFilters = {
@@ -14,6 +15,7 @@ export const inbaArticlesDefaultFilters: InbaArticlesFilters = {
   pageSize: 9,
   page: 1,
   tagDocumentIds: [],
+  releaseDocumentIds: [],
 }
 
 export const getInbaArticlesQueryKey = (filters: InbaArticlesFilters, locale: string) => [
@@ -33,6 +35,9 @@ export const inbaArticlesFetcher = (filters: InbaArticlesFilters, locale: string
         `locale = ${locale}`,
         filters.tagDocumentIds.length > 0
           ? `inba-article.inbaTag.documentId IN [${filters.tagDocumentIds.join(',')}]`
+          : '',
+        filters.releaseDocumentIds.length > 0
+          ? `inba-article.inbaRelease.documentId IN [${filters.releaseDocumentIds.join(',')}]`
           : '',
       ],
       sort: ['inba-article.publishedAtTimestamp:desc'],

--- a/strapi/config/plugins.meilisearch.config.ts
+++ b/strapi/config/plugins.meilisearch.config.ts
@@ -44,6 +44,7 @@ const searchIndexSettings = {
     'blog-post.tag.documentId',
     'document.documentCategory.documentId',
     'inba-article.inbaTag.documentId',
+    'inba-article.inbaRelease.documentId',
     'regulation.category',
   ],
   sortableAttributes: [
@@ -129,7 +130,7 @@ const config = {
     indexName: 'search_index',
     entriesQuery: {
       locale: '*',
-      populate: ['inbaTag', 'coverImage'],
+      populate: ['inbaTag', 'coverImage', 'inbaRelease'],
     },
     settings: searchIndexSettings,
     transformEntry: ({ entry }) =>


### PR DESCRIPTION
- use meili fetcher instead of graphql
- show pagination
- show search bar - this is up to figma design, but I find it usefull(even tho the search bar is too big and with hardcoded "Co hladate" label - this will be revisited some day)
- prefetch articles in release
- on page change, it should scroll to first article on the page
- known issues - if no articles are selected in strapi for old inba releases, there will be empty section - I think this is ok until someone reports it

<img width="800" height="701" alt="image" src="https://github.com/user-attachments/assets/bfe24516-68a2-4f2a-9300-f0373e3dcbbd" />


No articles:

<img width="1200" height="878" alt="image" src="https://github.com/user-attachments/assets/d7e3ee60-76aa-41d4-9f98-6a1a68095968" />


Respo:

<img width="400" height="559" alt="image" src="https://github.com/user-attachments/assets/5bac5a06-1f5c-4398-b91b-bfd23d7fcf1b" />
