### PR TITLE
Setup running local scripts with ts-node

### DIFF
--- a/next/README.md
+++ b/next/README.md
@@ -39,7 +39,19 @@ graphql endpoint, simply run:
 npm run gen
 ```
 
-## Next API endpoints and server-side functions
+## Notes
+
+### How to run local scripts
+
+You can run a local script using `ts-node`. Scripts are located in `scripts/` folder. Development only scripts (those that are run from locale machine) are located in `scripts/dev/` subfolder.
+
+To run a script outside Next.js environment, we have to add `dotenv` support for reading .env files (e.g. `dotenv.config({ path: '.env.local' })`), and run scripts together with `tsconfig-paths/register` to resolve path aliases (`@/*`):
+
+```
+ts-node -r tsconfig-paths/register scripts/.../nameOfYourScript.ts
+```
+
+### Next API endpoints and server-side functions
 
 Some external services, such as Active Directory or GINIS, must be called only from server for security reasons
 or because they are available only from the internal network. For this purpose, we use Next API endpoints.
@@ -49,6 +61,6 @@ These functions are grouped usually in `server` subdirectory of a specific servi
 
 Use Next API endpoints only if needed for mentioned reasons. Otherwise, fetch data directly from client.
 
-## Resources
+### Resources
 
 There is one resource that needs to be available in https://bratislava.sk/Img/bratislava4.png, it is used in mails in signature as logo. Therefore please don't erase `public/Img/bratislava4.png`.

--- a/next/package-lock.json
+++ b/next/package-lock.json
@@ -21,6 +21,7 @@
         "@types/uuid": "^10.0.0",
         "axios": "1.8.4",
         "clsx": "2.1.1",
+        "dotenv": "^17.2.1",
         "focus-trap-react": "^11.0.3",
         "framer-motion": "^12.6.0",
         "graphql": "16.10.0",
@@ -118,6 +119,8 @@
         "sass": "^1.62.1",
         "sharp": "0.32.6",
         "tailwindcss": "^4.1.7",
+        "ts-node": "^10.9.2",
+        "tsconfig-paths": "^4.2.0",
         "typescript": "5.8.2"
       },
       "engines": {
@@ -1928,6 +1931,30 @@
         "uuid": "dist/esm/bin/uuid"
       }
     },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.3.1.tgz",
@@ -3720,6 +3747,19 @@
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/prisma-loader/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/@graphql-tools/relay-operation-optimizer": {
@@ -7618,6 +7658,34 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.9.0.tgz",
@@ -7685,7 +7753,8 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/lodash": {
       "version": "4.17.16",
@@ -8307,6 +8376,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
@@ -8396,6 +8478,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -9943,6 +10032,13 @@
         "sha.js": "^2.4.8"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-fetch": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
@@ -10377,6 +10473,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/diffie-hellman": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
@@ -10492,10 +10598,10 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.4.7",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
-      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
-      "dev": true,
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       },
@@ -11386,6 +11492,32 @@
         "ms": "^2.1.1"
       }
     },
+    "node_modules/eslint-config-next/node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/tsconfig-paths": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      }
+    },
     "node_modules/eslint-config-prettier": {
       "version": "10.1.1",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.1.tgz",
@@ -11583,6 +11715,32 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/tsconfig-paths": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
       }
     },
     "node_modules/eslint-plugin-json": {
@@ -15261,6 +15419,13 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/map-cache": {
       "version": "0.2.2",
@@ -21754,28 +21919,63 @@
       "integrity": "sha512-320x5Ggei84AxzlXp91QkIGSw5wgaLT6GeAH0KsqDmRZdVWW2OiSeVvElVoatk3f7nicwXlElXsoFkARiGE2yg==",
       "dev": true
     },
-    "node_modules/tsconfig-paths": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
-      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@types/json5": "^0.0.29",
-        "json5": "^1.0.2",
-        "minimist": "^1.2.6",
-        "strip-bom": "^3.0.0"
-      }
-    },
-    "node_modules/tsconfig-paths/node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.0"
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
       },
       "bin": {
-        "json5": "lib/cli.js"
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tslib": {
@@ -22362,6 +22562,13 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -22969,6 +23176,16 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/next/package.json
+++ b/next/package.json
@@ -40,6 +40,7 @@
     "@types/uuid": "^10.0.0",
     "axios": "1.8.4",
     "clsx": "2.1.1",
+    "dotenv": "^17.2.1",
     "focus-trap-react": "^11.0.3",
     "framer-motion": "^12.6.0",
     "graphql": "16.10.0",
@@ -137,6 +138,8 @@
     "sass": "^1.62.1",
     "sharp": "0.32.6",
     "tailwindcss": "^4.1.7",
+    "ts-node": "^10.9.2",
+    "tsconfig-paths": "^4.2.0",
     "typescript": "5.8.2"
   },
   "engines": {

--- a/next/scripts/dev/getAllUsedFilesInMediaLibrary.ts
+++ b/next/scripts/dev/getAllUsedFilesInMediaLibrary.ts
@@ -1,0 +1,93 @@
+import dotenv from 'dotenv'
+import { GraphQLClient } from 'graphql-request'
+
+import { getSdk } from '@/src/services/graphql'
+import { isDefined } from '@/src/utils/isDefined'
+
+// Load envs
+dotenv.config({ path: '.env.local' })
+
+const gql = new GraphQLClient(`${process.env.STRAPI_URL}/graphql`)
+export const client = getSdk(gql)
+
+// Run for both locales separately
+const locale = 'sk'
+
+const getAllUsedFilesInMediaLibrary = async () => {
+  const allFilesQuery = await client.allFiles({ locale })
+
+  const ids: Array<string | null | undefined> = []
+  allFilesQuery.articles.forEach((article) => {
+    ids.push(article?.coverMedia?.documentId)
+    article?.files?.forEach((file) => ids.push(file?.media?.documentId))
+    article?.gallery?.forEach((image) => ids.push(image?.documentId))
+  })
+  allFilesQuery.inbaArticles.forEach((article) => {
+    ids.push(article?.coverImage?.documentId)
+  })
+  allFilesQuery.inbaReleases.forEach((release) => {
+    ids.push(release?.coverImage?.documentId, release?.rearImage?.documentId)
+    release?.files?.forEach((file) => ids.push(file?.media?.documentId))
+  })
+  allFilesQuery.regulations.forEach((regulation) => {
+    ids.push(regulation?.mainDocument.documentId)
+    regulation?.attachments?.forEach((attachment) => ids.push(attachment?.documentId))
+  })
+  allFilesQuery.pages.forEach((page) => {
+    ids.push(page?.pageBackgroundImage?.documentId)
+    page?.pageHeaderSections?.forEach((pageHeaderSection) => {
+      if (pageHeaderSection?.__typename === 'ComponentHeaderSectionsFacility') {
+        pageHeaderSection.media.forEach((media) => ids.push(media?.documentId))
+      }
+    })
+    page?.sections?.forEach((section) => {
+      // eslint-disable-next-line default-case
+      switch (section?.__typename) {
+        case 'ComponentSectionsAccordion':
+          section?.flatText?.forEach((flatText) => {
+            flatText?.fileList?.forEach((file) => ids.push(file?.media?.documentId))
+          })
+          break
+
+        case 'ComponentSectionsBanner':
+          ids.push(section?.media?.documentId)
+          break
+
+        case 'ComponentSectionsColumns':
+          section?.columns?.forEach((column) => ids.push(column?.image?.documentId))
+          break
+
+        case 'ComponentSectionsComparisonSection':
+          section?.cards?.forEach((card) => ids.push(card?.iconMedia?.documentId))
+          break
+
+        case 'ComponentSectionsFileList':
+          section?.fileList?.forEach((file) => ids.push(file?.media?.documentId))
+          break
+
+        case 'ComponentSectionsGallery':
+          section?.medias?.forEach((media) => ids.push(media?.documentId))
+          break
+
+        case 'ComponentSectionsPartners':
+          section?.partners?.forEach((partner) => ids.push(partner?.logo?.documentId))
+          break
+
+        case 'ComponentSectionsTextWithImage':
+          ids.push(section?.imageSrc?.documentId)
+          break
+
+        case 'ComponentSectionsTextWithImageOverlapped':
+          ids.push(section?.image?.documentId)
+          break
+      }
+    })
+  })
+
+  const filteredIds = ids.filter(isDefined)
+
+  console.log('all used files length', filteredIds.length, new Set(filteredIds).size)
+}
+
+// migrateDocuments()
+getAllUsedFilesInMediaLibrary()

--- a/next/scripts/dev/migrateFilesToDocuments.ts
+++ b/next/scripts/dev/migrateFilesToDocuments.ts
@@ -1,0 +1,53 @@
+import dotenv from 'dotenv'
+import { GraphQLClient } from 'graphql-request'
+
+import { FileListSectionFragment, getSdk } from '@/src/services/graphql'
+import { isDefined } from '@/src/utils/isDefined'
+
+dotenv.config({ path: '.env.local' })
+
+const gql = new GraphQLClient(`${process.env.STRAPI_URL}/graphql`)
+export const client = getSdk(gql)
+
+const locale = 'sk'
+
+/**
+ * Temporary file to migrate strapi File List section to new Documents
+ */
+export const migrateDocuments = async () => {
+  console.log(process.env.STRAPI_URL)
+
+  const { pages } = await client.Dev_AllPages({ locale, limit: -1 })
+
+  const filteredPages = pages
+    .filter(isDefined)
+    .filter((page) =>
+      page.sections?.some((section) => section?.__typename === 'ComponentSectionsFileList'),
+    )
+    .filter(
+      (page) =>
+        page.slug &&
+        !(
+          page.slug.includes('platna-uzemnoplanovacia-dokumentacia') ||
+          page.slug.includes('archivne-pomocky')
+        ),
+    )
+  console.log(filteredPages.length)
+
+  // eslint-disable-next-line no-restricted-syntax
+  for (const page of filteredPages) {
+    const fileListSections = (page.sections?.filter(
+      (section) => section?.__typename === 'ComponentSectionsFileList',
+    ) ?? []) as FileListSectionFragment[]
+
+    const counts = fileListSections.map((section) => section.fileList?.length ?? 0)
+    console.log(fileListSections.length, counts, `https://bratislava.sk/${page.slug}`)
+
+    // eslint-disable-next-line no-await-in-loop
+    // await client.updatePage({
+    //   documentId: page.documentId,
+    //   locale,
+    //   pageInput: { subnavigation: { links } },
+    // })
+  }
+}

