### PR TITLE
#1660 Refactor main content-type sections to handle starz content

### DIFF
--- a/next/src/components/sections/ArticlesSection/ArticlesFiltered.tsx
+++ b/next/src/components/sections/ArticlesSection/ArticlesFiltered.tsx
@@ -24,46 +24,63 @@ type Props = {
  * Figma: https://www.figma.com/design/17wbd0MDQcMW9NbXl6UPs8/DS--Component-library?node-id=16846-35571&m=dev
  */
 
-const ArticlesByCategory = ({ section }: Props) => {
+const ArticlesFiltered = ({ section }: Props) => {
   const locale = useLocale()
 
-  const { title, text, category } = section
+  const { title, text, category, tags, adminGroups } = section
+
+  const adminGroupDocumentIds = adminGroups
+    .map((adminGroup) => adminGroup?.documentId)
+    .filter(isDefined)
+
+  const tagDocumentIds = tags.map((tag) => tag?.documentId).filter(isDefined)
 
   const [filters, setFilters] = useRoutePreservedState({
     ...articlesDefaultFilters,
+    adminGroupDocumentIds,
+    tagDocumentIds,
     pageSize: 12,
   })
 
-  const { data: tagsData } = useQuery({
+  // TODO remove this after removing main categories in strapi
+  const { data: tagsDataFromCategoryField } = useQuery({
     queryKey: ['Tags', locale],
     queryFn: () => client.Tags({ locale }),
     staleTime: Infinity,
+    enabled: !!category,
   })
 
-  const tagDocumentIds =
-    tagsData?.tags
-      .filter((tag) => {
-        return tag?.pageCategory?.documentId === category?.documentId
-      })
-      .map((tag) => tag?.documentId ?? '')
-      .filter(isDefined) ?? []
-
+  // TODO remove this after removing main categories in strapi
   useEffect(() => {
-    setFilters({ ...filters, tagDocumentIds })
+    if (!category || !tagsDataFromCategoryField) return
+    setFilters({
+      ...filters,
+      adminGroupDocumentIds: [],
+      tagDocumentIds:
+        tagsDataFromCategoryField.tags
+          .filter((tag) => {
+            return tag?.pageCategory?.documentId === category?.documentId
+          })
+          .map((tag) => tag?.documentId ?? '')
+          .filter(isDefined) ?? [],
+    })
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tagsData])
+  }, [tagsDataFromCategoryField])
 
   // TODO prefetch section
   const { data } = useQuery({
     queryKey: getArticlesQueryKey(filters, locale),
     queryFn: () => articlesFetcher(filters, locale),
     placeholderData: keepPreviousData,
-    enabled: filters.tagDocumentIds.length > 0,
   })
 
   return (
-    <div className="flex flex-col">
-      <SectionHeader title={title} text={text} />
+    <div className="flex flex-col gap-8">
+      <SectionHeader
+        title={title}
+        text={text}
+        // TODO showMoreLink
+      />
       {data?.hits ? (
         <ResponsiveCarousel
           items={data.hits
@@ -71,16 +88,17 @@ const ArticlesByCategory = ({ section }: Props) => {
               return card ? (
                 <ArticleCard
                   key={card.slug}
-                  {...transformArticleProps(card, { withText: false })}
+                  {...transformArticleProps(card, { withText: false, withTag: false })}
                 />
               ) : null
             })
             .filter(isDefined)}
-          desktop={4}
+          desktop={3}
+          hasVerticalPadding={false}
         />
       ) : null}
     </div>
   )
 }
 
-export default ArticlesByCategory
+export default ArticlesFiltered

--- a/next/src/components/sections/ArticlesSection/ArticlesFiltered.tsx
+++ b/next/src/components/sections/ArticlesSection/ArticlesFiltered.tsx
@@ -27,7 +27,7 @@ type Props = {
 const ArticlesFiltered = ({ section }: Props) => {
   const locale = useLocale()
 
-  const { title, text, category, tags, adminGroups } = section
+  const { title, text, category, tags, adminGroups, showMoreLink } = section
 
   const adminGroupDocumentIds = adminGroups
     .map((adminGroup) => adminGroup?.documentId)
@@ -76,11 +76,7 @@ const ArticlesFiltered = ({ section }: Props) => {
 
   return (
     <div className="flex flex-col gap-8">
-      <SectionHeader
-        title={title}
-        text={text}
-        // TODO showMoreLink
-      />
+      <SectionHeader title={title} text={text} showMoreLink={showMoreLink} />
       {data?.hits ? (
         <ResponsiveCarousel
           items={data.hits

--- a/next/src/components/sections/ArticlesSection/ArticlesSection.tsx
+++ b/next/src/components/sections/ArticlesSection/ArticlesSection.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import SectionContainer from '@/src/components/layouts/SectionContainer'
 import ArticlesAll from '@/src/components/sections/ArticlesSection/ArticlesAll'
-import ArticlesByCategory from '@/src/components/sections/ArticlesSection/ArticlesByCategory'
+import ArticlesFiltered from '@/src/components/sections/ArticlesSection/ArticlesFiltered'
 import { ArticlesSectionFragment } from '@/src/services/graphql'
 
 type Props = {
@@ -12,11 +12,7 @@ type Props = {
 const ArticlesSection = ({ section }: Props) => {
   return (
     <SectionContainer>
-      {section.showAll ? (
-        <ArticlesAll section={section} />
-      ) : (
-        <ArticlesByCategory section={section} />
-      )}
+      {section.showAll ? <ArticlesAll section={section} /> : <ArticlesFiltered section={section} />}
     </SectionContainer>
   )
 }

--- a/next/src/services/fetchers/homepageContextFetcher.ts
+++ b/next/src/services/fetchers/homepageContextFetcher.ts
@@ -19,6 +19,7 @@ export const homepageContextFetcher = async (locale: string): Promise<HomepageCo
       limit: 7,
       sort: 'addedAt:desc',
       locale,
+      filters: { adminGroups: { adminGroupId: { eq: null } } },
     }),
     client.LatestInbaRelease(),
   ])

--- a/next/src/services/fetchers/homepageContextFetcher.ts
+++ b/next/src/services/fetchers/homepageContextFetcher.ts
@@ -19,6 +19,7 @@ export const homepageContextFetcher = async (locale: string): Promise<HomepageCo
       limit: 7,
       sort: 'addedAt:desc',
       locale,
+      // Only show articles with no adminGroup assigned
       filters: { adminGroups: { adminGroupId: { eq: null } } },
     }),
     client.LatestInbaRelease(),

--- a/next/src/services/graphql/index.ts
+++ b/next/src/services/graphql/index.ts
@@ -1347,27 +1347,59 @@ export type ComponentSectionsAccordionInput = {
 
 export type ComponentSectionsArticles = {
   __typename?: 'ComponentSectionsArticles'
+  adminGroups: Array<Maybe<AdminGroup>>
+  adminGroups_connection?: Maybe<AdminGroupRelationResponseCollection>
   category?: Maybe<PageCategory>
   id: Scalars['ID']['output']
   showAll?: Maybe<Scalars['Boolean']['output']>
+  tags: Array<Maybe<Tag>>
+  tags_connection?: Maybe<TagRelationResponseCollection>
   text?: Maybe<Scalars['String']['output']>
   title?: Maybe<Scalars['String']['output']>
 }
 
+export type ComponentSectionsArticlesAdminGroupsArgs = {
+  filters?: InputMaybe<AdminGroupFiltersInput>
+  pagination?: InputMaybe<PaginationArg>
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>
+}
+
+export type ComponentSectionsArticlesAdminGroups_ConnectionArgs = {
+  filters?: InputMaybe<AdminGroupFiltersInput>
+  pagination?: InputMaybe<PaginationArg>
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>
+}
+
+export type ComponentSectionsArticlesTagsArgs = {
+  filters?: InputMaybe<TagFiltersInput>
+  pagination?: InputMaybe<PaginationArg>
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>
+}
+
+export type ComponentSectionsArticlesTags_ConnectionArgs = {
+  filters?: InputMaybe<TagFiltersInput>
+  pagination?: InputMaybe<PaginationArg>
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>
+}
+
 export type ComponentSectionsArticlesFiltersInput = {
+  adminGroups?: InputMaybe<AdminGroupFiltersInput>
   and?: InputMaybe<Array<InputMaybe<ComponentSectionsArticlesFiltersInput>>>
   category?: InputMaybe<PageCategoryFiltersInput>
   not?: InputMaybe<ComponentSectionsArticlesFiltersInput>
   or?: InputMaybe<Array<InputMaybe<ComponentSectionsArticlesFiltersInput>>>
   showAll?: InputMaybe<BooleanFilterInput>
+  tags?: InputMaybe<TagFiltersInput>
   text?: InputMaybe<StringFilterInput>
   title?: InputMaybe<StringFilterInput>
 }
 
 export type ComponentSectionsArticlesInput = {
+  adminGroups?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>
   category?: InputMaybe<Scalars['ID']['input']>
   id?: InputMaybe<Scalars['ID']['input']>
   showAll?: InputMaybe<Scalars['Boolean']['input']>
+  tags?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>
   text?: InputMaybe<Scalars['String']['input']>
   title?: InputMaybe<Scalars['String']['input']>
 }
@@ -6168,6 +6200,8 @@ export type UsersPermissionsUserRelationResponseCollection = {
   nodes: Array<UsersPermissionsUser>
 }
 
+export type AdminGroupEntityFragment = { __typename?: 'AdminGroup'; documentId: string }
+
 export type ArticleCategoryEntityFragment = {
   __typename?: 'ArticleCategory'
   documentId: string
@@ -9085,6 +9119,18 @@ export type PageEntityFragment = {
           title?: string | null
           color?: Enum_Pagecategory_Color | null
         } | null
+        tags: Array<{
+          __typename?: 'Tag'
+          documentId: string
+          title?: string | null
+          pageCategory?: {
+            __typename?: 'PageCategory'
+            documentId: string
+            title?: string | null
+            color?: Enum_Pagecategory_Color | null
+          } | null
+        } | null>
+        adminGroups: Array<{ __typename?: 'AdminGroup'; documentId: string } | null>
       }
     | {
         __typename: 'ComponentSectionsBanner'
@@ -9955,6 +10001,18 @@ export type PageBySlugQuery = {
             title?: string | null
             color?: Enum_Pagecategory_Color | null
           } | null
+          tags: Array<{
+            __typename?: 'Tag'
+            documentId: string
+            title?: string | null
+            pageCategory?: {
+              __typename?: 'PageCategory'
+              documentId: string
+              title?: string | null
+              color?: Enum_Pagecategory_Color | null
+            } | null
+          } | null>
+          adminGroups: Array<{ __typename?: 'AdminGroup'; documentId: string } | null>
         }
       | {
           __typename: 'ComponentSectionsBanner'
@@ -10854,6 +10912,18 @@ export type Dev_AllPagesQuery = {
             title?: string | null
             color?: Enum_Pagecategory_Color | null
           } | null
+          tags: Array<{
+            __typename?: 'Tag'
+            documentId: string
+            title?: string | null
+            pageCategory?: {
+              __typename?: 'PageCategory'
+              documentId: string
+              title?: string | null
+              color?: Enum_Pagecategory_Color | null
+            } | null
+          } | null>
+          adminGroups: Array<{ __typename?: 'AdminGroup'; documentId: string } | null>
         }
       | {
           __typename: 'ComponentSectionsBanner'
@@ -12170,6 +12240,18 @@ export type ArticlesSectionFragment = {
     title?: string | null
     color?: Enum_Pagecategory_Color | null
   } | null
+  tags: Array<{
+    __typename?: 'Tag'
+    documentId: string
+    title?: string | null
+    pageCategory?: {
+      __typename?: 'PageCategory'
+      documentId: string
+      title?: string | null
+      color?: Enum_Pagecategory_Color | null
+    } | null
+  } | null>
+  adminGroups: Array<{ __typename?: 'AdminGroup'; documentId: string } | null>
 }
 
 export type InbaArticlesListSectionFragment = {
@@ -13119,6 +13201,18 @@ type Sections_ComponentSectionsArticles_Fragment = {
     title?: string | null
     color?: Enum_Pagecategory_Color | null
   } | null
+  tags: Array<{
+    __typename?: 'Tag'
+    documentId: string
+    title?: string | null
+    pageCategory?: {
+      __typename?: 'PageCategory'
+      documentId: string
+      title?: string | null
+      color?: Enum_Pagecategory_Color | null
+    } | null
+  } | null>
+  adminGroups: Array<{ __typename?: 'AdminGroup'; documentId: string } | null>
 }
 
 type Sections_ComponentSectionsBanner_Fragment = {
@@ -14787,6 +14881,11 @@ export const NumericalListSectionFragmentDoc = gql`
   }
   ${NumericalListItemBlockFragmentDoc}
 `
+export const AdminGroupEntityFragmentDoc = gql`
+  fragment AdminGroupEntity on AdminGroup {
+    documentId
+  }
+`
 export const ArticlesSectionFragmentDoc = gql`
   fragment ArticlesSection on ComponentSectionsArticles {
     title
@@ -14795,8 +14894,16 @@ export const ArticlesSectionFragmentDoc = gql`
     category {
       ...PageCategoryEntity
     }
+    tags {
+      ...TagEntity
+    }
+    adminGroups {
+      ...AdminGroupEntity
+    }
   }
   ${PageCategoryEntityFragmentDoc}
+  ${TagEntityFragmentDoc}
+  ${AdminGroupEntityFragmentDoc}
 `
 export const InbaArticlesListSectionFragmentDoc = gql`
   fragment InbaArticlesListSection on ComponentSectionsInbaArticlesList {

--- a/next/src/services/graphql/index.ts
+++ b/next/src/services/graphql/index.ts
@@ -1352,6 +1352,7 @@ export type ComponentSectionsArticles = {
   category?: Maybe<PageCategory>
   id: Scalars['ID']['output']
   showAll?: Maybe<Scalars['Boolean']['output']>
+  showMoreLink?: Maybe<ComponentBlocksCommonLink>
   tags: Array<Maybe<Tag>>
   tags_connection?: Maybe<TagRelationResponseCollection>
   text?: Maybe<Scalars['String']['output']>
@@ -1389,6 +1390,7 @@ export type ComponentSectionsArticlesFiltersInput = {
   not?: InputMaybe<ComponentSectionsArticlesFiltersInput>
   or?: InputMaybe<Array<InputMaybe<ComponentSectionsArticlesFiltersInput>>>
   showAll?: InputMaybe<BooleanFilterInput>
+  showMoreLink?: InputMaybe<ComponentBlocksCommonLinkFiltersInput>
   tags?: InputMaybe<TagFiltersInput>
   text?: InputMaybe<StringFilterInput>
   title?: InputMaybe<StringFilterInput>
@@ -1399,6 +1401,7 @@ export type ComponentSectionsArticlesInput = {
   category?: InputMaybe<Scalars['ID']['input']>
   id?: InputMaybe<Scalars['ID']['input']>
   showAll?: InputMaybe<Scalars['Boolean']['input']>
+  showMoreLink?: InputMaybe<ComponentBlocksCommonLinkInput>
   tags?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>
   text?: InputMaybe<Scalars['String']['input']>
   title?: InputMaybe<Scalars['String']['input']>
@@ -9131,6 +9134,26 @@ export type PageEntityFragment = {
           } | null
         } | null>
         adminGroups: Array<{ __typename?: 'AdminGroup'; documentId: string } | null>
+        showMoreLink?: {
+          __typename?: 'ComponentBlocksCommonLink'
+          label?: string | null
+          url?: string | null
+          analyticsId?: string | null
+          page?: {
+            __typename?: 'Page'
+            documentId: string
+            slug?: string | null
+            title: string
+            locale?: string | null
+          } | null
+          article?: {
+            __typename: 'Article'
+            documentId: string
+            slug: string
+            title: string
+            locale?: string | null
+          } | null
+        } | null
       }
     | {
         __typename: 'ComponentSectionsBanner'
@@ -10013,6 +10036,26 @@ export type PageBySlugQuery = {
             } | null
           } | null>
           adminGroups: Array<{ __typename?: 'AdminGroup'; documentId: string } | null>
+          showMoreLink?: {
+            __typename?: 'ComponentBlocksCommonLink'
+            label?: string | null
+            url?: string | null
+            analyticsId?: string | null
+            page?: {
+              __typename?: 'Page'
+              documentId: string
+              slug?: string | null
+              title: string
+              locale?: string | null
+            } | null
+            article?: {
+              __typename: 'Article'
+              documentId: string
+              slug: string
+              title: string
+              locale?: string | null
+            } | null
+          } | null
         }
       | {
           __typename: 'ComponentSectionsBanner'
@@ -10924,6 +10967,26 @@ export type Dev_AllPagesQuery = {
             } | null
           } | null>
           adminGroups: Array<{ __typename?: 'AdminGroup'; documentId: string } | null>
+          showMoreLink?: {
+            __typename?: 'ComponentBlocksCommonLink'
+            label?: string | null
+            url?: string | null
+            analyticsId?: string | null
+            page?: {
+              __typename?: 'Page'
+              documentId: string
+              slug?: string | null
+              title: string
+              locale?: string | null
+            } | null
+            article?: {
+              __typename: 'Article'
+              documentId: string
+              slug: string
+              title: string
+              locale?: string | null
+            } | null
+          } | null
         }
       | {
           __typename: 'ComponentSectionsBanner'
@@ -12252,6 +12315,26 @@ export type ArticlesSectionFragment = {
     } | null
   } | null>
   adminGroups: Array<{ __typename?: 'AdminGroup'; documentId: string } | null>
+  showMoreLink?: {
+    __typename?: 'ComponentBlocksCommonLink'
+    label?: string | null
+    url?: string | null
+    analyticsId?: string | null
+    page?: {
+      __typename?: 'Page'
+      documentId: string
+      slug?: string | null
+      title: string
+      locale?: string | null
+    } | null
+    article?: {
+      __typename: 'Article'
+      documentId: string
+      slug: string
+      title: string
+      locale?: string | null
+    } | null
+  } | null
 }
 
 export type InbaArticlesListSectionFragment = {
@@ -13213,6 +13296,26 @@ type Sections_ComponentSectionsArticles_Fragment = {
     } | null
   } | null>
   adminGroups: Array<{ __typename?: 'AdminGroup'; documentId: string } | null>
+  showMoreLink?: {
+    __typename?: 'ComponentBlocksCommonLink'
+    label?: string | null
+    url?: string | null
+    analyticsId?: string | null
+    page?: {
+      __typename?: 'Page'
+      documentId: string
+      slug?: string | null
+      title: string
+      locale?: string | null
+    } | null
+    article?: {
+      __typename: 'Article'
+      documentId: string
+      slug: string
+      title: string
+      locale?: string | null
+    } | null
+  } | null
 }
 
 type Sections_ComponentSectionsBanner_Fragment = {
@@ -14900,10 +15003,14 @@ export const ArticlesSectionFragmentDoc = gql`
     adminGroups {
       ...AdminGroupEntity
     }
+    showMoreLink {
+      ...CommonLink
+    }
   }
   ${PageCategoryEntityFragmentDoc}
   ${TagEntityFragmentDoc}
   ${AdminGroupEntityFragmentDoc}
+  ${CommonLinkFragmentDoc}
 `
 export const InbaArticlesListSectionFragmentDoc = gql`
   fragment InbaArticlesListSection on ComponentSectionsInbaArticlesList {

--- a/next/src/services/graphql/queries/AdminGroups.graphql
+++ b/next/src/services/graphql/queries/AdminGroups.graphql
@@ -1,0 +1,3 @@
+fragment AdminGroupEntity on AdminGroup {
+  documentId
+}

--- a/next/src/services/graphql/queries/Sections.graphql
+++ b/next/src/services/graphql/queries/Sections.graphql
@@ -27,6 +27,9 @@ fragment ArticlesSection on ComponentSectionsArticles {
   adminGroups {
     ...AdminGroupEntity
   }
+  showMoreLink {
+    ...CommonLink
+  }
 }
 
 fragment InbaArticlesListSection on ComponentSectionsInbaArticlesList {

--- a/next/src/services/graphql/queries/Sections.graphql
+++ b/next/src/services/graphql/queries/Sections.graphql
@@ -21,6 +21,12 @@ fragment ArticlesSection on ComponentSectionsArticles {
   category {
     ...PageCategoryEntity
   }
+  tags {
+    ...TagEntity
+  }
+  adminGroups {
+    ...AdminGroupEntity
+  }
 }
 
 fragment InbaArticlesListSection on ComponentSectionsInbaArticlesList {

--- a/next/src/services/meili/fetchers/articlesFetcher.ts
+++ b/next/src/services/meili/fetchers/articlesFetcher.ts
@@ -7,6 +7,7 @@ export type ArticlesFilters = {
   pageSize: number
   page: number
   tagDocumentIds: string[]
+  adminGroupDocumentIds: string[]
 }
 
 export const articlesDefaultFilters: ArticlesFilters = {
@@ -14,6 +15,7 @@ export const articlesDefaultFilters: ArticlesFilters = {
   pageSize: 6,
   page: 1,
   tagDocumentIds: [],
+  adminGroupDocumentIds: [],
 }
 
 export const getArticlesQueryKey = (filters: ArticlesFilters, locale: string) => [
@@ -33,6 +35,9 @@ export const articlesFetcher = (filters: ArticlesFilters, locale: string) => {
         `locale = ${locale}`,
         filters.tagDocumentIds.length > 0
           ? `article.tag.documentId IN [${filters.tagDocumentIds.join(',')}]`
+          : '',
+        filters.adminGroupDocumentIds.length > 0
+          ? `article.adminGroups.documentId IN [${filters.adminGroupDocumentIds.join(',')}]`
           : '',
       ],
       sort: ['article.addedAtTimestamp:desc'],

--- a/strapi/config/plugins.meilisearch.config.ts
+++ b/strapi/config/plugins.meilisearch.config.ts
@@ -41,6 +41,7 @@ const searchIndexSettings = {
     'type',
     'locale',
     'article.tag.documentId',
+    'article.adminGroups.documentId',
     'blog-post.tag.documentId',
     'document.documentCategory.documentId',
     'inba-article.inbaTag.documentId',

--- a/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.articles.json
+++ b/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.articles.json
@@ -106,6 +106,20 @@
           "sortable": false
         }
       },
+      "showMoreLink": {
+        "edit": {
+          "label": "showMoreLink",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "showMoreLink",
+          "searchable": false,
+          "sortable": false
+        }
+      },
       "documentId": {
         "edit": {},
         "list": {
@@ -116,6 +130,12 @@
       }
     },
     "layouts": {
+      "list": [
+        "id",
+        "title",
+        "text",
+        "category"
+      ],
       "edit": [
         [
           {
@@ -152,13 +172,13 @@
             "name": "adminGroups",
             "size": 6
           }
+        ],
+        [
+          {
+            "name": "showMoreLink",
+            "size": 12
+          }
         ]
-      ],
-      "list": [
-        "id",
-        "title",
-        "text",
-        "category"
       ]
     },
     "uid": "sections.articles",

--- a/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.articles.json
+++ b/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.articles.json
@@ -47,6 +47,20 @@
           "sortable": true
         }
       },
+      "showAll": {
+        "edit": {
+          "label": "Zobraziť všetky",
+          "description": "Ak je toto pole TRUE, zobrazia sa všetky články spolu s filtrovaním. Ak je FALSE, zobrazia sa články, ktoré spĺňajú kritériá v poliach nižšie.",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "showAll",
+          "searchable": true,
+          "sortable": true
+        }
+      },
       "category": {
         "edit": {
           "label": "Kategória",
@@ -62,18 +76,34 @@
           "sortable": true
         }
       },
-      "showAll": {
+      "tags": {
         "edit": {
-          "label": "Zobraziť všetky",
-          "description": "Ak je toto pole TRUE, zobrazia sa všetky články spolu s filtrovaním. Ak je FALSE, zobrazia sa články, ktoré spĺňajú kritériá v poliach nižšie.",
+          "label": "Tagy",
+          "description": "",
           "placeholder": "",
           "visible": true,
-          "editable": true
+          "editable": true,
+          "mainField": "title"
         },
         "list": {
-          "label": "showAll",
-          "searchable": true,
-          "sortable": true
+          "label": "tags",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "adminGroups": {
+        "edit": {
+          "label": "Admin skupiny",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "title"
+        },
+        "list": {
+          "label": "adminGroups",
+          "searchable": false,
+          "sortable": false
         }
       },
       "documentId": {
@@ -103,9 +133,23 @@
           {
             "name": "showAll",
             "size": 12
-          },
-          {
+          }
+        ],
+        [
+                    {
             "name": "category",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "tags",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "adminGroups",
             "size": 6
           }
         ]

--- a/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.articles.json
+++ b/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.articles.json
@@ -63,7 +63,7 @@
       },
       "category": {
         "edit": {
-          "label": "Kategória",
+          "label": "Kategória (toto pole prosíme napoužívať, bude odstránené)",
           "description": "",
           "placeholder": "",
           "visible": true,
@@ -136,7 +136,7 @@
           }
         ],
         [
-                    {
+          {
             "name": "category",
             "size": 6
           }

--- a/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.articles.json
+++ b/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.articles.json
@@ -65,7 +65,7 @@
       "showAll": {
         "edit": {
           "label": "Zobraziť všetky",
-          "description": "Ak je toto pole TRUE, zobrazia sa všetky články spolu s filtrovaním. Ak je FALSE, zobrazia sa články podľa vybranej Kategórie vo vedľajšom poli.",
+          "description": "Ak je toto pole TRUE, zobrazia sa všetky články spolu s filtrovaním. Ak je FALSE, zobrazia sa články, ktoré spĺňajú kritériá v poliach nižšie.",
           "placeholder": "",
           "visible": true,
           "editable": true
@@ -86,12 +86,6 @@
       }
     },
     "layouts": {
-      "list": [
-        "id",
-        "title",
-        "text",
-        "category"
-      ],
       "edit": [
         [
           {
@@ -107,14 +101,20 @@
         ],
         [
           {
-            "name": "category",
-            "size": 6
+            "name": "showAll",
+            "size": 12
           },
           {
-            "name": "showAll",
+            "name": "category",
             "size": 6
           }
         ]
+      ],
+      "list": [
+        "id",
+        "title",
+        "text",
+        "category"
       ]
     },
     "uid": "sections.articles",

--- a/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.documents.json
+++ b/strapi/config/sync/core-store.plugin_content_manager_configuration_components##sections.documents.json
@@ -65,7 +65,7 @@
       "showAll": {
         "edit": {
           "label": "Zobraziť všetky",
-          "description": "Ak je toto pole TRUE, zobrazia sa všetky Dokumenty spolu s vyhľadávaním. Ak je FALSE, zobrazia sa Dokumenty vybrané vo vedľajšom poli.",
+          "description": "Ak je toto pole TRUE, zobrazia sa všetky Dokumenty spolu s vyhľadávaním. Ak je FALSE, zobrazia sa Dokumenty vybrané v poli Dokumenty",
           "placeholder": "",
           "visible": true,
           "editable": true
@@ -115,13 +115,13 @@
         ],
         [
           {
-            "name": "documents",
+            "name": "showAll",
             "size": 12
           }
         ],
         [
           {
-            "name": "showAll",
+            "name": "documents",
             "size": 12
           }
         ],

--- a/strapi/config/sync/user-role.public.json
+++ b/strapi/config/sync/user-role.public.json
@@ -6,6 +6,16 @@
   "locale": null,
   "permissions": [
     {
+      "action": "api::admin-group.admin-group.find",
+      "documentId": "sumrxhrfjovjj0yybxiwqh1k",
+      "locale": null
+    },
+    {
+      "action": "api::admin-group.admin-group.findOne",
+      "documentId": "ucjhz1999u7zw42j9m74npgy",
+      "locale": null
+    },
+    {
       "action": "api::alert.alert.find",
       "documentId": "y1trr2dak04brwpoajk29alg",
       "locale": null

--- a/strapi/schema.graphql
+++ b/strapi/schema.graphql
@@ -1056,27 +1056,35 @@ input ComponentSectionsAccordionInput {
 }
 
 type ComponentSectionsArticles {
+  adminGroups(filters: AdminGroupFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): [AdminGroup]!
+  adminGroups_connection(filters: AdminGroupFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): AdminGroupRelationResponseCollection
   category: PageCategory
   id: ID!
   showAll: Boolean
+  tags(filters: TagFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): [Tag]!
+  tags_connection(filters: TagFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): TagRelationResponseCollection
   text: String
   title: String
 }
 
 input ComponentSectionsArticlesFiltersInput {
+  adminGroups: AdminGroupFiltersInput
   and: [ComponentSectionsArticlesFiltersInput]
   category: PageCategoryFiltersInput
   not: ComponentSectionsArticlesFiltersInput
   or: [ComponentSectionsArticlesFiltersInput]
   showAll: BooleanFilterInput
+  tags: TagFiltersInput
   text: StringFilterInput
   title: StringFilterInput
 }
 
 input ComponentSectionsArticlesInput {
+  adminGroups: [ID]
   category: ID
   id: ID
   showAll: Boolean
+  tags: [ID]
   text: String
   title: String
 }

--- a/strapi/schema.graphql
+++ b/strapi/schema.graphql
@@ -1061,6 +1061,7 @@ type ComponentSectionsArticles {
   category: PageCategory
   id: ID!
   showAll: Boolean
+  showMoreLink: ComponentBlocksCommonLink
   tags(filters: TagFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): [Tag]!
   tags_connection(filters: TagFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): TagRelationResponseCollection
   text: String
@@ -1074,6 +1075,7 @@ input ComponentSectionsArticlesFiltersInput {
   not: ComponentSectionsArticlesFiltersInput
   or: [ComponentSectionsArticlesFiltersInput]
   showAll: BooleanFilterInput
+  showMoreLink: ComponentBlocksCommonLinkFiltersInput
   tags: TagFiltersInput
   text: StringFilterInput
   title: StringFilterInput
@@ -1084,6 +1086,7 @@ input ComponentSectionsArticlesInput {
   category: ID
   id: ID
   showAll: Boolean
+  showMoreLink: ComponentBlocksCommonLinkInput
   tags: [ID]
   text: String
   title: String

--- a/strapi/src/components/sections/articles.json
+++ b/strapi/src/components/sections/articles.json
@@ -12,14 +12,24 @@
     "text": {
       "type": "text"
     },
-    "category": {
-      "type": "relation",
-      "relation": "oneToOne",
-      "target": "api::page-category.page-category"
-    },
     "showAll": {
       "type": "boolean",
       "default": false
+    },
+    "category": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::page-category.page-category",
+      "conditions": {
+        "visible": {
+          "!=": [
+            {
+              "var": "showAll"
+            },
+            true
+          ]
+        }
+      }
     }
   }
 }

--- a/strapi/src/components/sections/articles.json
+++ b/strapi/src/components/sections/articles.json
@@ -60,6 +60,21 @@
           ]
         }
       }
+    },
+    "showMoreLink": {
+      "type": "component",
+      "conditions": {
+        "visible": {
+          "!=": [
+            {
+              "var": "showAll"
+            },
+            true
+          ]
+        }
+      },
+      "component": "blocks.common-link",
+      "repeatable": false
     }
   }
 }

--- a/strapi/src/components/sections/articles.json
+++ b/strapi/src/components/sections/articles.json
@@ -30,6 +30,36 @@
           ]
         }
       }
+    },
+    "tags": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::tag.tag",
+      "conditions": {
+        "visible": {
+          "!=": [
+            {
+              "var": "showAll"
+            },
+            true
+          ]
+        }
+      }
+    },
+    "adminGroups": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::admin-group.admin-group",
+      "conditions": {
+        "visible": {
+          "!=": [
+            {
+              "var": "showAll"
+            },
+            true
+          ]
+        }
+      }
     }
   }
 }

--- a/strapi/src/components/sections/documents.json
+++ b/strapi/src/components/sections/documents.json
@@ -13,14 +13,24 @@
     "text": {
       "type": "text"
     },
-    "documents": {
-      "type": "relation",
-      "relation": "oneToMany",
-      "target": "api::document.document"
-    },
     "showAll": {
       "type": "boolean",
       "default": false
+    },
+    "documents": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::document.document",
+      "conditions": {
+        "visible": {
+          "!=": [
+            {
+              "var": "showAll"
+            },
+            true
+          ]
+        }
+      }
     },
     "titleLevel": {
       "type": "enumeration",

--- a/strapi/types/generated/components.d.ts
+++ b/strapi/types/generated/components.d.ts
@@ -476,6 +476,7 @@ export interface SectionsArticles extends Struct.ComponentSchema {
     adminGroups: Schema.Attribute.Relation<'oneToMany', 'api::admin-group.admin-group'>
     category: Schema.Attribute.Relation<'oneToOne', 'api::page-category.page-category'>
     showAll: Schema.Attribute.Boolean & Schema.Attribute.DefaultTo<false>
+    showMoreLink: Schema.Attribute.Component<'blocks.common-link', false>
     tags: Schema.Attribute.Relation<'oneToMany', 'api::tag.tag'>
     text: Schema.Attribute.Text
     title: Schema.Attribute.String

--- a/strapi/types/generated/components.d.ts
+++ b/strapi/types/generated/components.d.ts
@@ -473,8 +473,10 @@ export interface SectionsArticles extends Struct.ComponentSchema {
     displayName: 'Articles'
   }
   attributes: {
+    adminGroups: Schema.Attribute.Relation<'oneToMany', 'api::admin-group.admin-group'>
     category: Schema.Attribute.Relation<'oneToOne', 'api::page-category.page-category'>
     showAll: Schema.Attribute.Boolean & Schema.Attribute.DefaultTo<false>
+    tags: Schema.Attribute.Relation<'oneToMany', 'api::tag.tag'>
     text: Schema.Attribute.Text
     title: Schema.Attribute.String
   }


### PR DESCRIPTION
## In this PR

- ArticlesSection
  - [x] add variant ArticlesByAdminGroup (ensure that when both adminGroup and tag is selected, we filter by both in the sense of AND)
  - [x] in [STaRZ landing page](https://www.figma.com/design/me3iRwjWTZjoJwSf14a8sP/STaRZ?node-id=4078-8983&m=dev), we use ArticlesByTags - ensure that this is possible with the correct design
  - [x] use conditional fields
- HomepageTags
  - [x] disable showing STaRZ admingroup articles (in future we want to enable only OKM admingroup articles)
- Documents (low priority)
  - [x] conditional fields

## Notes

- best reviewed commit by commit
- In ArticlesSection, showMoreLink can be added when filtering by tags or adminGroups. If we want to point this link to the main Aktuality page, then it needs to be filled in by super admin, because starz admin would not see that relation (due to admingroups role based access). An alternative would be to hardcode the link to Aktuality page.
- deviations from Figma
  - ArticlesSection background set to white
  - Carousel controls variant set to bottom