### PR TITLE
#1788 Fix iframe map size and title translation

### DIFF
--- a/next/public/locales/en/translation.json
+++ b/next/public/locales/en/translation.json
@@ -21,6 +21,7 @@
   "ContactCtaCard.bankConnection": "Bank connection",
   "ContactCtaCard.billingInfo": "Billing information",
   "ContactCtaCard.directions": "How to get there",
+  "ContactCtaCard.directions.iframeTitle": "Map",
   "ContactCtaCard.email": "Email",
   "ContactCtaCard.openingHours": "Office hours",
   "ContactCtaCard.phone": "Phone",

--- a/next/public/locales/sk/translation.json
+++ b/next/public/locales/sk/translation.json
@@ -21,6 +21,7 @@
   "ContactCtaCard.bankConnection": "Bankové spojenie",
   "ContactCtaCard.billingInfo": "Fakturačné údaje",
   "ContactCtaCard.directions": "Ako sa k nám dostať",
+  "ContactCtaCard.directions.iframeTitle": "Mapa",
   "ContactCtaCard.email": "Email",
   "ContactCtaCard.openingHours": "Úradné hodiny",
   "ContactCtaCard.phone": "Telefón",

--- a/next/src/components/cards/ContactCtaCard.tsx
+++ b/next/src/components/cards/ContactCtaCard.tsx
@@ -160,7 +160,7 @@ const ContactCtaCard = ({ className, contact }: ContactCtaCardProps) => {
             {contact.iframeUrl ? (
               <div className="aspect-video">
                 <iframe
-                  title="Mapa"
+                  title={t('ContactCtaCard.directions.iframeTitle')}
                   src={contact.iframeUrl}
                   className="h-full w-full border"
                   allow="geolocation *"
@@ -178,7 +178,7 @@ const ContactCtaCard = ({ className, contact }: ContactCtaCardProps) => {
     }
 
     return null
-  }, [contact])
+  }, [contact, t])
 
   if (!data) {
     return null
@@ -191,7 +191,7 @@ const ContactCtaCard = ({ className, contact }: ContactCtaCardProps) => {
       <div className="flex shrink-0 items-center justify-center rounded-full text-gray-700">
         <Icon className="size-6 lg:size-8" />
       </div>
-      <div className="flex flex-col gap-1 overflow-hidden wrap-break-word">
+      <div className="flex w-full flex-col gap-1 overflow-hidden wrap-break-word">
         <Typography variant="h6" as="p" className="font-semibold">
           {label}
         </Typography>


### PR DESCRIPTION
Use short urls in form of `https://maps.app.goo.gl/...` from "Share modal":
<img width="1000" height="385" alt="image" src="https://github.com/user-attachments/assets/2288e31a-ba34-4e8a-8ce8-e7daf60eddfd" />


This is the desired width of map. All individual contacts have limited width to this size.

<img width="1200" height="540" alt="image" src="https://github.com/user-attachments/assets/a7eca501-1872-43eb-8205-44e70e68cae2" />


<img width="774" height="648" alt="image" src="https://github.com/user-attachments/assets/8e879ca9-e5dc-4262-a3d2-83d9bb3bb127" />
