### PR TITLE
#1827 Implement localised starz submenu

### DIFF
--- a/next/src/components/common/Submenu/StarzSubmenu.tsx
+++ b/next/src/components/common/Submenu/StarzSubmenu.tsx
@@ -7,6 +7,7 @@ import SectionContainer from '@/src/components/layouts/SectionContainer'
 import { AdminGroupEntityFragment } from '@/src/services/graphql'
 import { getLinkProps } from '@/src/utils/getLinkProps'
 import { isDefined } from '@/src/utils/isDefined'
+import { useLocale } from '@/src/utils/useLocale'
 
 type Props = {
   landingPage: NonNullable<AdminGroupEntityFragment['landingPage']>
@@ -20,9 +21,17 @@ type Props = {
  * TODO make it more generic in future when more organizations need it
  */
 const StarzSubmenu = ({ landingPage }: Props) => {
-  const childPages = landingPage.childPages.filter(isDefined) ?? []
+  const locale = useLocale()
 
-  const { children: ariaLabel, ...linkProps } = getLinkProps({ page: landingPage })
+  // Strapi returns only other locales in localizations prop
+  const localisedLandingPage =
+    landingPage.locale === locale
+      ? landingPage
+      : landingPage.localizations.find((page) => page?.locale === locale)
+
+  const childPages = localisedLandingPage?.childPages.filter(isDefined) ?? []
+
+  const { children: ariaLabel, ...linkProps } = getLinkProps({ page: localisedLandingPage })
 
   // Beware of paddings, margins and gaps - they are used to enlarge clickable/touchable area of links, and they are carefully set to fit Figma design together
   return (

--- a/next/src/services/graphql/index.ts
+++ b/next/src/services/graphql/index.ts
@@ -1006,19 +1006,19 @@ export type ComponentBlocksNumericalListItemInput = {
 export type ComponentBlocksOpeningHoursAlertMessage = {
   __typename?: 'ComponentBlocksOpeningHoursAlertMessage'
   id: Scalars['ID']['output']
-  text?: Maybe<Scalars['JSON']['output']>
+  text?: Maybe<Scalars['String']['output']>
 }
 
 export type ComponentBlocksOpeningHoursAlertMessageFiltersInput = {
   and?: InputMaybe<Array<InputMaybe<ComponentBlocksOpeningHoursAlertMessageFiltersInput>>>
   not?: InputMaybe<ComponentBlocksOpeningHoursAlertMessageFiltersInput>
   or?: InputMaybe<Array<InputMaybe<ComponentBlocksOpeningHoursAlertMessageFiltersInput>>>
-  text?: InputMaybe<JsonFilterInput>
+  text?: InputMaybe<StringFilterInput>
 }
 
 export type ComponentBlocksOpeningHoursAlertMessageInput = {
   id?: InputMaybe<Scalars['ID']['input']>
-  text?: InputMaybe<Scalars['JSON']['input']>
+  text?: InputMaybe<Scalars['String']['input']>
 }
 
 export type ComponentBlocksOpeningHoursItem = {
@@ -6479,6 +6479,21 @@ export type UsersPermissionsUserRelationResponseCollection = {
 
 export type AdminGroupDocumentIdEntityFragment = { __typename?: 'AdminGroup'; documentId: string }
 
+export type PageSubnavigationEntityFragment = {
+  __typename?: 'Page'
+  documentId: string
+  slug?: string | null
+  title: string
+  locale?: string | null
+  childPages: Array<{
+    __typename?: 'Page'
+    documentId: string
+    slug?: string | null
+    title: string
+    locale?: string | null
+  } | null>
+}
+
 export type AdminGroupEntityFragment = {
   __typename?: 'AdminGroup'
   adminGroupId?: string | null
@@ -6490,6 +6505,20 @@ export type AdminGroupEntityFragment = {
     slug?: string | null
     title: string
     locale?: string | null
+    localizations: Array<{
+      __typename?: 'Page'
+      documentId: string
+      slug?: string | null
+      title: string
+      locale?: string | null
+      childPages: Array<{
+        __typename?: 'Page'
+        documentId: string
+        slug?: string | null
+        title: string
+        locale?: string | null
+      } | null>
+    } | null>
     childPages: Array<{
       __typename?: 'Page'
       documentId: string
@@ -9382,6 +9411,20 @@ export type PageEntityFragment = {
       slug?: string | null
       title: string
       locale?: string | null
+      localizations: Array<{
+        __typename?: 'Page'
+        documentId: string
+        slug?: string | null
+        title: string
+        locale?: string | null
+        childPages: Array<{
+          __typename?: 'Page'
+          documentId: string
+          slug?: string | null
+          title: string
+          locale?: string | null
+        } | null>
+      } | null>
       childPages: Array<{
         __typename?: 'Page'
         documentId: string
@@ -10085,7 +10128,7 @@ export type PageEntityFragment = {
         } | null> | null
         alertMessage?: {
           __typename?: 'ComponentBlocksOpeningHoursAlertMessage'
-          text?: any | null
+          text?: string | null
         } | null
       }
     | { __typename: 'ComponentSectionsOrganizationalStructure'; title?: string | null }
@@ -10526,6 +10569,20 @@ export type PageBySlugQuery = {
         slug?: string | null
         title: string
         locale?: string | null
+        localizations: Array<{
+          __typename?: 'Page'
+          documentId: string
+          slug?: string | null
+          title: string
+          locale?: string | null
+          childPages: Array<{
+            __typename?: 'Page'
+            documentId: string
+            slug?: string | null
+            title: string
+            locale?: string | null
+          } | null>
+        } | null>
         childPages: Array<{
           __typename?: 'Page'
           documentId: string
@@ -11232,7 +11289,7 @@ export type PageBySlugQuery = {
           } | null> | null
           alertMessage?: {
             __typename?: 'ComponentBlocksOpeningHoursAlertMessage'
-            text?: any | null
+            text?: string | null
           } | null
         }
       | { __typename: 'ComponentSectionsOrganizationalStructure'; title?: string | null }
@@ -11699,6 +11756,20 @@ export type Dev_AllPagesQuery = {
         slug?: string | null
         title: string
         locale?: string | null
+        localizations: Array<{
+          __typename?: 'Page'
+          documentId: string
+          slug?: string | null
+          title: string
+          locale?: string | null
+          childPages: Array<{
+            __typename?: 'Page'
+            documentId: string
+            slug?: string | null
+            title: string
+            locale?: string | null
+          } | null>
+        } | null>
         childPages: Array<{
           __typename?: 'Page'
           documentId: string
@@ -12405,7 +12476,7 @@ export type Dev_AllPagesQuery = {
           } | null> | null
           alertMessage?: {
             __typename?: 'ComponentBlocksOpeningHoursAlertMessage'
-            text?: any | null
+            text?: string | null
           } | null
         }
       | { __typename: 'ComponentSectionsOrganizationalStructure'; title?: string | null }
@@ -14568,7 +14639,7 @@ export type OpeningHoursSectionFragment = {
   } | null> | null
   alertMessage?: {
     __typename?: 'ComponentBlocksOpeningHoursAlertMessage'
-    text?: any | null
+    text?: string | null
   } | null
 }
 
@@ -15213,7 +15284,7 @@ type Sections_ComponentSectionsOpeningHours_Fragment = {
   } | null> | null
   alertMessage?: {
     __typename?: 'ComponentBlocksOpeningHoursAlertMessage'
-    text?: any | null
+    text?: string | null
   } | null
 }
 
@@ -16265,20 +16336,29 @@ export const AdminGroupDocumentIdEntityFragmentDoc = gql`
     documentId
   }
 `
+export const PageSubnavigationEntityFragmentDoc = gql`
+  fragment PageSubnavigationEntity on Page {
+    ...PageSlugEntity
+    childPages {
+      ...PageSlugEntity
+    }
+  }
+  ${PageSlugEntityFragmentDoc}
+`
 export const AdminGroupEntityFragmentDoc = gql`
   fragment AdminGroupEntity on AdminGroup {
     ...AdminGroupDocumentIdEntity
     adminGroupId
     contentManagedBy
     landingPage {
-      ...PageSlugEntity
-      childPages {
-        ...PageSlugEntity
+      ...PageSubnavigationEntity
+      localizations {
+        ...PageSubnavigationEntity
       }
     }
   }
   ${AdminGroupDocumentIdEntityFragmentDoc}
-  ${PageSlugEntityFragmentDoc}
+  ${PageSubnavigationEntityFragmentDoc}
 `
 export const PageLinkFragmentDoc = gql`
   fragment PageLink on ComponentBlocksPageLink {

--- a/next/src/services/graphql/queries/AdminGroups.graphql
+++ b/next/src/services/graphql/queries/AdminGroups.graphql
@@ -2,14 +2,21 @@ fragment AdminGroupDocumentIdEntity on AdminGroup {
   documentId
 }
 
+fragment PageSubnavigationEntity on Page {
+  ...PageSlugEntity
+  childPages {
+    ...PageSlugEntity
+  }
+}
+
 fragment AdminGroupEntity on AdminGroup {
   ...AdminGroupDocumentIdEntity
   adminGroupId
   contentManagedBy
   landingPage {
-    ...PageSlugEntity
-    childPages {
-      ...PageSlugEntity
+    ...PageSubnavigationEntity
+    localizations {
+      ...PageSubnavigationEntity
     }
   }
 }


### PR DESCRIPTION
(child pages titles are long, but that's not the concern of this PR)

Testing:
In Strapi, in Starz Agmin Group, select a landing page ("Šport" or other)
Open some starz page in SK on FE, you should see SK submenu.
The switch to EN version on FE and you should see EN submenu.

<img width="1376" height="400" alt="image" src="https://github.com/user-attachments/assets/7c0dc718-4f2d-478f-96f9-df6dc7d1fab8" />

<img width="1342" height="324" alt="image" src="https://github.com/user-attachments/assets/b819b093-54f2-40eb-915e-b57abad650a8" />


Notes:

There are some unrelated changes in generated file, I noticed some change in Alert from JSON to String type.
It seems that it war incorrect before.

<img width="1557" height="612" alt="image" src="https://github.com/user-attachments/assets/e220c271-7d03-45e9-b9d7-344652d0480a" />
