### PR TITLE
Temporarily ignore tar security updates blocked by Strapi transitive dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
       interval: 'monthly'
       day: 'sunday'
     rebase-strategy: 'disabled'
+    ignore:
+      - dependency-name: "tar"
+        reason: "Blocked by Strapi transitive dependency" # Remove after Strapi upgrade
 
   - package-ecosystem: 'npm' # See documentation for possible values
     directory: '/next' # Location of package manifests


### PR DESCRIPTION
Dependabot security updates for tar are currently blocked by pinned transitive dependencies in Strapi packages (@strapi/data-transfer, @strapi/cloud-cli).

The vulnerable tar versions are only used by Strapi CLI tooling and are not executed in the application runtime or exposed to user input. No compatible non-vulnerable version can be resolved until Strapi releases an update.

This change suppresses the Dependabot alert to keep CI green and will be reverted after upgrading Strapi to a version that lifts the tar constraint.

> AI generated