### PR TITLE
feat(strapi): add nginx client-max-body-size annotation to ingress

### DIFF
--- a/strapi/kubernetes/base/ingress.yml
+++ b/strapi/kubernetes/base/ingress.yml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: cloudflare-dns01
     cert-manager.io/issue-temporary-certificate: 'true'
+    nginx.org/client-max-body-size: '100m'
 spec:
   ingressClassName: nginx
   tls:


### PR DESCRIPTION
## Summary
- Adds `nginx.org/client-max-body-size: 100m` annotation to the `bratislava-strapi-ingress` in the base kustomize config
- This was previously set manually via `kubectl annotate` on staging and prod; adding it to the base ingress manifest ensures it persists across all clusters and deployments
- Please don't deploy to prod without this

Without the annotation the default is 1mb. Let me know if 100mb is too little/too much.

Made with [Cursor](https://cursor.com)