### PR TITLE
#1644 Fix 404 test after changes

### DIFF
--- a/tests/cypress/e2e/404Page.cy.ts
+++ b/tests/cypress/e2e/404Page.cy.ts
@@ -14,7 +14,6 @@ describe('Page 404', { testIsolation: false }, () => {
 
         it('1. Check if the 404 page is displayed.', () => {
           cy.dataCy('404-image').should('be.visible')
-          cy.dataCy('404-left-side', '> div').contains('404').should('be.visible')
           cy.dataCy('404-left-side', '> a').should('be.visible').click()
         })
 


### PR DESCRIPTION
We don't have to check the title. Image (and link is enought).

Note that cypress tests sometimes don't pass due to cookie banner.