### PR TITLE
#2392 Fix overflowing search bar in strapi media library AssetDialog

### DIFF
--- a/strapi/patches/@strapi+upload+5.48.1.patch
+++ b/strapi/patches/@strapi+upload+5.48.1.patch
@@ -1,0 +1,32 @@
+diff --git a/node_modules/@strapi/upload/dist/admin/components/AssetDialog/BrowseStep/BrowseStep.mjs b/node_modules/@strapi/upload/dist/admin/components/AssetDialog/BrowseStep/BrowseStep.mjs
+index 38f61fd..5ebff66 100644
+--- a/node_modules/@strapi/upload/dist/admin/components/AssetDialog/BrowseStep/BrowseStep.mjs
++++ b/node_modules/@strapi/upload/dist/admin/components/AssetDialog/BrowseStep/BrowseStep.mjs
+@@ -1,3 +1,8 @@
++/**
++ * This patch fixes overflowing icons in the Media library dialog when selecting assets in list view.
++ * Without it, user needs to scroll horizontally to find the search bar and the view switcher.
++ */
++
+ import { jsxs, jsx, Fragment } from 'react/jsx-runtime';
+ import { Typography, Box, Flex, Checkbox, IconButton, Button, Grid, VisuallyHidden, Divider } from '@strapi/design-system';
+ import { List, GridFour, Plus, Pencil } from '@strapi/icons';
+@@ -74,8 +79,8 @@ const BrowseStep = ({ allowedTypes = [], assets: rawAssets, canCreate, canRead,
+             onSelectAllAsset && /*#__PURE__*/ jsx(Box, {
+                 paddingBottom: 4,
+                 children: /*#__PURE__*/ jsxs(Flex, {
+-                    justifyContent: "space-between",
+-                    alignItems: "flex-start",
++                    alignItems: "flex-center",
++                    gap: 2,
+                     children: [
+                         (assetCount > 0 || folderCount > 0 || isFiltering) && /*#__PURE__*/ jsxs(Flex, {
+                             gap: 2,
+@@ -108,7 +113,6 @@ const BrowseStep = ({ allowedTypes = [], assets: rawAssets, canCreate, canRead,
+                             ]
+                         }),
+                         (assetCount > 0 || folderCount > 0 || isSearching) && /*#__PURE__*/ jsxs(Flex, {
+-                            marginLeft: "auto",
+                             shrink: 0,
+                             gap: 2,
+                             children: [


### PR DESCRIPTION
Before - Search and View icon overflow to the right edge which needs scrolling - why, strapi, why
<img width="809" height="327" alt="Image" src="https://github.com/user-attachments/assets/a8e54748-2e3f-4b40-a3cf-7e366502d7ed" />

After
<img width="751" height="236" alt="Image" src="https://github.com/user-attachments/assets/0961b8a6-b9cf-4e68-a8c9-f343c1c11ad9" />