### PR TITLE
#2163 Add formatter to SectionHeader title

### DIFF
--- a/next/src/components/layouts/SectionHeader.tsx
+++ b/next/src/components/layouts/SectionHeader.tsx
@@ -7,6 +7,7 @@ import { TABLE_OF_CONTENTS_HEADING_ATTRIBUTE } from '@/src/components/common/Tab
 import Markdown from '@/src/components/formatting/Markdown/Markdown'
 import { CommonLinkFragment } from '@/src/services/graphql'
 import cn from '@/src/utils/cn'
+import { formatWithNonBreakingHyphen } from '@/src/utils/formatWithNonBreakingHyphen'
 import { getLinkProps } from '@/src/utils/getLinkProps'
 
 type SectionHeaderProps = {
@@ -41,10 +42,6 @@ const SectionHeader = ({
 }: SectionHeaderProps) => {
   if (!title && !text && !showMoreLink) {
     return null
-  }
-
-  const formatWithNonBreakingHyphen = (titleText: string) => {
-    return titleText.replace(/(\w)-(\w)/g, '$1\u2011$2')
   }
 
   return (

--- a/next/src/components/sections/NewsletterSection/NewsletterSection.tsx
+++ b/next/src/components/sections/NewsletterSection/NewsletterSection.tsx
@@ -135,26 +135,28 @@ const NewsletterSection = ({ section }: Props) => {
                * Checkbox label and link are separated for accessibility reasons:
                * https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/label#interactive_content
                */}
-              <div className="inline-block">
-                <Checkbox
-                  isSelected={consentChecked}
-                  onChange={setConsentChecked}
-                  aria-label={[
-                    t('NewsletterSection.consentCheckboxLabel'),
-                    t('NewsletterSection.consentLinkLabel'),
-                  ].join(' ')}
+              <div className="pl-9">
+                <div className="-ml-9 inline-block">
+                  <Checkbox
+                    isSelected={consentChecked}
+                    onChange={setConsentChecked}
+                    aria-label={[
+                      t('NewsletterSection.consentCheckboxLabel'),
+                      t('NewsletterSection.consentLinkLabel'),
+                    ].join(' ')}
+                  >
+                    <span className="mr-1">{t('NewsletterSection.consentCheckboxLabel')}</span>
+                  </Checkbox>
+                </div>
+                <MLink
+                  variant="underlined"
+                  aria-label={t('NewsletterSection.consentLinkLabel.aria')}
+                  className="inline-block align-top"
+                  {...getLinkProps({ page: privacyPolicyPage })}
                 >
-                  {t('NewsletterSection.consentCheckboxLabel')}{' '}
-                </Checkbox>
+                  {t('NewsletterSection.consentLinkLabel')}
+                </MLink>
               </div>
-              <MLink
-                variant="underlined"
-                aria-label={t('NewsletterSection.consentLinkLabel.aria')}
-                className="ml-9 inline-block align-top lg:ml-1"
-                {...getLinkProps({ page: privacyPolicyPage })}
-              >
-                {t('NewsletterSection.consentLinkLabel')}
-              </MLink>
             </div>
             {successMessage ? (
               <Typography variant="p-small" className="text-content-success-default">

--- a/next/src/utils/formatWithNonBreakingHyphen.ts
+++ b/next/src/utils/formatWithNonBreakingHyphen.ts
@@ -1,0 +1,3 @@
+export const formatWithNonBreakingHyphen = (titleText: string) => {
+  return titleText.replace(/(\w)-(\w)/g, '$1\u2011$2')
+}


### PR DESCRIPTION
 - added non-breaking hyphen into SectionHeader title
 - also fixed newsletter consent checkbox label on mobile

<img width="402" height="784" alt="image" src="https://github.com/user-attachments/assets/781c628b-3b49-4553-b481-d02617a38a4e" />
