### PR TITLE
#1875 Redesign TootootEventCard and add grid variant to TootootEvents…

### DIFF
--- a/next/src/components/cards/TootootEventCard.tsx
+++ b/next/src/components/cards/TootootEventCard.tsx
@@ -1,9 +1,9 @@
 import { Typography } from '@bratislava/component-library'
-import Image from 'next/image'
 import React, { HTMLAttributes } from 'react'
 
 import CardBase from '@/src/components/cards/CardBase'
 import CardContent from '@/src/components/cards/CardContent'
+import CardImage from '@/src/components/common/Image/CardImage'
 import MLink from '@/src/components/common/MLink/MLink'
 import FormatEventDateRange from '@/src/components/formatting/FormatEventDateRange'
 import cn from '@/src/utils/cn'
@@ -40,26 +40,31 @@ const TootootEventCard = ({
   const { t } = useTranslation()
 
   return (
-    <CardBase variant="no-border" className={cn('rounded-lg text-white', className)} {...rest}>
-      <Image src={imageSrc} alt="" fill className="absolute object-cover" sizes={imageSizes} />
-      <CardContent className="relative inline-flex size-full flex-col items-start justify-end bg-linear-to-b from-transparent to-[black] p-4 text-clip lg:p-5">
-        <div className="flex w-full flex-col items-start gap-4 self-stretch">
-          <Typography variant="h5" as="h3">
-            <MLink
-              stretched
-              variant="underlineOnHover"
-              {...getLinkProps({ label: title, url: linkHref })}
-            />
-          </Typography>
+    <CardBase
+      variant="no-border"
+      className={cn('gap-4 rounded-lg bg-transparent', className)}
+      {...rest}
+    >
+      <CardImage imgSrc={imageSrc} className="aspect-tootoot rounded-lg" sizes={imageSizes} />
 
-          <div className="flex flex-col items-start text-size-p-tiny font-medium">
-            {/* FIXME Typography: Convert to use Typography. Issue: Different size and weight than typography have */}
-            {address && <span className="line-clamp-1">{address}</span>}
-            <span className="line-clamp-1">
-              {isLongTerm && `${t('common.from')} `}
-              <FormatEventDateRange dateFrom={dateFrom} dateTo={dateTo ?? undefined} />
-            </span>
-          </div>
+      <CardContent variant="no-padding" className="grow gap-2">
+        <Typography variant="h5" as="h3">
+          <MLink
+            stretched
+            variant="underlineOnHover"
+            {...getLinkProps({ label: title, url: linkHref })}
+          />
+        </Typography>
+        <div className="flex flex-col">
+          <Typography variant="p-small">
+            {isLongTerm && `${t('common.from')} `}
+            <FormatEventDateRange dateFrom={dateFrom} dateTo={dateTo ?? undefined} />
+          </Typography>
+          {address ? (
+            <Typography variant="p-small" className="line-clamp-1">
+              {address}
+            </Typography>
+          ) : null}
         </div>
       </CardContent>
     </CardBase>

--- a/next/src/components/layouts/Sections.tsx
+++ b/next/src/components/layouts/Sections.tsx
@@ -120,7 +120,7 @@ const SectionContent = ({ section }: { section: SectionsFragment }) => {
       return <FaqCategoriesSection section={section} />
 
     case 'ComponentSectionsTootootEvents':
-      return <TootootEventsSection section={section} />
+      return <TootootEventsSection section={section} variant="grid" />
 
     case 'ComponentSectionsPartners':
       return <PartnersSection section={section} />

--- a/next/src/components/sections/TootootEventsSection.tsx
+++ b/next/src/components/sections/TootootEventsSection.tsx
@@ -8,10 +8,7 @@ import Spinner from '@/src/components/common/Spinner/Spinner'
 import SectionContainer from '@/src/components/layouts/SectionContainer'
 import SectionHeader from '@/src/components/layouts/SectionHeader'
 import { TootootEventsSectionFragment } from '@/src/services/graphql'
-import {
-  getTootootEvents,
-  getTootootEventsQueryKey,
-} from '@/src/services/tootoot/tootootEvents.fetcher'
+import { getTootootEvents, getTootootEventsQueryKey } from '@/src/services/tootoot/tootootEvents.fetcher'
 import cn from '@/src/utils/cn'
 import { generateImageSizes } from '@/src/utils/generateImageSizes'
 import { getLinkProps } from '@/src/utils/getLinkProps'
@@ -25,7 +22,7 @@ type Props = {
 }
 
 /**
- * TODO Figma link
+ * Figma: https://www.figma.com/design/17wbd0MDQcMW9NbXl6UPs8/DS--Component-library?node-id=16920-16897&t=NNX7neyleEepsSIq-4
  */
 
 const TootootEventsSection = ({ section, variant = 'carousel', className }: Props) => {

--- a/next/src/components/sections/TootootEventsSection.tsx
+++ b/next/src/components/sections/TootootEventsSection.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
+import React from 'react'
 
 import TootootEventCard from '@/src/components/cards/TootootEventCard'
 import Button from '@/src/components/common/Button/Button'
@@ -11,6 +12,7 @@ import {
   getTootootEvents,
   getTootootEventsQueryKey,
 } from '@/src/services/tootoot/tootootEvents.fetcher'
+import cn from '@/src/utils/cn'
 import { generateImageSizes } from '@/src/utils/generateImageSizes'
 import { getLinkProps } from '@/src/utils/getLinkProps'
 
@@ -18,6 +20,7 @@ const imageSizes = generateImageSizes({ default: '100vw', lg: '33vw' })
 
 type Props = {
   section: TootootEventsSectionFragment
+  variant?: 'carousel' | 'grid'
   className?: string
 }
 
@@ -25,7 +28,7 @@ type Props = {
  * TODO Figma link
  */
 
-const TootootEventsSection = ({ section, className }: Props) => {
+const TootootEventsSection = ({ section, variant = 'carousel', className }: Props) => {
   const { title, text, showMoreLink } = section
 
   const { data, isPending, isError, error } = useQuery({
@@ -33,53 +36,69 @@ const TootootEventsSection = ({ section, className }: Props) => {
     queryFn: () => getTootootEvents(),
   })
 
+  const eventCards =
+    data?.map((event) => {
+      const {
+        title: eventTitle,
+        url,
+        image: imageSrc,
+        address,
+        beginDate,
+        endDate,
+        isLongTerm,
+      } = event
+
+      return (
+        <TootootEventCard
+          key={url}
+          lang="sk" // Specify language for screen readers because we fetch only SK events also on EN page
+          title={eventTitle}
+          linkHref={url}
+          imageSrc={imageSrc}
+          address={address}
+          dateFrom={beginDate}
+          dateTo={endDate}
+          isLongTerm={isLongTerm}
+          imageSizes={imageSizes}
+          className="h-full"
+        />
+      )
+    }) ?? []
+
   return (
     <SectionContainer className={className}>
-      <SectionHeader title={title} text={text} isCentered />
+      <div
+        className={cn('flex flex-col', {
+          'max-md:gap-6': variant === 'carousel', // From md screen, we don't want gap because we show carousel control buttons and it would be too much white space
+          'gap-6 lg:gap-12': variant === 'grid', // We always want a gap for grid variant
+        })}
+      >
+        <div className="flex flex-col gap-6 lg:gap-8">
+          <SectionHeader title={title} text={text} isCentered />
 
-      {isPending ? (
-        <Spinner />
-      ) : isError ? (
-        <div>{error.message}</div>
-      ) : (
-        <ResponsiveCarousel
-          shiftVariant="byPage"
-          itemClassName="h-[14.5rem] lg:h-[18.75rem]" // 232px, lg: 300px
-          items={
-            data?.map((event) => {
-              const {
-                title: eventTitle,
-                url,
-                image: imageSrc,
-                address,
-                beginDate,
-                endDate,
-                isLongTerm,
-              } = event
-
-              return (
-                <TootootEventCard
-                  key={url}
-                  lang="sk" // Specify language for screen readers because we fetch only SK events also on EN page
-                  title={eventTitle}
-                  linkHref={url}
-                  imageSrc={imageSrc}
-                  address={address}
-                  dateFrom={beginDate}
-                  dateTo={endDate}
-                  isLongTerm={isLongTerm}
-                  imageSizes={imageSizes}
-                />
-              )
-            }) ?? []
-          }
-        />
-      )}
-      {showMoreLink && (
-        <div className="flex justify-center">
-          <Button variant="outline" {...getLinkProps(showMoreLink)} />
+          {isPending ? (
+            <Spinner />
+          ) : isError ? (
+            <div>{error.message}</div>
+          ) : variant === 'carousel' ? (
+            <ResponsiveCarousel
+              shiftVariant="byPage"
+              hasVerticalPadding={false}
+              items={eventCards}
+            />
+          ) : (
+            <div className="grid grid-cols-1 gap-x-8 gap-y-10 sm:grid-cols-2 lg:grid-cols-3">
+              {eventCards}
+            </div>
+          )}
         </div>
-      )}
+
+        {showMoreLink && (
+          <div className="flex justify-center">
+            <Button variant="outline" {...getLinkProps(showMoreLink)} />
+          </div>
+        )}
+      </div>
     </SectionContainer>
   )
 }

--- a/next/src/components/sections/TootootEventsSection.tsx
+++ b/next/src/components/sections/TootootEventsSection.tsx
@@ -8,7 +8,10 @@ import Spinner from '@/src/components/common/Spinner/Spinner'
 import SectionContainer from '@/src/components/layouts/SectionContainer'
 import SectionHeader from '@/src/components/layouts/SectionHeader'
 import { TootootEventsSectionFragment } from '@/src/services/graphql'
-import { getTootootEvents, getTootootEventsQueryKey } from '@/src/services/tootoot/tootootEvents.fetcher'
+import {
+  getTootootEvents,
+  getTootootEventsQueryKey,
+} from '@/src/services/tootoot/tootootEvents.fetcher'
 import cn from '@/src/utils/cn'
 import { generateImageSizes } from '@/src/utils/generateImageSizes'
 import { getLinkProps } from '@/src/utils/getLinkProps'

--- a/next/src/styles/globals.css
+++ b/next/src/styles/globals.css
@@ -391,6 +391,7 @@
 
   /* Aspect ratio */
   --aspect-inba: 5 / 8;
+  --aspect-tootoot: 2 / 1; /* Taken as average image sizes used on tootoot.fm and bkis.sk */
 }
 
 @layer base {


### PR DESCRIPTION
…Section used on pages DZ

The aim is to unify cards with BKIS page and tootoot, and to get rid of the gradient card.
Tootoot and BKIS uses slightly different image ratios on multiple places, but 2:1 is very reasonable average.

<img width="1200" height="496" alt="image" src="https://github.com/user-attachments/assets/6db072c2-ca28-49df-bca6-6216f6edb8e1" />

<img width="800" height="453" alt="image" src="https://github.com/user-attachments/assets/c45a7d02-fc0c-445b-a089-ebce0b1f0c18" />

<img width="400" height="375" alt="image" src="https://github.com/user-attachments/assets/93d8fe02-46d9-407d-a829-05d90db4721c" />


<img width="800" height="1032" alt="image" src="https://github.com/user-attachments/assets/048c1463-8fc2-47fa-83f6-ff3001a424b1" />
