### PR TITLE
Fix GraphQL repeatable component ordering

### DIFF
--- a/strapi/README.md
+++ b/strapi/README.md
@@ -65,6 +65,14 @@ We add `'en'` locale to `.localCompare()` function so properties order in genera
 npx patch-package @strapi/typescript-utils
 ```
 
+### @strapi/database
+
+Fixes repeatable component / dynamic zone ordering in GraphQL responses. The GraphQL component field resolver injects an empty `orderBy: []` into the populate query. In `getJoinTableOrderBy` (`query/helpers/populate/apply.js`) the check `if (populateValue.orderBy || ...)` treats that empty array as truthy, so the join-table `order` column is dropped and components fall back to natural primary-key (`id`) order instead of the order set in the admin. REST is unaffected. The patch treats an empty array as "no explicit sort".
+
+```bash
+npx patch-package @strapi/database
+```
+
 ## Pages by Component
 
 We add a custom admin page `PagesByComponent.tsx` that lists which pages use which section components. This feature uses a custom api route defined in `api/pages-by-component`.

--- a/strapi/patches/@strapi+database+5.47.1.patch
+++ b/strapi/patches/@strapi+database+5.47.1.patch
@@ -1,0 +1,16 @@
+diff --git a/node_modules/@strapi/database/dist/query/helpers/populate/apply.js b/node_modules/@strapi/database/dist/query/helpers/populate/apply.js
+index d9594bb..5156f0d 100644
+--- a/node_modules/@strapi/database/dist/query/helpers/populate/apply.js
++++ b/node_modules/@strapi/database/dist/query/helpers/populate/apply.js
+@@ -12,7 +12,10 @@ const joinColPrefix = '__strapi';
+  * When `populateValue.orderBy` is present, join-table ordering must not take precedence
+  * over the target attribute sort (see query-builder join vs root orderBy ordering).
+  */ const getJoinTableOrderBy = (populateValue, joinTable)=>{
+-    if (populateValue.orderBy || !joinTable.orderBy) {
++    // An empty `orderBy` array (e.g. injected by the GraphQL component resolver) is truthy
++    // but means "no explicit sort", so it must not suppress the join-table `order`.
++    const hasExplicitOrderBy = _.isArray(populateValue.orderBy) ? populateValue.orderBy.length > 0 : Boolean(populateValue.orderBy);
++    if (hasExplicitOrderBy || !joinTable.orderBy) {
+         return undefined;
+     }
+     return _.mapValues((v)=>populateValue.ordering || v, joinTable.orderBy);


### PR DESCRIPTION
## Problem

Mega menu items rendered in wrong order. GraphQL returned nested repeatable components (menu sections/links) sorted by primary key `id` instead of the `order` set in Strapi admin. REST (`/api/menu?populate=...`) returned correct order.

Example — *Doprava a komunikácie*: "Mapy" appeared 4th instead of 6th.

## Root cause

`@strapi/database` → `getJoinTableOrderBy` (`query/helpers/populate/apply.js`).

The GraphQL component field resolver injects an empty `orderBy: []` into the populate query. The guard:

```js
if (populateValue.orderBy || !joinTable.orderBy) return undefined;
```

treats the empty array as **truthy** → bails → drops the join-table `order` column → components fall back to natural PK (`id`) order. REST leaves `orderBy` unset, so it's unaffected.

Affects all GraphQL-fetched repeatable components and dynamic zones, not just the menu.

## Fix

`patch-package` patch on `@strapi/database` — treat empty array as "no explicit sort":

```js
const hasExplicitOrderBy = _.isArray(populateValue.orderBy)
  ? populateValue.orderBy.length > 0
  : Boolean(populateValue.orderBy);
if (hasExplicitOrderBy || !joinTable.orderBy) return undefined;
```

Applies automatically via existing `postinstall: patch-package`. README updated.

## Verification

Local GraphQL `menu` query before/after, compared against REST. After patch every section + link is in the admin-defined order (Mapy 6th), matching REST exactly.

Created issue in Strapi repo: https://github.com/strapi/strapi/issues/26584

🤖 Generated with [Claude Code](https://claude.com/claude-code)