### PR TITLE
#1841 Redesign Links section

### DIFF
--- a/next/public/locales/en/translation.json
+++ b/next/public/locales/en/translation.json
@@ -68,6 +68,7 @@
   "InbaRelease.releaseDetail": "Issue detail",
   "InbaRelease.releasedOn": "Published on {{date}}",
   "InbaRelease.toDownload": "Downloads",
+  "LinkRowCard.goToWeb": "Go to website",
   "links.searchLink": "/search",
   "MinimumCalculator.adultsText": "Number of adults in your household",
   "MinimumCalculator.answerDescriptionNo": "To meet the subsistence level, you need to achieve an income of at least XY €. Therefore, you are not entitled to apply for temporary accommodation in our hostel.",

--- a/next/public/locales/sk/translation.json
+++ b/next/public/locales/sk/translation.json
@@ -72,6 +72,7 @@
   "InbaRelease.releaseDetail": "Detail čísla",
   "InbaRelease.releasedOn": "Publikované {{date}}",
   "InbaRelease.toDownload": "Na stiahnutie",
+  "LinkRowCard.goToWeb": "Prejsť na stránku",
   "links.searchLink": "/vyhladavanie",
   "MinimumCalculator.adultsText": "Počet dospelých vo Vašej domácnosti",
   "MinimumCalculator.answerDescriptionNo": "Na splnenie životného minima potrebujete dosiahnuť výšku príjmov aspoň XY €. Preto nemáte nárok uchádzať sa o prechodné ubytovanie v našej ubytovni.",

