### PR TITLE
#1772 Enable hiding SectionHeader heading from ToC, hide in RelatedArticlesSection

### DIFF
--- a/next/src/components/layouts/SectionHeader.tsx
+++ b/next/src/components/layouts/SectionHeader.tsx
@@ -17,6 +17,7 @@ type SectionHeaderProps = {
   asRichtext?: boolean
   isFullWidth?: boolean
   isCentered?: boolean
+  excludeFromTableOfContents?: boolean
   showMoreLink?: CommonLinkFragment | null | undefined
   className?: string
 }
@@ -34,6 +35,7 @@ const SectionHeader = ({
   asRichtext = false,
   isFullWidth = false,
   isCentered = false,
+  excludeFromTableOfContents = false,
   showMoreLink,
   className,
 }: SectionHeaderProps) => {
@@ -43,7 +45,7 @@ const SectionHeader = ({
 
   return (
     <div
-      {...TABLE_OF_CONTENTS_HEADING_ATTRIBUTE}
+      {...(excludeFromTableOfContents ? undefined : TABLE_OF_CONTENTS_HEADING_ATTRIBUTE)}
       className={cn('flex items-center lg:justify-end', {
         'flex flex-col items-start gap-y-4 lg:flex-row lg:flex-wrap lg:justify-between': title,
         'lg:justify-start': !showMoreLink,

--- a/next/src/components/sections/RelatedArticlesSection.tsx
+++ b/next/src/components/sections/RelatedArticlesSection.tsx
@@ -40,7 +40,10 @@ const RelatedArticlesSection = ({ page, className }: Props) => {
   return (
     <SectionContainer className={className}>
       <div className="flex flex-col">
-        <SectionHeader title={t('RelatedArticlesSection.relatedArticles')} />
+        <SectionHeader
+          title={t('RelatedArticlesSection.relatedArticles')}
+          excludeFromTableOfContents
+        />
 
         <ResponsiveCarousel
           items={data.hits.map((card) => {


### PR DESCRIPTION
## Notes

Implemented as a prop to SectionHeader - pondered a minute about naming, chose `excludeFromTableOfContents` which seems to me the most legible when actually using this prop:
<img width="580" height="90" alt="image" src="https://github.com/user-attachments/assets/1696ae2c-4db6-4b49-854b-746246b988fd" />