--- a/next/scripts/dev/migrateSubnavigation.ts
+++ b/next/scripts/dev/migrateSubnavigation.ts
@@ -1,0 +1,77 @@
+import dotenv from 'dotenv'
+import { GraphQLClient } from 'graphql-request'
+
+import { getSdk } from '@/src/services/graphql'
+import { isDefined } from '@/src/utils/isDefined'
+
+dotenv.config({ path: '.env.local' })
+
+const gql = new GraphQLClient(`${process.env.STRAPI_URL}/graphql`)
+export const client = getSdk(gql)
+
+// Triple-check & test locally before running!
+// Run the script for both locales separately.
+
+const locale = 'sk'
+
+/**
+ * Temporary script to migrate SubpageList header section to new Subnavigation (rozcestnik)
+ */
+export const migrateSubnavigation = async () => {
+  console.log(process.env.STRAPI_URL)
+
+  const { pages } = await client.Dev_AllPages({ locale, limit: -1 })
+
+  const filteredPages = pages
+    .filter(isDefined)
+    .filter((page) =>
+      page.pageHeaderSections?.some(
+        (section) => section?.__typename === 'ComponentSectionsSubpageList',
+      ),
+    )
+
+  console.log(filteredPages.length)
+
+  // eslint-disable-next-line no-restricted-syntax
+  for (const page of filteredPages) {
+    const [subpageList] =
+      page.pageHeaderSections?.filter(
+        (header) => header?.__typename === 'ComponentSectionsSubpageList',
+      ) ?? []
+
+    if (!(subpageList && subpageList.__typename === 'ComponentSectionsSubpageList')) {
+      // eslint-disable-next-line no-continue
+      continue
+    }
+
+    const oldLinks = subpageList.subpageList?.filter(isDefined) ?? []
+
+    if (oldLinks.length === 0) {
+      // eslint-disable-next-line no-continue
+      continue
+    }
+
+    console.log(page.slug, page.documentId, oldLinks.length)
+
+    const links =
+      oldLinks.map((link) => {
+        return {
+          label: link.label,
+          url: link.url,
+          analyticsId: link.analyticsId,
+          page: link.page?.documentId,
+        }
+      }) ?? []
+
+    // console.log(links)
+
+    // eslint-disable-next-line no-await-in-loop
+    await client.updatePage({
+      documentId: page.documentId,
+      locale,
+      pageInput: { subnavigation: { links } },
+    })
+  }
+}
+
+migrateSubnavigation()

