### PR TITLE
#1557 Insert also image caption to markdown

### DIFF
--- a/next/src/components/formatting/Markdown/Markdown.tsx
+++ b/next/src/components/formatting/Markdown/Markdown.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars,jsx-a11y/heading-has-content */
 import { Typography } from '@bratislava/component-library'
 import slugify from '@sindresorhus/slugify'
+import Image from 'next/image'
 import ReactMarkdown, { defaultUrlTransform } from 'react-markdown'
 import rehypeRaw from 'rehype-raw'
 import remarkGfm from 'remark-gfm'
@@ -127,11 +128,28 @@ const Markdown = ({ content, variant = 'default', className }: MarkdownProps) =>
               </MLink>
             )
           },
-          // TODO caption from Strapi, use <figure> and <figcaption> tags, see Marianum project
           img: ({ node, src, alt, title, ...props }) => (
-            <div className="flex justify-center">
-              {src && <img src={src} alt={alt} {...props} />}
-            </div>
+            // Based on OLO: https://github.com/bratislava/olo.sk/blob/master/next/src/components/formatting/Markdown.tsx#L179
+            // TODO Note from OLO: This can still produce a hydration error, because the remark-unwrap-images only works when image is the only child of the paragraph
+            <figure className="flex flex-col items-center gap-4">
+              <Image
+                {...props}
+                src={src ?? ''}
+                width="0"
+                height="0"
+                sizes="100vw"
+                alt={alt ?? ''}
+                className="h-auto w-full overflow-hidden rounded-xl"
+              />
+              {title ? (
+                <figcaption
+                  aria-hidden={title === alt}
+                  className="text-center text-size-p-small text-content-passive-tertiary"
+                >
+                  {title}
+                </figcaption>
+              ) : null}
+            </figure>
           ),
           blockquote: ({ node, ...props }) => (
             <blockquote className="my-4 border-l-4 border-category-600 py-2 pl-8" {...props} />

--- a/strapi/README.md
+++ b/strapi/README.md
@@ -54,3 +54,10 @@ and then run the command to create a patch file:
 ```bash
 npx patch-package @strapi/admin
 ```
+
+### @strapi/content-manager
+
+We change Wysiwyg editor image inserting so it inserts also image title (caption), so we can display it on FE.
+```bash
+npx patch-package @strapi/content-manager
+```

--- a/strapi/patches/@strapi+content-manager+5.18.0.patch
+++ b/strapi/patches/@strapi+content-manager+5.18.0.patch
@@ -1,0 +1,27 @@
+diff --git a/node_modules/@strapi/content-manager/dist/admin/pages/EditView/components/FormInputs/Wysiwyg/Field.mjs b/node_modules/@strapi/content-manager/dist/admin/pages/EditView/components/FormInputs/Wysiwyg/Field.mjs
+index 88c6e88..0e50319 100644
+--- a/node_modules/@strapi/content-manager/dist/admin/pages/EditView/components/FormInputs/Wysiwyg/Field.mjs
++++ b/node_modules/@strapi/content-manager/dist/admin/pages/EditView/components/FormInputs/Wysiwyg/Field.mjs
+@@ -28,7 +28,8 @@ const Wysiwyg = /*#__PURE__*/ React.forwardRef(({ hint, disabled, label, name, p
+         const formattedFiles = files.map((f)=>({
+                 alt: f.alternativeText || f.name,
+                 url: prefixFileUrlWithBackendUrl(f.url),
+-                mime: f.mime
++                mime: f.mime,
++                caption: f.caption || f.name
+             }));
+         insertFile(editorRef, formattedFiles);
+         setMediaLibVisible(false);
+diff --git a/node_modules/@strapi/content-manager/dist/admin/pages/EditView/components/FormInputs/Wysiwyg/utils/utils.mjs b/node_modules/@strapi/content-manager/dist/admin/pages/EditView/components/FormInputs/Wysiwyg/utils/utils.mjs
+index 4f76601..939d23b 100644
+--- a/node_modules/@strapi/content-manager/dist/admin/pages/EditView/components/FormInputs/Wysiwyg/utils/utils.mjs
++++ b/node_modules/@strapi/content-manager/dist/admin/pages/EditView/components/FormInputs/Wysiwyg/utils/utils.mjs
+@@ -231,7 +231,7 @@ const insertFile = (editor, files)=>{
+             editor.current.replaceSelection('\n');
+         }
+         if (file.mime.includes('image')) {
+-            editor.current.replaceSelection(`![${file.alt}](${file.url})`);
++            editor.current.replaceSelection(`![${file.alt}](${file.url} "${file.caption}")`);
+         } else {
+             editor.current.replaceSelection(`[${file.alt}](${file.url})`);
+         }


### PR DESCRIPTION
- patch @strapi/content-manager so it inserts also image caption as markdown image title
- use `<figure>` + `<figcaption>` on FE
- add rounded corners
- if no caption is provided in media library, file's name will be inserted - this way we hopefully force content admins to entry also the caption

<img width="1200" height="400" alt="image" src="https://github.com/user-attachments/assets/1f6c8107-6f96-499e-bc29-3d92495acee1" />
