### PR TITLE
Fix Postgress version in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   postgres:
-    image: postgres:latest
+    image: postgres:17
     environment:
       POSTGRES_USER: strapi
       POSTGRES_PASSWORD: password


### PR DESCRIPTION
Latest verzia Postgressu robila problem pri buildeni docker imagu. Viac o tom mozno vie Pinto alebo Tyci. Mozno sa bude musiet upravit aj v ostatnych repach.