### PR TITLE
Add customPublishedAt and customMetadata help fields to Assets

### DIFF
--- a/next/src/services/graphql/index.ts
+++ b/next/src/services/graphql/index.ts
@@ -467,6 +467,8 @@ export type Asset = {
   adminGroups_connection?: Maybe<AdminGroupRelationResponseCollection>
   assetCategory?: Maybe<AssetCategory>
   createdAt?: Maybe<Scalars['DateTime']['output']>
+  customMetadata?: Maybe<Scalars['JSON']['output']>
+  customPublishedAt?: Maybe<Scalars['DateTime']['output']>
   description?: Maybe<Scalars['String']['output']>
   documentId: Scalars['ID']['output']
   files: Array<Maybe<UploadFile>>
@@ -589,6 +591,8 @@ export type AssetFiltersInput = {
   and?: InputMaybe<Array<InputMaybe<AssetFiltersInput>>>
   assetCategory?: InputMaybe<AssetCategoryFiltersInput>
   createdAt?: InputMaybe<DateTimeFilterInput>
+  customMetadata?: InputMaybe<JsonFilterInput>
+  customPublishedAt?: InputMaybe<DateTimeFilterInput>
   description?: InputMaybe<StringFilterInput>
   documentId?: InputMaybe<IdFilterInput>
   not?: InputMaybe<AssetFiltersInput>
@@ -602,6 +606,8 @@ export type AssetFiltersInput = {
 export type AssetInput = {
   adminGroups?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>
   assetCategory?: InputMaybe<Scalars['ID']['input']>
+  customMetadata?: InputMaybe<Scalars['JSON']['input']>
+  customPublishedAt?: InputMaybe<Scalars['DateTime']['input']>
   description?: InputMaybe<Scalars['String']['input']>
   files?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>
   publishedAt?: InputMaybe<Scalars['DateTime']['input']>

--- a/strapi/config/sync/admin-role.strapi-super-admin.json
+++ b/strapi/config/sync/admin-role.strapi-super-admin.json
@@ -456,12 +456,14 @@
           "files",
           "description",
           "assetCategory",
-          "adminGroups"
+          "adminGroups",
+          "customPublishedAt",
+          "customMetadata"
         ]
       },
       "conditions": [],
       "actionParameters": {},
-      "documentId": "w90yvbi7yfd4gn5dsww20d8y",
+      "documentId": "jsk2uvlqvo9taxr2vqnjwn48",
       "locale": null
     },
     {
@@ -492,12 +494,14 @@
           "files",
           "description",
           "assetCategory",
-          "adminGroups"
+          "adminGroups",
+          "customPublishedAt",
+          "customMetadata"
         ]
       },
       "conditions": [],
       "actionParameters": {},
-      "documentId": "ioahh1076gk5494bgwonlu9z",
+      "documentId": "nr53kq3ixyw9521f6w6b2hwh",
       "locale": null
     },
     {
@@ -510,12 +514,14 @@
           "files",
           "description",
           "assetCategory",
-          "adminGroups"
+          "adminGroups",
+          "customPublishedAt",
+          "customMetadata"
         ]
       },
       "conditions": [],
       "actionParameters": {},
-      "documentId": "oraijsdhev72bhtewv88lqby",
+      "documentId": "antv4ixe14hj1c67v3tpjq1j",
       "locale": null
     },
     {

--- a/strapi/config/sync/core-store.plugin_content_manager_configuration_content_types##api##asset.asset.json
+++ b/strapi/config/sync/core-store.plugin_content_manager_configuration_content_types##api##asset.asset.json
@@ -7,8 +7,8 @@
       "searchable": true,
       "pageSize": 10,
       "mainField": "title",
-      "defaultSortBy": "title",
-      "defaultSortOrder": "ASC"
+      "defaultSortBy": "updatedAt",
+      "defaultSortOrder": "DESC"
     },
     "metadatas": {
       "id": {
@@ -105,6 +105,34 @@
           "sortable": false
         }
       },
