### PR TITLE
#1907 Add correct focus ring to alertbanner close button

### DIFF
--- a/next/src/components/common/NavBar/AlertBanner.tsx
+++ b/next/src/components/common/NavBar/AlertBanner.tsx
@@ -57,7 +57,8 @@ const AlertBanner = forwardRef<HTMLDivElement>((props, forwardedRef) => {
             <Markdown content={text} variant="small" />
           </div>
           <Button
-            className="-m-3 h-fit shrink-0 p-3 lg:-m-4 lg:p-4"
+            variant="icon-wrapped-negative-margin"
+            className="h-fit shrink-0"
             icon={<CrossIcon />}
             aria-label={t('AlertBanner.aria.closeAlert')}
             onPress={() => handleClose()}


### PR DESCRIPTION
<img width="939" height="164" alt="image" src="https://github.com/user-attachments/assets/70eb6aa5-07be-4eec-bf93-cb93ff6b9043" />
