### PR TITLE
#1913 Change padding-y on NumbersOverviewSection

### DIFF
--- a/next/src/components/sections/NumbersOverviewSection.tsx
+++ b/next/src/components/sections/NumbersOverviewSection.tsx
@@ -14,7 +14,7 @@ type NumbersOverviewSectionProps = {
 
 const NumbersOverviewSection = ({ section }: NumbersOverviewSectionProps) => {
   return (
-    <SectionContainer className="py-6 lg:py-24">
+    <SectionContainer className="py-6 lg:py-16">
       <NumbersOverview section={section} />
     </SectionContainer>
   )


### PR DESCRIPTION
## Was
<img width="940" height="710" alt="image" src="https://github.com/user-attachments/assets/5ea3c7b4-d995-43e9-acec-b2abea7c6a26" />


## Is
<img width="945" height="789" alt="image" src="https://github.com/user-attachments/assets/b9fe279b-ca9c-4ae5-8bad-025aad9840e9" />