### PR TITLE
Add solid-inverted button variant and implement in PageHeaderFacility

### DIFF
--- a/next/src/components/common/Button/Button.tsx
+++ b/next/src/components/common/Button/Button.tsx
@@ -23,11 +23,13 @@ type ButtonOrIconButton =
     } & PropsWithChildren)
 
 type ButtonBase = {
+  // When adding a new variant, include it also in is...Variant booleans below
   variant?:
     | 'unstyled'
     | 'icon-wrapped'
     | 'icon-wrapped-negative-margin'
     | 'solid'
+    | 'solid-inverted'
     | 'outline'
     | 'plain'
     | 'negative-solid'
@@ -86,7 +88,8 @@ const Button = forwardRef<HTMLAnchorElement | HTMLButtonElement, PolymorphicProp
   ) => {
     const isLoadingOrDisabled = isLoading || isDisabled
 
-    const isSolidVariant = variant === 'solid' || variant === 'negative-solid'
+    const isSolidVariant =
+      variant === 'solid' || variant === 'negative-solid' || variant === 'solid-inverted'
     const isOutlineVariant = variant === 'outline'
     const isSolidOrOutlineVariant = isSolidVariant || isOutlineVariant
     const isPlainVariant = variant === 'plain' || variant === 'negative-plain'
@@ -160,6 +163,14 @@ const Button = forwardRef<HTMLAnchorElement | HTMLButtonElement, PolymorphicProp
                 variant === 'solid',
               'hover:border-action-border-hover hover:bg-action-background-hover':
                 variant === 'solid',
+
+              // colors - bg, border, content - variant solid (figma: boxed primary inverted)
+              'border-background-active-primary-inverted-default bg-background-active-primary-inverted-default text-content-active-primary-default':
+                variant === 'solid-inverted',
+              'active:border-background-active-primary-inverted-pressed active:bg-background-active-primary-inverted-pressed':
+                variant === 'solid-inverted',
+              'hover:border-background-active-primary-inverted-hover hover:bg-background-active-primary-inverted-hover':
+                variant === 'solid-inverted',
 
               // colors - bg, border, content - variant outline (figma: boxed secondary)
               'border-action-border-default bg-transparent text-action-content-default':

--- a/next/src/components/sections/headers/PageHeaderFacility.tsx
+++ b/next/src/components/sections/headers/PageHeaderFacility.tsx
@@ -111,7 +111,7 @@ const PageHeaderFacility = ({ title, breadcrumbs, headerLinks, header }: Props) 
                   .filter(isDefined)
                   .slice(0, 3)}
                 <div className="absolute right-4 bottom-4 z-1">
-                  <Button variant="solid" onPress={() => openAtImageIndex(0)}>
+                  <Button variant="solid-inverted" onPress={() => openAtImageIndex(0)}>
                     {t('PageHeaderFacility.allPhotos')}
                   </Button>
                 </div>
@@ -132,7 +132,7 @@ const PageHeaderFacility = ({ title, breadcrumbs, headerLinks, header }: Props) 
                 <ImagePlaceholder />
               )}
               <div className="absolute right-2 bottom-2 z-1 sm:right-3 sm:bottom-3">
-                <Button variant="solid" onPress={() => openAtImageIndex(0)}>
+                <Button variant="solid-inverted" onPress={() => openAtImageIndex(0)}>
                   {t('PageHeaderFacility.allPhotos')}
                 </Button>
               </div>


### PR DESCRIPTION
## Notes

- also implemented in ImageLightbox and GalleryModal so it is closer to intended design: https://www.figma.com/design/17wbd0MDQcMW9NbXl6UPs8/DS--Component-library?node-id=5505-6757&m=dev

## Screenshots

### Intended use in PageHeaderFacility
<img width="1521" height="846" alt="image" src="https://github.com/user-attachments/assets/7d79b3cf-6bfb-4548-8b65-ef6e4867b29d" />

### ImageLightbox - after
<img width="1909" height="868" alt="image" src="https://github.com/user-attachments/assets/5f4e42f1-17ba-4bae-9ba5-75ccb72e98ff" />

### ImageLightbox - before
<img width="1908" height="852" alt="image" src="https://github.com/user-attachments/assets/77f34af8-44b8-4774-a3e9-8c9a17b881c2" />
