### PR TITLE
docs: connecting to / dumping the on-cluster Strapi CNPG database

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Each sub-project contains README which should get you up and running. More docum
 
 🏡 `/next` bratislava.sk Nextjs web app
 
-🗄️ `/strapi` Strapi CMS server for bratislava.sk
+🗄️ `/strapi` Strapi CMS server for bratislava.sk — for connecting to / dumping the deployed database, see [`strapi/README.md`](./strapi/README.md#connecting-to-the-deployed-database-staging--dev--prod)
 
 📝 `/docs` contain the mapping between React and Strapi components - to be replaced by a styleguide in the future
 

--- a/strapi/README.md
+++ b/strapi/README.md
@@ -19,21 +19,26 @@ The three clusters (`development`, `staging`, `production`) are laid out identic
 
 ### 1. Log in to the cluster
 
-Kube context / login is handled by the [`k8-helpers`](https://github.com/bratislava/k8-helpers) aliases:
+Login is handled by the [`k8-helpers`](https://github.com/bratislava/k8-helpers) aliases — either log in to everything at once with `k8all`, or to a single cluster with `k8dev` / `k8stage` / `k8prod`:
 
 ```bash
-k8stage   # staging   (use k8dev / k8prod for the other clusters)
+k8all     # authenticate to all clusters at once (development / staging / production / ...)
+# or a single one:
+k8stage   # staging   (k8dev / k8prod for the others)
 ```
+
+Every `kubectl` command below passes `--context` explicitly, so it doesn't matter which context is currently active — you just need to be logged in. The context name is the environment: `development`, `staging`, or `production`. Examples use `staging`.
 
 ### 2. Read the database credentials
 
 Each web's credentials live in a `strapi-cnpg-<web>-credentials` secret in the `standalone` namespace — for this repo, `strapi-cnpg-bratislava-credentials`:
 
 ```bash
+CTX=staging   # or development / production
 NS=standalone
-kubectl get secret strapi-cnpg-bratislava-credentials -n $NS -o jsonpath='{.data.DATABASE_USERNAME}' | base64 -d; echo
-kubectl get secret strapi-cnpg-bratislava-credentials -n $NS -o jsonpath='{.data.DATABASE_NAME}'     | base64 -d; echo
-kubectl get secret strapi-cnpg-bratislava-credentials -n $NS -o jsonpath='{.data.DATABASE_PASSWORD}' | base64 -d; echo
+kubectl --context $CTX get secret strapi-cnpg-bratislava-credentials -n $NS -o jsonpath='{.data.DATABASE_USERNAME}' | base64 -d; echo
+kubectl --context $CTX get secret strapi-cnpg-bratislava-credentials -n $NS -o jsonpath='{.data.DATABASE_NAME}'     | base64 -d; echo
+kubectl --context $CTX get secret strapi-cnpg-bratislava-credentials -n $NS -o jsonpath='{.data.DATABASE_PASSWORD}' | base64 -d; echo
 ```
 
 ### 3. Connect
@@ -41,7 +46,7 @@ kubectl get secret strapi-cnpg-bratislava-credentials -n $NS -o jsonpath='{.data
 Port-forward the shared cluster's read-write service to a local port. Use **5433** so it doesn't clash with the local docker Postgres on 5432:
 
 ```bash
-kubectl port-forward -n standalone svc/strapi-cnpg-rw 5433:5432
+kubectl --context staging port-forward -n standalone svc/strapi-cnpg-rw 5433:5432
 # then, in another shell (user / db / password from step 2):
 PGPASSWORD=<password> psql -h localhost -p 5433 -U <user> -d <db>
 ```

--- a/strapi/README.md
+++ b/strapi/README.md
@@ -11,6 +11,55 @@ cp .env.example .env.local
 
 You need postgres running locally (with correct credentials & database available). The easiest way to get a postgres db with the right credentials up&running is via `docker-compose.yml` file. Check the readme in the root of this repo.
 
+## Connecting to the deployed database (staging / dev / prod)
+
+The deployed Strapi stores its data in an on-cluster [CloudNativePG (CNPG)](https://cloudnative-pg.io/) Postgres. Unlike a per-app DB, this uses a **shared** CNPG cluster `strapi-cnpg` in the `standalone` namespace that hosts one database per Bratislava Strapi backend (`bratislava`, `city-foundation`, `city-gallery`, `city-library`, `general`, `marianum`, `olo`). This repo's database is **`bratislava`**.
+
+The three clusters (`development`, `staging`, `production`) are laid out identically, so the steps below are the same for every environment — you only switch the kube context. Examples use **staging**.
+
+### 1. Log in to the cluster
+
+Kube context / login is handled by the [`k8-helpers`](https://github.com/bratislava/k8-helpers) aliases:
+
+```bash
+k8stage   # staging   (use k8dev / k8prod for the other clusters)
+```
+
+### 2. Read the database credentials
+
+Each web's credentials live in a `strapi-cnpg-<web>-credentials` secret in the `standalone` namespace — for this repo, `strapi-cnpg-bratislava-credentials`:
+
+```bash
+NS=standalone
+kubectl get secret strapi-cnpg-bratislava-credentials -n $NS -o jsonpath='{.data.DATABASE_USERNAME}' | base64 -d; echo
+kubectl get secret strapi-cnpg-bratislava-credentials -n $NS -o jsonpath='{.data.DATABASE_NAME}'     | base64 -d; echo
+kubectl get secret strapi-cnpg-bratislava-credentials -n $NS -o jsonpath='{.data.DATABASE_PASSWORD}' | base64 -d; echo
+```
+
+### 3. Connect
+
+Port-forward the shared cluster's read-write service to a local port. Use **5433** so it doesn't clash with the local docker Postgres on 5432:
+
+```bash
+kubectl port-forward -n standalone svc/strapi-cnpg-rw 5433:5432
+# then, in another shell (user / db / password from step 2):
+PGPASSWORD=<password> psql -h localhost -p 5433 -U <user> -d <db>
+```
+
+### 4. Dump it and restore locally
+
+```bash
+# dump (custom format) while the port-forward from step 3 is running
+PGPASSWORD=<password> pg_dump -h localhost -p 5433 -U <user> -d <db> -Fc -f strapi-staging.dump
+
+# start a local Postgres (see root readme): docker compose up postgres
+# restore into it (creds/db from your .env.local, default port 5432)
+PGPASSWORD=<local_password> pg_restore --clean --no-owner \
+  -h localhost -p 5432 -U <local_user> -d <local_db> strapi-staging.dump
+```
+
+> **Note:** `strapi-cnpg` is shared — only ever dump the `bratislava` database, and never write to another web's database. Treat **production** dumps as sensitive.
+
 ## Build
 
 Build your admin panel. [Learn more](https://docs.strapi.io/developer-docs/latest/developer-resources/cli/CLI.html#strapi-build)

--- a/strapi/README.md
+++ b/strapi/README.md
@@ -65,8 +65,6 @@ PGPASSWORD=<local_password> pg_restore --clean --no-owner \
   -h localhost -p 5432 -U <local_user> -d <local_db> strapi-staging.dump
 ```
 
-> **Note:** `strapi-cnpg` is shared — only ever dump the `bratislava` database, and never write to another web's database. Treat **production** dumps as sensitive.
-
 ## Build
 
 Build your admin panel. [Learn more](https://docs.strapi.io/developer-docs/latest/developer-resources/cli/CLI.html#strapi-build)

--- a/strapi/README.md
+++ b/strapi/README.md
@@ -40,7 +40,7 @@ kubectl --context staging get secret strapi-cnpg-bratislava-credentials -n stand
 kubectl --context staging get secret strapi-cnpg-bratislava-credentials -n standalone -o jsonpath='{.data.DATABASE_PASSWORD}' | base64 -d; echo
 ```
 
-> Prefer a GUI? In a tool such as [OpenLens](https://github.com/MuhammedKalkan/OpenLens) (or Lens) pick the cluster/context, open **Config → Secrets** in the `standalone` namespace, find `strapi-cnpg-bratislava-credentials` and reveal `DATABASE_USERNAME` / `DATABASE_NAME` / `DATABASE_PASSWORD`.
+> Prefer a GUI? In a tool such as [FreeLens](https://github.com/freelensapp/freelens) (or Lens) pick the cluster/context, open **Config → Secrets** in the `standalone` namespace, find `strapi-cnpg-bratislava-credentials` and reveal `DATABASE_USERNAME` / `DATABASE_NAME` / `DATABASE_PASSWORD`.
 
 ### 3. Connect
 

--- a/strapi/README.md
+++ b/strapi/README.md
@@ -41,6 +41,8 @@ kubectl --context $CTX get secret strapi-cnpg-bratislava-credentials -n $NS -o j
 kubectl --context $CTX get secret strapi-cnpg-bratislava-credentials -n $NS -o jsonpath='{.data.DATABASE_PASSWORD}' | base64 -d; echo
 ```
 
+> Prefer a GUI? In a tool such as [OpenLens](https://github.com/MuhammedKalkan/OpenLens) (or Lens) pick the cluster/context, open **Config → Secrets** in the `standalone` namespace, find `strapi-cnpg-bratislava-credentials` and reveal `DATABASE_USERNAME` / `DATABASE_NAME` / `DATABASE_PASSWORD`.
+
 ### 3. Connect
 
 Port-forward the shared cluster's read-write service to a local port. Use **5433** so it doesn't clash with the local docker Postgres on 5432:

--- a/strapi/README.md
+++ b/strapi/README.md
@@ -34,11 +34,10 @@ Every `kubectl` command below passes `--context` explicitly, so it doesn't matte
 Each web's credentials live in a `strapi-cnpg-<web>-credentials` secret in the `standalone` namespace — for this repo, `strapi-cnpg-bratislava-credentials`:
 
 ```bash
-CTX=staging   # or development / production
-NS=standalone
-kubectl --context $CTX get secret strapi-cnpg-bratislava-credentials -n $NS -o jsonpath='{.data.DATABASE_USERNAME}' | base64 -d; echo
-kubectl --context $CTX get secret strapi-cnpg-bratislava-credentials -n $NS -o jsonpath='{.data.DATABASE_NAME}'     | base64 -d; echo
-kubectl --context $CTX get secret strapi-cnpg-bratislava-credentials -n $NS -o jsonpath='{.data.DATABASE_PASSWORD}' | base64 -d; echo
+# staging shown; swap --context for development / production
+kubectl --context staging get secret strapi-cnpg-bratislava-credentials -n standalone -o jsonpath='{.data.DATABASE_USERNAME}' | base64 -d; echo
+kubectl --context staging get secret strapi-cnpg-bratislava-credentials -n standalone -o jsonpath='{.data.DATABASE_NAME}'     | base64 -d; echo
+kubectl --context staging get secret strapi-cnpg-bratislava-credentials -n standalone -o jsonpath='{.data.DATABASE_PASSWORD}' | base64 -d; echo
 ```
 
 > Prefer a GUI? In a tool such as [OpenLens](https://github.com/MuhammedKalkan/OpenLens) (or Lens) pick the cluster/context, open **Config → Secrets** in the `standalone` namespace, find `strapi-cnpg-bratislava-credentials` and reveal `DATABASE_USERNAME` / `DATABASE_NAME` / `DATABASE_PASSWORD`.


### PR DESCRIPTION
## What

Documents how a developer reaches the **deployed** Strapi Postgres, which lives in an on-cluster CloudNativePG (CNPG) instance and wasn't described anywhere in the repo.

Strapi uses a **shared** CNPG cluster `strapi-cnpg` in the `standalone` namespace that hosts one database per Bratislava Strapi backend; this repo's db is `bratislava`.

Added under a new *"Connecting to the deployed database"* section in `strapi/README.md`:

- log in to a cluster with [`k8-helpers`](https://github.com/bratislava/k8-helpers) (`k8stage` / `k8dev` / `k8prod`)
- read creds from the `strapi-cnpg-bratislava-credentials` secret
- port-forward the `-rw` service (local **5433** to avoid the docker Postgres on 5432) + `psql`
- `pg_dump -Fc` of the `bratislava` db → `pg_restore` into the local `docker compose up postgres` DB

The root `README.md` `/strapi` bullet now links to this section. Steps are identical for dev / staging / prod (only the kube context changes).

## Notes

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
