### PR TITLE
AVI-to-nginx-migration: use default ingress class

### DIFF
--- a/next/kubernetes/base/redirects/nocnapomoc.ingress.yml
+++ b/next/kubernetes/base/redirects/nocnapomoc.ingress.yml
@@ -14,7 +14,6 @@ metadata:
           return 301 https://${BRATISKA_HOSTNAME}/socialne-sluzby-a-byvanie/socialne-sluzby-a-zariadenia/nocna-pomoc;
       }
 spec:
-  ingressClassName: nginx
   tls:
     - hosts:
         - nocnapomoc.sk

--- a/strapi/kubernetes/base/ingress.yml
+++ b/strapi/kubernetes/base/ingress.yml
@@ -11,7 +11,6 @@ metadata:
     nginx.org/client-max-body-size: '0'
     nginx.org/location-snippets: 'proxy_request_buffering off;'
 spec:
-  ingressClassName: nginx
   tls:
     - hosts:
         - ${BRATISKA_HOSTNAME}


### PR DESCRIPTION
Note: should be merged once production default ingress is switched to nginx.

Removes the explicitly pinned `spec.ingressClassName: nginx` so these Ingresses inherit the cluster's default IngressClass. The AVI -> nginx cutover then happens once at the cluster level rather than repo by repo.

**Files changed**
- `next/kubernetes/base/redirects/nocnapomoc.ingress.yml`
- `strapi/kubernetes/base/ingress.yml`

**Why the merge order matters here specifically:** both files pin `nginx` *because* they depend on `nginx.org/*` annotations — `nocnapomoc` does its 301 via `nginx.org/server-snippets`, and the Strapi ingress sets `nginx.org/client-max-body-size` and `nginx.org/location-snippets` for uploads. Until the cluster default is nginx, removing the pin sends them to AVI where those annotations are inert, so the nocnapomoc redirect and the Strapi upload limit both stop working. Merging early is a user-visible regression, not a no-op.

Verified with `kustomize build` on the Dev, Staging and Prod overlays for both `next/` and `strapi/`: builds pass and the only delta in rendered output is the removed class.

Out of scope: the 14 redirect Ingresses in this repo still using the AVI-only `ingress.kubernetes.io/redirect-to` annotation, which nginx does not implement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)