--- a/next/scripts/dev/listPages.ts
+++ b/next/scripts/dev/listPages.ts
@@ -24,12 +24,10 @@ export const listPages = async () => {
     // .filter((page) => !page.slug?.includes('/'))
     .filter((page) => {
       const sections =
-        page.sections?.filter((section) => section?.__typename === 'ComponentSectionsNarrowText') ??
-        []
+        page.sections?.filter((section) => section?.__typename === 'ComponentSectionsLinks') ?? []
 
       return sections.some(
-        (section) =>
-          section?.__typename === 'ComponentSectionsNarrowText' && section.content?.includes('<'),
+        (section) => section?.__typename === 'ComponentSectionsLinks',
         // section.width === 'wide',
       )
     })

--- a/next/src/components/cards/DocumentRowCard.tsx
+++ b/next/src/components/cards/DocumentRowCard.tsx
@@ -7,6 +7,7 @@ import { FolderIcon } from '@/src/assets/material-icons'
 import CardBase from '@/src/components/cards/CardBase'
 import { CardTitleLevel } from '@/src/components/cards/getCardTitleLevel'
 import Button from '@/src/components/common/Button/Button'
+import cn from '@/src/utils/cn'
 
 export type DocumentRowCardProps = {
   variant: 'single-file' | 'multiple-files'
@@ -36,65 +37,63 @@ const DocumentRowCard = ({
   const { t } = useTranslation()
 
   return (
-    <CardBase variant="no-border" className={className}>
-      <div className="bg-background-passive-base" title={title}>
-        <div className="flex items-center gap-3 py-4 lg:gap-4">
-          <div className="flex grow items-start gap-3 lg:gap-4">
-            <div className="lg:rounded-lg lg:bg-background-passive-secondary lg:p-3 lg:text-content-passive-secondary">
-              {variant === 'single-file' ? (
-                <AttachmentIcon className="size-5 md:size-6" />
-              ) : (
-                <FolderIcon className="size-5 md:size-6" />
-              )}
-            </div>
-            <div className="flex grow flex-col gap-1">
-              <Typography variant="h6" as={cardTitleLevel} className="group-hover:underline">
-                {title}
-              </Typography>
-              {metadata?.length ? (
-                <div className="flex flex-wrap items-center gap-x-3">
-                  {metadata.map((item, index) => (
-                    // eslint-disable-next-line react/no-array-index-key
-                    <Fragment key={index}>
-                      {index > 0 ? (
-                        <div
-                          className="size-1 rounded-full bg-content-passive-secondary"
-                          aria-hidden
-                        />
-                      ) : null}
-                      <Typography variant="p-small">{item}</Typography>
-                    </Fragment>
-                  ))}
-                </div>
-              ) : null}
-            </div>
+    <CardBase variant="no-border" className={cn('bg-background-passive-base', className)}>
+      <div className="flex items-center gap-3 py-4 lg:gap-4">
+        <div className="flex grow items-start gap-3 lg:gap-4">
+          <div className="lg:rounded-lg lg:bg-background-passive-secondary lg:p-3 lg:text-content-passive-secondary">
+            {variant === 'single-file' ? (
+              <AttachmentIcon className="size-5 md:size-6" />
+            ) : (
+              <FolderIcon className="size-5 md:size-6" />
+            )}
           </div>
-          {/* Screen: desktop */}
-          <Button
-            variant="outline"
-            href={linkHref}
-            stretched
-            hasLinkIcon={false}
-            // eslint-disable-next-line sonarjs/no-duplicate-string
-            startIcon={variant === 'single-file' ? <DownloadIcon /> : undefined}
-            // eslint-disable-next-line sonarjs/no-duplicate-string
-            aria-label={ariaLabel ?? `${t('common.showMore')}: ${title}`}
-            endIcon={variant === 'multiple-files' ? <ArrowRightIcon /> : undefined}
-            className="whitespace-nowrap max-lg:hidden"
-          >
-            {variant === 'single-file' ? t('common.download') : t('common.show')}
-          </Button>
-          {/* Screen: mobile */}
-          <Button
-            variant="unstyled"
-            href={linkHref}
-            aria-label={ariaLabel ?? `${t('common.showMore')}: ${title}`}
-            stretched
-            hasLinkIcon={false}
-            icon={variant === 'single-file' ? <DownloadIcon /> : <ArrowRightIcon />}
-            className="ml-auto p-1.5 lg:hidden"
-          />
+          <div className="flex grow flex-col gap-1">
+            <Typography variant="h6" as={cardTitleLevel} className="group-hover:underline">
+              {title}
+            </Typography>
+            {metadata?.length ? (
+              <div className="flex flex-wrap items-center gap-x-3">
+                {metadata.map((item, index) => (
+                  // eslint-disable-next-line react/no-array-index-key
+                  <Fragment key={index}>
+                    {index > 0 ? (
+                      <div
+                        className="size-1 rounded-full bg-content-passive-secondary"
+                        aria-hidden
+                      />
+                    ) : null}
+                    <Typography variant="p-small">{item}</Typography>
+                  </Fragment>
+                ))}
+              </div>
+            ) : null}
+          </div>
         </div>
+        {/* Screen: desktop */}
+        <Button
+          variant="outline"
+          href={linkHref}
+          stretched
+          hasLinkIcon={false}
+          // eslint-disable-next-line sonarjs/no-duplicate-string
+          startIcon={variant === 'single-file' ? <DownloadIcon /> : undefined}
+          // eslint-disable-next-line sonarjs/no-duplicate-string
+          aria-label={ariaLabel ?? `${t('common.showMore')}: ${title}`}
+          endIcon={variant === 'multiple-files' ? <ArrowRightIcon /> : undefined}
+          className="whitespace-nowrap max-lg:hidden"
+        >
+          {variant === 'single-file' ? t('common.download') : t('common.show')}
+        </Button>
+        {/* Screen: mobile */}
+        <Button
+          variant="unstyled"
+          href={linkHref}
+          aria-label={ariaLabel ?? `${t('common.showMore')}: ${title}`}
+          stretched
+          hasLinkIcon={false}
+          icon={variant === 'single-file' ? <DownloadIcon /> : <ArrowRightIcon />}
+          className="ml-auto p-1.5 lg:hidden"
+        />
       </div>
     </CardBase>
   )

--- a/next/src/components/cards/LinkRowCard.tsx
+++ b/next/src/components/cards/LinkRowCard.tsx
@@ -1,0 +1,95 @@
+import { Typography } from '@bratislava/component-library'
+import { useTranslation } from 'next-i18next'
+import React, { Fragment, useId } from 'react'
+
+import { LanguageIcon } from '@/src/assets/material-icons'
+import CardBase from '@/src/components/cards/CardBase'
+import { CardTitleLevel } from '@/src/components/cards/getCardTitleLevel'
+import Button from '@/src/components/common/Button/Button'
+
+export type LinkRowCardProps = {
+  title: string
+  cardTitleLevel?: CardTitleLevel
+  linkHref: string
+  metadata?: string[]
+  className?: string
+}
+
+/**
+ * TODO Figma link
+ */
+
+const LinkRowCard = ({
+  title,
+  cardTitleLevel = 'h3',
+  linkHref,
+  metadata,
+  className,
+}: LinkRowCardProps) => {
+  const { t } = useTranslation()
+
+  const titleId = useId()
+
+  return (
+    <CardBase variant="no-border" className={className}>
+      <div className="bg-background-passive-base">
+        <div className="flex items-center gap-3 py-4 lg:gap-4">
+          <div className="flex grow items-center gap-3 lg:gap-4">
+            <div className="lg:rounded-lg lg:bg-background-passive-secondary lg:p-3 lg:text-content-passive-secondary">
+              <LanguageIcon className="size-5 shrink-0 md:size-6" />
+            </div>
+            <div className="flex grow flex-col gap-1">
+              <Typography
+                id={titleId}
+                variant="h6"
+                as={cardTitleLevel}
+                className="group-hover:underline"
+              >
+                {title}
+              </Typography>
+              {metadata?.length ? (
+                <div className="flex flex-wrap items-center gap-x-3 text-content-passive-secondary">
+                  {metadata.map((item, index) => (
+                    // eslint-disable-next-line react/no-array-index-key
+                    <Fragment key={index}>
+                      {index > 0 ? (
+                        <div
+                          className="size-1 rounded-full bg-content-passive-secondary"
+                          aria-hidden
+                        />
+                      ) : null}
+                      {/* Using break-all because we pass very long urls to metadata */}
+                      <Typography variant="p-small" className="break-all">
+                        {item}
+                      </Typography>
+                    </Fragment>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          </div>
+          {/* Screen: desktop */}
+          <Button
+            variant="outline"
+            href={linkHref}
+            aria-labelledby={titleId}
+            stretched
+            className="whitespace-nowrap max-lg:hidden"
+          >
+            {t('LinkRowCard.goToWeb')}
+          </Button>
+          {/* Screen: mobile */}
+          <Button
+            variant="unstyled"
+            href={linkHref}
+            aria-labelledby={titleId}
+            stretched
+            className="ml-auto p-1.5 lg:hidden"
+          />
+        </div>
+      </div>
+    </CardBase>
+  )
+}
+
+export default LinkRowCard

--- a/next/src/components/cards/LinkRowCard.tsx
+++ b/next/src/components/cards/LinkRowCard.tsx
@@ -6,6 +6,7 @@ import { LanguageIcon } from '@/src/assets/material-icons'
 import CardBase from '@/src/components/cards/CardBase'
 import { CardTitleLevel } from '@/src/components/cards/getCardTitleLevel'
 import Button from '@/src/components/common/Button/Button'
+import cn from '@/src/utils/cn'
 
 export type LinkRowCardProps = {
   title: string
@@ -31,62 +32,60 @@ const LinkRowCard = ({
   const titleId = useId()
 
   return (
-    <CardBase variant="no-border" className={className}>
-      <div className="bg-background-passive-base">
-        <div className="flex items-center gap-3 py-4 lg:gap-4">
-          <div className="flex grow items-center gap-3 lg:gap-4">
-            <div className="lg:rounded-lg lg:bg-background-passive-secondary lg:p-3 lg:text-content-passive-secondary">
-              <LanguageIcon className="size-5 shrink-0 md:size-6" />
-            </div>
-            <div className="flex grow flex-col gap-1">
-              <Typography
-                id={titleId}
-                variant="h6"
-                as={cardTitleLevel}
-                className="group-hover:underline"
-              >
-                {title}
-              </Typography>
-              {metadata?.length ? (
-                <div className="flex flex-wrap items-center gap-x-3 text-content-passive-secondary">
-                  {metadata.map((item, index) => (
-                    // eslint-disable-next-line react/no-array-index-key
-                    <Fragment key={index}>
-                      {index > 0 ? (
-                        <div
-                          className="size-1 rounded-full bg-content-passive-secondary"
-                          aria-hidden
-                        />
-                      ) : null}
-                      {/* Using break-all because we pass very long urls to metadata */}
-                      <Typography variant="p-small" className="break-all">
-                        {item}
-                      </Typography>
-                    </Fragment>
-                  ))}
-                </div>
-              ) : null}
-            </div>
+    <CardBase variant="no-border" className={cn('bg-background-passive-base', className)}>
+      <div className="flex items-center gap-3 py-4 lg:gap-4">
+        <div className="flex grow items-center gap-3 lg:gap-4">
+          <div className="lg:rounded-lg lg:bg-background-passive-secondary lg:p-3 lg:text-content-passive-secondary">
+            <LanguageIcon className="size-5 shrink-0 md:size-6" />
           </div>
-          {/* Screen: desktop */}
-          <Button
-            variant="outline"
-            href={linkHref}
-            aria-labelledby={titleId}
-            stretched
-            className="whitespace-nowrap max-lg:hidden"
-          >
-            {t('LinkRowCard.goToWeb')}
-          </Button>
-          {/* Screen: mobile */}
-          <Button
-            variant="unstyled"
-            href={linkHref}
-            aria-labelledby={titleId}
-            stretched
-            className="ml-auto p-1.5 lg:hidden"
-          />
+          <div className="flex grow flex-col gap-1">
+            <Typography
+              id={titleId}
+              variant="h6"
+              as={cardTitleLevel}
+              className="group-hover:underline"
+            >
+              {title}
+            </Typography>
+            {metadata?.length ? (
+              <div className="flex flex-wrap items-center gap-x-3 text-content-passive-secondary">
+                {metadata.map((item, index) => (
+                  // eslint-disable-next-line react/no-array-index-key
+                  <Fragment key={index}>
+                    {index > 0 ? (
+                      <div
+                        className="size-1 rounded-full bg-content-passive-secondary"
+                        aria-hidden
+                      />
+                    ) : null}
+                    {/* Using break-all because we pass very long urls to metadata */}
+                    <Typography variant="p-small" className="break-all">
+                      {item}
+                    </Typography>
+                  </Fragment>
+                ))}
+              </div>
+            ) : null}
+          </div>
         </div>
+        {/* Screen: desktop */}
+        <Button
+          variant="outline"
+          href={linkHref}
+          aria-labelledby={titleId}
+          stretched
+          className="whitespace-nowrap max-lg:hidden"
+        >
+          {t('LinkRowCard.goToWeb')}
+        </Button>
+        {/* Screen: mobile */}
+        <Button
+          variant="unstyled"
+          href={linkHref}
+          aria-labelledby={titleId}
+          stretched
+          className="ml-auto p-1.5 lg:hidden"
+        />
       </div>
     </CardBase>
   )

--- a/next/src/components/common/Button/Button.tsx
+++ b/next/src/components/common/Button/Button.tsx
@@ -221,7 +221,7 @@ const Button = forwardRef<HTMLAnchorElement | HTMLButtonElement, PolymorphicProp
 
     if (rest.href) {
       const isExternal = rest.href.startsWith('http')
-      const isAnchor = rest.href.startsWith('#')
+      const isAnchor = rest.href.startsWith('#') && rest.href !== '#'
       const linkIcon = hasLinkIcon ? (
         isExternal ? (
           <ExportIcon className="shrink-0" />

--- a/next/src/components/common/Links/Links.tsx
+++ b/next/src/components/common/Links/Links.tsx
@@ -1,8 +1,8 @@
-import React from 'react'
-import { ArrowRightIcon } from 'src/assets/icons'
+import React, { Fragment } from 'react'
 
 import { SectionTitleLevel } from '@/src/components/cards/getCardTitleLevel'
-import Button from '@/src/components/common/Button/Button'
+import LinkRowCard from '@/src/components/cards/LinkRowCard'
+import HorizontalDivider from '@/src/components/common/Divider/HorizontalDivider'
 import SectionHeader from '@/src/components/layouts/SectionHeader'
 import { LinksSectionFragment } from '@/src/services/graphql'
 import cn from '@/src/utils/cn'
@@ -22,21 +22,28 @@ export type LinksProps = {
 
 const Links = ({ title, titleLevel, pageLinks, className }: LinksProps) => {
   return (
-    <div className={cn('flex w-full flex-col gap-6 md:w-10/12', className)}>
+    <div className={cn('flex w-full flex-col gap-6', className)}>
       <SectionHeader title={title} titleLevel={titleLevel} />
 
-      <ul className="flex flex-col gap-4">
-        {pageLinks?.filter(isDefined).map((pageLink, index) => (
-          // eslint-disable-next-line react/no-array-index-key
-          <li key={index}>
-            <Button
-              variant="link"
-              startIcon={<ArrowRightIcon className="shrink-0" />}
-              {...getLinkProps(pageLink)}
-              hasLinkIcon={getLinkProps(pageLink).target === '_blank'} // show link icon only for external urls since we already use arrow icon in startIcon
-            />
-          </li>
-        ))}
+      <ul className="flex flex-col rounded-lg border py-2">
+        {pageLinks?.filter(isDefined).map((pageLink, index) => {
+          const { children: linkTitle, href } = getLinkProps(pageLink)
+
+          return (
+            // eslint-disable-next-line react/no-array-index-key
+            <Fragment key={index}>
+              {index > 0 ? <HorizontalDivider asListItem className="mx-4 lg:mx-6" /> : null}
+              <li className="w-full">
+                <LinkRowCard
+                  title={linkTitle}
+                  linkHref={href}
+                  metadata={[href]}
+                  className="px-4 lg:px-6"
+                />
+              </li>
+            </Fragment>
+          )
+        })}
       </ul>
     </div>
   )


### PR DESCRIPTION
The aim was to quickly improve Links section design, without huge effort. Design is taken from ux workshop figma, it's not in DS yet. Implementing only simple internal/external link, not "document link".

- implement LinkRowCard 
- tested with long urls also on mobile - I decided to use `break-all` class on metadata, to prevent overflow, even tho it breaks url anywhere in the middle of words, but it doesn't matter with urls I think

Some urls to test on:

/mesto-bratislava/sprava-mesta/legislativa-mesta/zakony
/mesto-bratislava/sprava-mesta/volene-organy/komunalne-volby
/socialne-sluzby-a-byvanie/socialne-sluzby-a-zariadenia/zariadenia-a-sluzby-pre-seniorov


<img width="1200" height="716" alt="image" src="https://github.com/user-attachments/assets/bf1d096b-cb5f-4b90-8a31-58add859af39" />

<img width="400" height="660" alt="image" src="https://github.com/user-attachments/assets/5bba4916-1d1c-4827-824b-58e5b82a411e" />

<img width="1200" height="585" alt="image" src="https://github.com/user-attachments/assets/57c2160b-afad-4be9-9f22-33b66c0b8d65" />


<img width="400" height="630" alt="image" src="https://github.com/user-attachments/assets/bf8868c5-6984-4ef9-97c4-033e37511273" />
