### PR TITLE
#1858 Fix text overflow in PageHeaderEvent date display div

### DIFF
--- a/next/src/components/sections/headers/PageHeaderEvent.tsx
+++ b/next/src/components/sections/headers/PageHeaderEvent.tsx
@@ -40,7 +40,7 @@ const PageHeaderEvent = ({ title, breadcrumbs, headerLinks, image, header }: Pro
     <PageHeader breadcrumbs={breadcrumbs}>
       <div className="flex w-full flex-col overflow-hidden rounded-2xl bg-background-passive-base lg:flex-row">
         <div className="flex flex-col justify-between gap-6 p-4 lg:w-[26rem] lg:gap-40 lg:p-6">
-          <div className="flex flex-col gap-6 lg:gap-8">
+          <div className="flex flex-col items-start gap-6 lg:gap-8">
             {date ? (
               <>
                 {/* Date display - Screen: mobile */}
@@ -49,7 +49,7 @@ const PageHeaderEvent = ({ title, breadcrumbs, headerLinks, image, header }: Pro
                 </div>
                 {/* Date display - Screen: desktop */}
                 <div className="max-lg:hidden">
-                  <div className="flex size-20 flex-col items-center justify-center rounded-lg bg-background-passive-inverted-base text-content-passive-inverted-primary">
+                  <div className="flex h-20 min-w-20 flex-col items-center justify-center rounded-lg bg-background-passive-inverted-base px-2 text-content-passive-inverted-primary">
                     <Typography variant="h3" as="p">
                       {day}
                     </Typography>


### PR DESCRIPTION
## Before
Square shape is forced, long text overflows, everybody is sad.

<img width="1322" height="526" alt="image" src="https://github.com/user-attachments/assets/1951e3b0-b21e-49eb-b3c0-46b587c8270b" />

## After 
Date display div has minimum width set so it keeps square shape when text is short. When text is long, the div reacts and keeps a small padding-x.

<img width="1295" height="595" alt="image" src="https://github.com/user-attachments/assets/058361b9-d4ef-468f-a3b7-c6562b057bf0" />