--- a/next/src/services/graphql/index.ts
+++ b/next/src/services/graphql/index.ts
@@ -6560,6 +6560,138 @@ export type FaqEntityFragment = {
   body?: string | null
 }
 
+export type UploadFileFragment = { __typename?: 'UploadFile'; documentId: string }
+
+export type AllFilesQueryVariables = Exact<{
+  locale?: InputMaybe<Scalars['I18NLocaleCode']['input']>
+}>
+
+export type AllFilesQuery = {
+  __typename?: 'Query'
+  articles: Array<{
+    __typename?: 'Article'
+    coverMedia?: { __typename?: 'UploadFile'; documentId: string } | null
+    gallery: Array<{ __typename?: 'UploadFile'; documentId: string } | null>
+    files?: Array<{
+      __typename?: 'ComponentBlocksFile'
+      media?: { __typename?: 'UploadFile'; documentId: string } | null
+    } | null> | null
+  } | null>
+  inbaArticles: Array<{
+    __typename?: 'InbaArticle'
+    coverImage?: { __typename?: 'UploadFile'; documentId: string } | null
+  } | null>
+  inbaReleases: Array<{
+    __typename?: 'InbaRelease'
+    coverImage?: { __typename?: 'UploadFile'; documentId: string } | null
+    rearImage?: { __typename?: 'UploadFile'; documentId: string } | null
+    files?: Array<{
+      __typename?: 'ComponentBlocksFile'
+      media?: { __typename?: 'UploadFile'; documentId: string } | null
+    } | null> | null
+  } | null>
+  regulations: Array<{
+    __typename?: 'Regulation'
+    mainDocument: { __typename?: 'UploadFile'; documentId: string }
+    attachments: Array<{ __typename?: 'UploadFile'; documentId: string } | null>
+  } | null>
+  pages: Array<{
+    __typename?: 'Page'
+    pageBackgroundImage?: { __typename?: 'UploadFile'; documentId: string } | null
+    pageHeaderSections?: Array<
+      | { __typename?: 'ComponentHeaderSectionsEvent' }
+      | {
+          __typename?: 'ComponentHeaderSectionsFacility'
+          media: Array<{ __typename?: 'UploadFile'; documentId: string } | null>
+        }
+      | { __typename?: 'ComponentSectionsSubpageList' }
+      | { __typename?: 'Error' }
+      | null
+    > | null
+    sections?: Array<
+      | {
+          __typename?: 'ComponentSectionsAccordion'
+          flatText?: Array<{
+            __typename?: 'ComponentAccordionItemsFlatText'
+            fileList?: Array<{
+              __typename?: 'ComponentBlocksFileItem'
+              media: { __typename?: 'UploadFile'; documentId: string }
+            } | null> | null
+          } | null> | null
+        }
+      | { __typename?: 'ComponentSectionsArticles' }
+      | {
+          __typename?: 'ComponentSectionsBanner'
+          media: { __typename?: 'UploadFile'; documentId: string }
+        }
+      | { __typename?: 'ComponentSectionsCalculator' }
+      | { __typename?: 'ComponentSectionsColumnedText' }
+      | {
+          __typename?: 'ComponentSectionsColumns'
+          columns: Array<{
+            __typename?: 'ComponentBlocksColumnsItem'
+            image?: { __typename?: 'UploadFile'; documentId: string } | null
+          } | null>
+        }
+      | {
+          __typename?: 'ComponentSectionsComparisonSection'
+          cards: Array<{
+            __typename?: 'ComponentBlocksComparisonCard'
+            iconMedia?: { __typename?: 'UploadFile'; documentId: string } | null
+          } | null>
+        }
+      | { __typename?: 'ComponentSectionsContactsSection' }
+      | { __typename?: 'ComponentSectionsDivider' }
+      | { __typename?: 'ComponentSectionsDocuments' }
+      | { __typename?: 'ComponentSectionsEvents' }
+      | { __typename?: 'ComponentSectionsFaqCategories' }
+      | { __typename?: 'ComponentSectionsFaqs' }
+      | {
+          __typename?: 'ComponentSectionsFileList'
+          fileList?: Array<{
+            __typename?: 'ComponentBlocksFile'
+            media?: { __typename?: 'UploadFile'; documentId: string } | null
+          } | null> | null
+        }
+      | {
+          __typename?: 'ComponentSectionsGallery'
+          medias: Array<{ __typename?: 'UploadFile'; documentId: string } | null>
+        }
+      | { __typename?: 'ComponentSectionsIframe' }
+      | { __typename?: 'ComponentSectionsInbaArticlesList' }
+      | { __typename?: 'ComponentSectionsInbaReleases' }
+      | { __typename?: 'ComponentSectionsLinks' }
+      | { __typename?: 'ComponentSectionsNarrowText' }
+      | { __typename?: 'ComponentSectionsNumbersOverview' }
+      | { __typename?: 'ComponentSectionsNumericalList' }
+      | { __typename?: 'ComponentSectionsOfficialBoard' }
+      | { __typename?: 'ComponentSectionsOrganizationalStructure' }
+      | {
+          __typename?: 'ComponentSectionsPartners'
+          partners: Array<{
+            __typename?: 'ComponentBlocksPartner'
+            logo: { __typename?: 'UploadFile'; documentId: string }
+          } | null>
+        }
+      | { __typename?: 'ComponentSectionsProsAndConsSection' }
+      | { __typename?: 'ComponentSectionsRegulations' }
+      | { __typename?: 'ComponentSectionsRegulationsList' }
+      | {
+          __typename?: 'ComponentSectionsTextWithImage'
+          imageSrc: { __typename?: 'UploadFile'; documentId: string }
+        }
+      | {
+          __typename?: 'ComponentSectionsTextWithImageOverlapped'
+          image: { __typename?: 'UploadFile'; documentId: string }
+        }
+      | { __typename?: 'ComponentSectionsTootootEvents' }
+      | { __typename?: 'ComponentSectionsVideos' }
+      | { __typename?: 'Error' }
+      | null
+    > | null
+  } | null>
+}
+
 export type UploadImageSrcEntityFragment = {
   __typename?: 'UploadFile'
   documentId: string
@@ -11193,6 +11325,17 @@ export type Dev_AllPagesQuery = {
   } | null>
 }
 
