### PR TITLE
Fix fading text in PageHeader

### DIFF
--- a/next/src/components/common/PageHeader/DocumentPageHeader.tsx
+++ b/next/src/components/common/PageHeader/DocumentPageHeader.tsx
@@ -46,7 +46,7 @@ const DocumentPageHeader = ({ document }: Props) => {
 
   return (
     <div className={cn('relative overflow-x-clip bg-grey-100')}>
-      <div className="mx-auto max-w-(--breakpoint-xl) px-4 lg:px-8">
+      <div className="relative mx-auto max-w-(--breakpoint-xl) px-4 lg:px-8">
         <div className="py-6 lg:py-8">
           <div className="flex flex-col items-start gap-4 lg:gap-6">
             <div className="rounded-2xl bg-background-passive-base p-4">

--- a/next/src/components/common/PageHeader/PageHeader.tsx
+++ b/next/src/components/common/PageHeader/PageHeader.tsx
@@ -37,7 +37,7 @@ const PageHeader = ({
   return (
     <div className={cn('relative overflow-x-clip bg-category-200', className)}>
       {imageSrc && (
-        <div className="absolute top-0 right-0 hidden h-full w-[350px] md:block lg:w-[750px]">
+        <div className="absolute top-0 right-0 hidden h-full w-[350px] md:block lg:w-[500px] xl:w-[750px]">
           <Image
             src={imageSrc}
             alt=""
@@ -47,7 +47,7 @@ const PageHeader = ({
               maskImage:
                 'linear-gradient(to right, rgba(0,0,0,0), rgba(0,0,0,1) 50%, rgba(0,0,0,1))',
             }}
-            sizes={generateImageSizes({ default: '350px', lg: '750px' })}
+            sizes={generateImageSizes({ default: '350px', lg: '500px', xl: '750px' })}
             fill
             className="pointer-events-none size-full object-cover"
           />
@@ -67,7 +67,7 @@ const PageHeader = ({
             )}
 
             {(title || subtext) && (
-              <div className="flex max-w-[800px] flex-col gap-y-1 lg:gap-y-4">
+              <div className="flex max-w-[640px] flex-col gap-y-1 lg:gap-y-4">
                 {title && (
                   <Typography variant="h1" data-cy="page-heading">
                     {title}
@@ -79,7 +79,7 @@ const PageHeader = ({
 
             {headerLinks?.length ? (
               // wrapping to flex-row earlier (md) to prevent too wide buttons on tablet
-              <div className="flex max-w-[800px] flex-col gap-2 md:flex-row lg:gap-3">
+              <div className="flex max-w-[640px] flex-col gap-2 md:flex-row lg:gap-3">
                 {headerLinks.map((button, index) => (
                   <Button
                     // eslint-disable-next-line react/no-array-index-key


### PR DESCRIPTION
The text in PageHeader component might currently not be readable, as it might be partially covered by the overlaid image. This happens on viewports with width approximately between 1060 - 1370px.

This fixes this issue by making following changes:

- make content area more narrow (640px)
- put content in front of image
- make image smaller on lg breakpoint (keeping it the same on xl and above)

# Example

**Before:**

<img width="2216" height="1222" alt="pageheader-before" src="https://github.com/user-attachments/assets/4ccd22ab-c597-409f-b40f-1146a7fabea9" />

**After:**

<img width="2216" height="1222" alt="pageheader-after" src="https://github.com/user-attachments/assets/0ff0fd7f-1e18-449a-845f-bff1a1a2348c" />
