### PR TITLE
Simplify GraphQLClient setup

### DIFF
--- a/next/src/services/graphql/gql.ts
+++ b/next/src/services/graphql/gql.ts
@@ -1,25 +1,6 @@
 import { getSdk } from '@/src/services/graphql/index'
 import { GraphQLClient } from 'graphql-request'
-import getConfig from 'next/config'
 
-type serverTypeConfig = {
-  strapiUrl: string
-}
-
-// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-const { serverRuntimeConfig }: { serverRuntimeConfig: serverTypeConfig } = getConfig()
-
-// URL becomes full url to strapi on server, but just /graphql (for proxy) on client
-
-const protocol =
-  serverRuntimeConfig?.strapiUrl &&
-  (serverRuntimeConfig?.strapiUrl.startsWith('http://') ||
-    serverRuntimeConfig?.strapiUrl.startsWith('https://'))
-    ? ''
-    : 'http://'
-
-const urlWithProtocol = `${protocol}${serverRuntimeConfig.strapiUrl}`
-const gql = new GraphQLClient(
-  `${serverRuntimeConfig?.strapiUrl ? urlWithProtocol : window.location.origin}/graphql`,
-)
+const gql = new GraphQLClient(`${process.env.STRAPI_URL}/graphql`)
 export const client = getSdk(gql)
+


### PR DESCRIPTION
Same as in OLO. 

The legacy setup is not needed anymore.