### PR TITLE
feat(strapi): set client-max-body-size to 0 and disable request buffering

### DIFF
--- a/strapi/kubernetes/base/ingress.yml
+++ b/strapi/kubernetes/base/ingress.yml
@@ -8,7 +8,8 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: cloudflare-dns01
     cert-manager.io/issue-temporary-certificate: 'true'
-    nginx.org/client-max-body-size: '100m'
+    nginx.org/client-max-body-size: '0'
+    nginx.org/location-snippets: 'proxy_request_buffering off;'
 spec:
   ingressClassName: nginx
   tls:


### PR DESCRIPTION
## Summary
- Changes `nginx.org/client-max-body-size` from `100m` to `0` (unlimited) on strapi ingress
- Adds `nginx.org/location-snippets: 'proxy_request_buffering off;'` to disable request buffering for large uploads

Follow-up to #2132.

Made with [Cursor](https://cursor.com)