### PR TITLE
Update config-sync for hp highlights

### DIFF
--- a/strapi/config/sync/core-store.plugin_content_manager_configuration_components##blocks.homepage-highlights-item.json
+++ b/strapi/config/sync/core-store.plugin_content_manager_configuration_components##blocks.homepage-highlights-item.json
@@ -7,7 +7,7 @@
       "filterable": true,
       "searchable": true,
       "pageSize": 10,
-      "mainField": "documentId",
+      "mainField": "label",
       "defaultSortBy": "id",
       "defaultSortOrder": "ASC"
     },
@@ -22,7 +22,7 @@
       },
       "label": {
         "edit": {
-          "label": "label",
+          "label": "Nadpis",
           "description": "",
           "placeholder": "",
           "visible": true,
@@ -36,7 +36,7 @@
       },
       "subtext": {
         "edit": {
-          "label": "subtext",
+          "label": "Text",
           "description": "",
           "placeholder": "",
           "visible": true,
@@ -50,8 +50,8 @@
       },
       "article": {
         "edit": {
-          "label": "article",
-          "description": "",
+          "label": "Článok",
+          "description": "Použite toto políčko, ak ide o článok z bratislava.sk.",
           "placeholder": "",
           "visible": true,
           "editable": true,
@@ -65,12 +65,12 @@
       },
       "page": {
         "edit": {
-          "label": "page",
-          "description": "",
+          "label": "Stránka",
+          "description": "Použite toto políčko, ak ide o stránku z bratislava.sk.",
           "placeholder": "",
           "visible": true,
           "editable": true,
-          "mainField": "title"
+          "mainField": "slug"
         },
         "list": {
           "label": "page",
@@ -80,8 +80,8 @@
       },
       "media": {
         "edit": {
-          "label": "media",
-          "description": "",
+          "label": "Obrázok",
+          "description": "V pípade, že odkazujeme na Článok alebo Stránku (nie cez políčko Url), obrázok sa automaticky dotiahne z daného článku alebo stránky.",
           "placeholder": "",
           "visible": true,
           "editable": true
@@ -94,8 +94,8 @@
       },
       "url": {
         "edit": {
-          "label": "url",
-          "description": "",
+          "label": "Url",
+          "description": "Toto políčko používame pre odkazy na externé stránky.",
           "placeholder": "",
           "visible": true,
           "editable": true
@@ -158,59 +158,51 @@
       }
     },
     "layouts": {
-      "list": [
-        "id",
-        "link",
-        "image",
-        "documentId"
-      ],
       "edit": [
         [
           {
-            "name": "link",
+            "name": "label",
             "size": 12
           }
         ],
         [
           {
-            "name": "image",
-            "size": 6
-          },
-          {
-            "name": "label",
-            "size": 6
-          }
-        ],
-        [
-          {
             "name": "subtext",
-            "size": 6
-          },
-          {
-            "name": "article",
-            "size": 6
+            "size": 12
           }
         ],
         [
-          {
-            "name": "page",
-            "size": 6
-          },
           {
             "name": "media",
-            "size": 6
+            "size": 12
+          },
+          {
+            "name": "page",
+            "size": 8
+          }
+        ],
+        [
+          {
+            "name": "article",
+            "size": 8
           }
         ],
         [
           {
             "name": "url",
-            "size": 6
+            "size": 8
           },
           {
             "name": "analyticsId",
-            "size": 6
+            "size": 4
           }
         ]
+      ],
+      "list": [
+        "id",
+        "link",
+        "image",
+        "documentId"
       ]
     },
     "isComponent": true


### PR DESCRIPTION
- arrange new field
- hide old link and image fields but keep them in strapi for manual migration (just in case, it's already migrated on prod)

<img width="2148" height="1628" alt="image" src="https://github.com/user-attachments/assets/5e87e7e7-877f-4088-946f-f575f44ed303" />