+export type UpdatePageMutationVariables = Exact<{
+  documentId: Scalars['ID']['input']
+  locale?: InputMaybe<Scalars['I18NLocaleCode']['input']>
+  pageInput: PageInput
+}>
+
+export type UpdatePageMutation = {
+  __typename?: 'Mutation'
+  updatePage?: { __typename?: 'Page'; documentId: string } | null
+}
+
 export type AllRegulationsQueryVariables = Exact<{ [key: string]: never }>
 
 export type AllRegulationsQuery = {
@@ -13665,6 +13808,11 @@ export const ArticleEntityFragmentDoc = gql`
   ${FileBlockFragmentDoc}
   ${UploadImageEntityFragmentDoc}
 `
+export const UploadFileFragmentDoc = gql`
+  fragment UploadFile on UploadFile {
+    documentId
+  }
+`
 export const PageSlugEntityFragmentDoc = gql`
   fragment PageSlugEntity on Page {
     documentId
@@ -14959,6 +15107,121 @@ export const DocumentBySlugDocument = gql`
   }
   ${DocumentEntityFragmentDoc}
 `
+export const AllFilesDocument = gql`
+  query allFiles($locale: I18NLocaleCode) {
+    articles(locale: $locale, pagination: { limit: -1 }) {
+      coverMedia {
+        ...UploadFile
+      }
+      gallery(pagination: { limit: -1 }) {
+        ...UploadFile
+      }
+      files(pagination: { limit: -1 }) {
+        media {
+          ...UploadFile
+        }
+      }
+    }
+    inbaArticles(locale: $locale, pagination: { limit: -1 }) {
+      coverImage {
+        ...UploadFile
+      }
+    }
+    inbaReleases(pagination: { limit: -1 }) {
+      coverImage {
+        ...UploadFile
+      }
+      rearImage {
+        ...UploadFile
+      }
+      files(pagination: { limit: -1 }) {
+        media {
+          ...UploadFile
+        }
+      }
+    }
+    regulations(pagination: { limit: -1 }) {
+      mainDocument {
+        ...UploadFile
+      }
+      attachments(pagination: { limit: -1 }) {
+        ...UploadFile
+      }
+    }
+    pages(locale: $locale, pagination: { limit: -1 }) {
+      pageBackgroundImage {
+        ...UploadFile
+      }
+      pageHeaderSections {
+        ... on ComponentHeaderSectionsFacility {
+          media(pagination: { limit: -1 }) {
+            ...UploadFile
+          }
+        }
+      }
+      sections {
+        ... on ComponentSectionsAccordion {
+          flatText(pagination: { limit: -1 }) {
+            fileList(pagination: { limit: -1 }) {
+              media {
+                ...UploadFile
+              }
+            }
+          }
+        }
+        ... on ComponentSectionsBanner {
+          media {
+            ...UploadFile
+          }
+        }
+        ... on ComponentSectionsColumns {
+          columns(pagination: { limit: -1 }) {
+            image {
+              ...UploadFile
+            }
+          }
+        }
+        ... on ComponentSectionsComparisonSection {
+          cards(pagination: { limit: -1 }) {
+            iconMedia {
+              ...UploadFile
+            }
+          }
+        }
+        ... on ComponentSectionsFileList {
+          fileList(pagination: { limit: -1 }) {
+            media {
+              ...UploadFile
+            }
+          }
+        }
+        ... on ComponentSectionsGallery {
+          medias(pagination: { limit: -1 }) {
+            ...UploadFile
+          }
+        }
+        ... on ComponentSectionsPartners {
+          partners(pagination: { limit: -1 }) {
+            logo {
+              ...UploadFile
+            }
+          }
+        }
+        ... on ComponentSectionsTextWithImage {
+          imageSrc {
+            ...UploadFile
+          }
+        }
+        ... on ComponentSectionsTextWithImageOverlapped {
+          image {
+            ...UploadFile
+          }
+        }
+      }
+    }
+  }
+  ${UploadFileFragmentDoc}
+`
 export const GeneralDocument = gql`
   query General($locale: I18NLocaleCode!) {
     general(locale: $locale) {
@@ -15124,6 +15387,13 @@ export const Dev_AllPagesDocument = gql`
     }
   }
   ${PageEntityFragmentDoc}
+`
+export const UpdatePageDocument = gql`
+  mutation updatePage($documentId: ID!, $locale: I18NLocaleCode, $pageInput: PageInput!) {
+    updatePage(documentId: $documentId, locale: $locale, data: $pageInput) {
+      documentId
+    }
+  }
 `
 export const AllRegulationsDocument = gql`
   query allRegulations {
@@ -15330,6 +15600,21 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
             ...wrappedRequestHeaders,
           }),
         'DocumentBySlug',
+        'query',
+        variables,
+      )
+    },
+    allFiles(
+      variables?: AllFilesQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<AllFilesQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<AllFilesQuery>(AllFilesDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'allFiles',
         'query',
         variables,
       )
@@ -15556,6 +15841,21 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
           }),
         'Dev_AllPages',
         'query',
+        variables,
+      )
+    },
+    updatePage(
+      variables: UpdatePageMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<UpdatePageMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<UpdatePageMutation>(UpdatePageDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'updatePage',
+        'mutation',
         variables,
       )
     },

--- a/next/src/services/graphql/queries/Files.graphql
+++ b/next/src/services/graphql/queries/Files.graphql
@@ -1,0 +1,116 @@
+fragment UploadFile on UploadFile {
+  documentId
+}
+
+query allFiles($locale: I18NLocaleCode) {
+  articles(locale: $locale, pagination: { limit: -1 }) {
+    coverMedia {
+      ...UploadFile
+    }
+    gallery(pagination: { limit: -1 }) {
+      ...UploadFile
+    }
+    files(pagination: { limit: -1 }) {
+      media {
+        ...UploadFile
+      }
+    }
+  }
+  inbaArticles(locale: $locale, pagination: { limit: -1 }) {
+    coverImage {
+      ...UploadFile
+    }
+  }
+  inbaReleases(pagination: { limit: -1 }) {
+    coverImage {
+      ...UploadFile
+    }
+    rearImage {
+      ...UploadFile
+    }
+    files(pagination: { limit: -1 }) {
+      media {
+        ...UploadFile
+      }
+    }
+  }
+  regulations(pagination: { limit: -1 }) {
+    mainDocument {
+      ...UploadFile
+    }
+    attachments(pagination: { limit: -1 }) {
+      ...UploadFile
+    }
+  }
+  pages(locale: $locale, pagination: { limit: -1 }) {
+    pageBackgroundImage {
+      ...UploadFile
+    }
+    pageHeaderSections {
+      ...on ComponentHeaderSectionsFacility {
+        media(pagination: { limit: -1 }) {
+          ...UploadFile
+        }
+      }
+    }
+    sections {
+      ...on ComponentSectionsAccordion {
+        flatText(pagination: { limit: -1 }) {
+          fileList(pagination: { limit: -1 }) {
+            media {
+              ...UploadFile
+            }
+          }
+        }
+      }
+      ...on ComponentSectionsBanner {
+        media {
+          ...UploadFile
+        }
+      }
+      ...on ComponentSectionsColumns {
+        columns(pagination: { limit: -1 }) {
+          image {
+            ...UploadFile
+          }
+        }
+      }
+      ...on ComponentSectionsComparisonSection {
+        cards(pagination: { limit: -1 }) {
+          iconMedia {
+            ...UploadFile
+          }
+        }
+      }
+      ...on ComponentSectionsFileList {
+        fileList(pagination: { limit: -1 }) {
+          media {
+            ...UploadFile
+          }
+        }
+      }
+      ...on ComponentSectionsGallery {
+        medias(pagination: { limit: -1 }) {
+          ...UploadFile
+        }
+      }
+      ...on ComponentSectionsPartners {
+        partners(pagination: { limit: -1 }) {
+          logo {
+            ...UploadFile
+          }
+        }
+      }
+      ...on ComponentSectionsTextWithImage {
+        imageSrc {
+          ...UploadFile
+        }
+      }
+      ...on ComponentSectionsTextWithImageOverlapped {
+        image {
+          ...UploadFile
+        }
+      }
+    }
+  }
+}

--- a/next/src/services/graphql/queries/Pages.graphql
+++ b/next/src/services/graphql/queries/Pages.graphql
@@ -120,3 +120,9 @@ query Dev_AllPages(
     ...PageEntity
   }
 }
+
+mutation updatePage($documentId: ID!, $locale: I18NLocaleCode, $pageInput: PageInput!) {
+  updatePage(documentId: $documentId, locale: $locale, data: $pageInput) {
+    documentId
+  }
+}

--- a/next/tsconfig.json
+++ b/next/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "jsx": "preserve",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
@@ -9,7 +9,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
-    "module": "esnext",
+    "module": "commonjs",
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,


### PR DESCRIPTION
We want to be able to run some .ts scripts locally (to lis pages, to list some specific sections use-cases etc.).

We can achieve it by using `ts-node` (as it is used in konto project).

Additionally to konto, we install also
- `dotenv` - to be able to read .env variables from a file - to get strapi url
  - strapi url can pottentially be hardcoded in the script 🤷 and we will not need `dotenv`
- `tsconfig-paths/register` - because we use path aliases in tsconfig (`@/*`)

I committed also some scripts, that I started to write, but they are only temporary or they will get stale with more strapi changes. These scripts are mostly for migration purposes around Files and Documents and Subnavigation.
I don't know yet what "policy" we will have about committing such kind of code, but it's in dev folder, that should signify that they need to be used with care. And we can delete them in near future.

This PR is more about the setup. And it's safe to test it with `getAllUsedFilesInMediaLibrary.ts` by running it as stated in REDME.