+      "customPublishedAt": {
+        "edit": {
+          "label": "customPublishedAt",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "customPublishedAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "customMetadata": {
+        "edit": {
+          "label": "customMetadata",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "customMetadata",
+          "searchable": false,
+          "sortable": false
+        }
+      },
       "createdAt": {
         "edit": {
           "label": "createdAt",
@@ -173,6 +201,13 @@
       }
     },
     "layouts": {
+      "list": [
+        "id",
+        "title",
+        "slug",
+        "updatedAt",
+        "createdAt"
+      ],
       "edit": [
         [
           {
@@ -203,9 +238,20 @@
             "name": "adminGroups",
             "size": 6
           }
+        ],
+        [
+          {
+            "name": "customPublishedAt",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "customMetadata",
+            "size": 12
+          }
         ]
-      ],
-      "list": ["id", "title", "slug", "createdAt"]
+      ]
     },
     "uid": "api::asset.asset"
   },

--- a/strapi/config/sync/core-store.plugin_upload_api-folder.json
+++ b/strapi/config/sync/core-store.plugin_upload_api-folder.json
@@ -1,0 +1,9 @@
+{
+  "key": "plugin_upload_api-folder",
+  "value": {
+    "id": 166
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/strapi/schema.graphql
+++ b/strapi/schema.graphql
@@ -268,6 +268,8 @@ type Asset {
   adminGroups_connection(filters: AdminGroupFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): AdminGroupRelationResponseCollection
   assetCategory: AssetCategory
   createdAt: DateTime
+  customMetadata: JSON
+  customPublishedAt: DateTime
   description: String
   documentId: ID!
   files(filters: UploadFileFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): [UploadFile]!
@@ -346,6 +348,8 @@ input AssetFiltersInput {
   and: [AssetFiltersInput]
   assetCategory: AssetCategoryFiltersInput
   createdAt: DateTimeFilterInput
+  customMetadata: JSONFilterInput
+  customPublishedAt: DateTimeFilterInput
   description: StringFilterInput
   documentId: IDFilterInput
   not: AssetFiltersInput
@@ -359,6 +363,8 @@ input AssetFiltersInput {
 input AssetInput {
   adminGroups: [ID]
   assetCategory: ID
+  customMetadata: JSON
+  customPublishedAt: DateTime
   description: String
   files: [ID]
   publishedAt: DateTime

--- a/strapi/src/api/asset/content-types/asset/schema.json
+++ b/strapi/src/api/asset/content-types/asset/schema.json
@@ -24,7 +24,10 @@
       "type": "media",
       "multiple": true,
       "required": true,
-      "allowedTypes": ["images", "files"]
+      "allowedTypes": [
+        "images",
+        "files"
+      ]
     },
     "description": {
       "type": "text"
@@ -40,6 +43,12 @@
       "relation": "manyToMany",
       "target": "api::admin-group.admin-group",
       "mappedBy": "assets"
+    },
+    "customPublishedAt": {
+      "type": "datetime"
+    },
+    "customMetadata": {
+      "type": "json"
     }
   }
 }

--- a/strapi/types/generated/contentTypes.d.ts
+++ b/strapi/types/generated/contentTypes.d.ts
@@ -577,6 +577,8 @@ export interface ApiAssetAsset extends Struct.CollectionTypeSchema {
     assetCategory: Schema.Attribute.Relation<'manyToOne', 'api::asset-category.asset-category'>
     createdAt: Schema.Attribute.DateTime
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> & Schema.Attribute.Private
+    customMetadata: Schema.Attribute.JSON
+    customPublishedAt: Schema.Attribute.DateTime
     description: Schema.Attribute.Text
     files: Schema.Attribute.Media<'images' | 'files', true> & Schema.Attribute.Required
     locale: Schema.Attribute.String & Schema.Attribute.Private


### PR DESCRIPTION
Due to Strapi v5 restrictions, there is no option to set publishedAt or createdAt manually (it gets ignored).
So we add custom help fields and we will migrate the date manually in db.

Note: strapi/config/sync/core-store.plugin_upload_api-folder.json represents probably the special API Uploads folder, where all files are stored when uploaded through api.
<img width="300" height="164" alt="image" src="https://github.com/user-attachments/assets/03bdcc2e-deb1-4cb3-bb77-da1b8757e5d6" />
