### PR TITLE
Create content-inventory API endpoint for AI chatbot

### DIFF
--- a/next/src/pages/api/content-inventory.ts
+++ b/next/src/pages/api/content-inventory.ts
@@ -1,0 +1,143 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import {
+  createLoader,
+  parseAsArrayOf,
+  parseAsInteger,
+  parseAsIsoDateTime,
+  parseAsStringLiteral,
+} from 'nuqs/server'
+
+import { getInventorySnapshot } from '@/src/services/content-inventory/snapshotCache'
+import {
+  InventoryEntry,
+  InventoryResponse,
+  inventoryTypes,
+} from '@/src/services/content-inventory/types'
+
+/** Bump when the shape of an entry changes in a way that can break consumers. */
+const INVENTORY_VERSION = 1
+
+/** Used when a page is requested without a page size. Without any pagination parameter everything is returned. */
+const DEFAULT_PAGE_SIZE = 100
+
+const searchParams = {
+  modifiedSince: parseAsIsoDateTime,
+  type: parseAsArrayOf(parseAsStringLiteral(inventoryTypes), ','),
+  locale: parseAsStringLiteral(['sk', 'en'] as const),
+  fields: parseAsStringLiteral(['url'] as const),
+  page: parseAsInteger,
+  pageSize: parseAsInteger,
+}
+
+const loadSearchParams = createLoader(searchParams)
+
+/**
+ * The nuqs parsers fall back to null instead of failing, and the array parser silently drops values it cannot parse -
+ * which would turn a mistyped `modifiedSince` into a full re-ingest or a mistyped `type` into a partial one. Anything
+ * that was sent but not fully parsed is an error instead.
+ */
+const getInvalidParams = (request: NextApiRequest, parsed: Record<string, unknown>) => {
+  return Object.keys(searchParams).filter((key) => {
+    const rawValue = request.query[key]
+
+    if (!rawValue || typeof rawValue !== 'string') {
+      return false
+    }
+
+    const parsedValue = parsed[key]
+
+    // A comma separated list is invalid as soon as one of its values could not be parsed.
+    if (Array.isArray(parsedValue)) {
+      return parsedValue.length !== rawValue.split(',').length
+    }
+
+    return parsedValue === null
+  })
+}
+
+const toUrlEntry = (entry: InventoryEntry) => ({
+  id: entry.id,
+  url: entry.url,
+  modifiedAt: entry.modifiedAt,
+})
+
+const handler = async (
+  request: NextApiRequest,
+  response: NextApiResponse<InventoryResponse | { error: string }>,
+) => {
+  if (request.method !== 'GET') {
+    response.setHeader('Allow', 'GET')
+    response.status(405).json({ error: 'Method not allowed' })
+
+    return
+  }
+
+  const parsedParams = loadSearchParams(request.query)
+  const invalidParams = getInvalidParams(request, parsedParams)
+
+  if (invalidParams.length > 0) {
+    response.status(400).json({
+      error: `Invalid query parameters: ${invalidParams.join(', ')}. Allowed types are ${inventoryTypes.join(', ')}, locales sk and en, fields url, modifiedSince is an ISO date.`,
+    })
+
+    return
+  }
+
+  let snapshot
+
+  try {
+    snapshot = await getInventorySnapshot()
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Content inventory: failed to build the snapshot.', error)
+    response.status(502).json({ error: 'Content backend is not reachable' })
+
+    return
+  }
+
+  const { modifiedSince, type, locale, fields, page, pageSize } = parsedParams
+
+  const filtered = snapshot.entries.filter((entry) => {
+    // An empty `type=` is treated as no filter at all, not as "nothing matches".
+    if (type?.length && !type.includes(entry.type)) {
+      return false
+    }
+
+    if (locale && entry.locale !== locale) {
+      return false
+    }
+
+    if (modifiedSince) {
+      return Boolean(entry.modifiedAt) && new Date(entry.modifiedAt as string) > modifiedSince
+    }
+
+    return true
+  })
+
+  // Without any pagination parameter everything is returned as a single page.
+  const isPaginated = Boolean(page ?? pageSize)
+  const currentPage = page ?? 1
+  const currentPageSize = isPaginated ? (pageSize ?? DEFAULT_PAGE_SIZE) : filtered.length
+  const paginated = isPaginated
+    ? filtered.slice((currentPage - 1) * currentPageSize, currentPage * currentPageSize)
+    : filtered
+
+  response.status(200).json({
+    version: INVENTORY_VERSION,
+    generatedAt: new Date(snapshot.builtAt).toISOString(),
+    totalItems: filtered.length,
+    page: currentPage,
+    pageSize: currentPageSize,
+    pageCount: currentPageSize > 0 ? Math.ceil(filtered.length / currentPageSize) : 1,
+    items: fields === 'url' ? paginated.map(toUrlEntry) : paginated,
+  })
+}
+
+export const config = {
+  api: {
+    // The full inventory is a few megabytes.
+    responseLimit: false,
+  },
+}
+
+export default handler

--- a/next/src/services/content-inventory/buildInventory.ts
+++ b/next/src/services/content-inventory/buildInventory.ts
@@ -1,0 +1,199 @@
+import { environment } from '@/src/environment'
+import { client } from '@/src/services/graphql/gql'
+import { isDefined } from '@/src/utils/isDefined'
+
+import { InventoryCategory, InventoryEntry, InventoryEntryBase, InventoryType } from './types'
+
+// TODO: The paths are hardcoded the same way as in getLinkProps and next-sitemap.config.js, extract them once.
+const getUrl = (path: string, locale = 'sk') =>
+  `${environment.siteUrl.replace(/\/$/, '')}${locale === 'en' ? '/en' : ''}${path}`
+
+const getFirstNonEmpty = (...values: (string | null | undefined)[]) =>
+  values.find((value) => isDefined(value) && value.trim().length > 0) ?? undefined
+
+/** Some dates are Strapi date fields (2026-08-03), the rest are datetimes - the api returns one format. */
+const getIsoDate = (value: unknown) => {
+  const date = value as string | null | undefined
+
+  if (!date) {
+    return null
+  }
+
+  return /^\d{4}-\d{2}-\d{2}$/.test(date) ? `${date}T00:00:00.000Z` : date
+}
+
+/** Omits the type specific object entirely when the content type has nothing to add. */
+const getTypeData = <T extends object>(data: T) =>
+  Object.values(data).some(isDefined) ? data : undefined
+
+const getCategory = (
+  category: InventoryCategory | null | undefined,
+): InventoryCategory | undefined =>
+  category ? { title: category.title, slug: category.slug } : undefined
+
+/**
+ * The part of an entry that is the same for every content type. `addedAt` unifies the various "published" dates - each
+ * content type passes in its own one (addedAt, customPublishedAt, releaseDate), falling back to Strapi's publishedAt.
+ */
+const getBase = <TType extends InventoryType>(
+  type: TType,
+  entry: {
+    documentId: string
+    path: string
+    locale?: string | null
+    title: string
+    summary?: string
+    addedAt?: unknown
+    modifiedAt?: unknown
+  },
+): InventoryEntryBase & { type: TType } => ({
+  id: `${type}:${entry.documentId}:${entry.locale ?? 'sk'}`,
+  type,
+  url: getUrl(entry.path, entry.locale ?? 'sk'),
+  locale: entry.locale ?? 'sk',
+  isLocalized: isDefined(entry.locale),
+  title: entry.title,
+  summary: entry.summary,
+  addedAt: getIsoDate(entry.addedAt),
+  modifiedAt: getIsoDate(entry.modifiedAt),
+})
+
+const buildPages = async (): Promise<InventoryEntry[]> => {
+  const { pages } = await client.PagesInventory()
+
+  return pages.filter(isDefined).map((page) => ({
+    ...getBase('page', {
+      ...page,
+      path: `/${page.path}`,
+      summary: getFirstNonEmpty(page.subtext, page.metaDescription),
+      addedAt: page.publishedAt,
+      modifiedAt: page.updatedAt,
+    }),
+    page: getTypeData({
+      metaDescription: page.metaDescription ?? undefined,
+      keywords: page.keywords ?? undefined,
+    }),
+  }))
+}
+
+const buildArticles = async (): Promise<InventoryEntry[]> => {
+  const { articles } = await client.ArticlesInventory()
+
+  return articles.filter(isDefined).map((article) => ({
+    ...getBase('article', {
+      ...article,
+      path: `/spravy/${article.slug}`,
+      summary: getFirstNonEmpty(article.perex),
+      addedAt: article.addedAt,
+      modifiedAt: article.updatedAt,
+    }),
+    article: {
+      category: getCategory(article.articleCategory),
+      tags: article.tags.filter(isDefined).map(({ title, slug }) => ({ title, slug })),
+    },
+  }))
+}
+
+const buildAssets = async (): Promise<InventoryEntry[]> => {
+  const { assets } = await client.AssetsInventory()
+
+  return assets.filter(isDefined).map((asset) => ({
+    ...getBase('asset', {
+      ...asset,
+      path: `/dokumenty/${asset.slug}`,
+      summary: getFirstNonEmpty(asset.description),
+      addedAt: asset.customPublishedAt ?? asset.publishedAt,
+      modifiedAt: asset.updatedAt,
+    }),
+    asset: getTypeData({ category: getCategory(asset.assetCategory) }),
+  }))
+}
+
+const buildRegulations = async (): Promise<InventoryEntry[]> => {
+  const { regulations } = await client.RegulationsInventory()
+
+  return regulations.filter(isDefined).map((regulation) => {
+    // Cancelled either directly, or through an amendee that got cancelled - same rule as getRegulationMetadata.ts.
+    const cancellation =
+      regulation.cancellation ??
+      regulation.amending.filter(isDefined).find((amendee) => isDefined(amendee.cancellation))
+        ?.cancellation
+
+    return {
+      ...getBase('regulation', {
+        ...regulation,
+        path: `/vzn/${regulation.slug}`,
+        title: getFirstNonEmpty(regulation.titleText, regulation.fullTitle) ?? regulation.regNumber,
+        summary: getFirstNonEmpty(regulation.fullTitle),
+        addedAt: regulation.publishedAt,
+        modifiedAt: regulation.updatedAt,
+      }),
+      regulation: {
+        regNumber: regulation.regNumber,
+        category: regulation.category,
+        validity: {
+          isValid: !cancellation,
+          effectiveFrom: getIsoDate(regulation.effectiveFrom),
+          effectiveUntil: getIsoDate(cancellation?.effectiveFrom),
+          cancelledBy: cancellation
+            ? {
+                regNumber: cancellation.regNumber,
+                url: getUrl(`/vzn/${cancellation.slug}`),
+              }
+            : null,
+        },
+      },
+    }
+  })
+}
+
+const buildInbaReleases = async (): Promise<InventoryEntry[]> => {
+  const { inbaReleases } = await client.InbaReleasesInventory()
+
+  return inbaReleases.filter(isDefined).map((inbaRelease) =>
+    getBase('inba-release', {
+      ...inbaRelease,
+      path: `/inba/vydania/${inbaRelease.slug}`,
+      summary: getFirstNonEmpty(inbaRelease.perex),
+      addedAt: inbaRelease.releaseDate ?? inbaRelease.publishedAt,
+      modifiedAt: inbaRelease.updatedAt,
+    }),
+  )
+}
+
+const buildUrbanStudies = async (): Promise<InventoryEntry[]> => {
+  const { urbanStudies } = await client.UrbanStudiesInventory()
+
+  return urbanStudies.filter(isDefined).map((urbanStudy) => ({
+    ...getBase('urban-study', {
+      ...urbanStudy,
+      path: `/uzemne-studie/${urbanStudy.slug}`,
+      addedAt: urbanStudy.customPublishedAt ?? urbanStudy.publishedAt,
+      modifiedAt: urbanStudy.updatedAt,
+    }),
+    'urban-study': getTypeData({
+      year: urbanStudy.year ?? undefined,
+      category: getCategory(urbanStudy.urbanStudyCategory),
+      state: getCategory(urbanStudy.urbanStudyState),
+    }),
+  }))
+}
+
+/**
+ * Builds the inventory of everything on the website that has its own url. Published content only - the Strapi GraphQL
+ * api returns published documents by default.
+ */
+export const buildInventory = async (): Promise<InventoryEntry[]> => {
+  const [pages, articles, assets, regulations, inbaReleases, urbanStudies] = await Promise.all([
+    buildPages(),
+    buildArticles(),
+    buildAssets(),
+    buildRegulations(),
+    buildInbaReleases(),
+    buildUrbanStudies(),
+  ])
+
+  return [...pages, ...articles, ...assets, ...regulations, ...inbaReleases, ...urbanStudies].sort(
+    (a, b) => (b.modifiedAt ?? '').localeCompare(a.modifiedAt ?? ''),
+  )
+}

--- a/next/src/services/content-inventory/snapshotCache.ts
+++ b/next/src/services/content-inventory/snapshotCache.ts
@@ -1,0 +1,48 @@
+import { buildInventory } from './buildInventory'
+import { InventoryEntry } from './types'
+
+const SNAPSHOT_TTL_MS = 10 * 60 * 1000 // 10 min
+
+type Snapshot = {
+  builtAt: number
+  entries: InventoryEntry[]
+}
+
+/**
+ * Only the whole snapshot is cached, never per-query responses - a public endpoint must not let anyone grow the cache
+ * by varying query parameters. Filtering and pagination are applied to this array per request.
+ *
+ * The app runs as a long-lived node server (`output: 'standalone'`), so module state survives between requests. Next's
+ * own data cache (`unstable_cache`, `"use cache"`, `revalidateTag`) is app router only and not available here.
+ */
+let snapshot: Snapshot | null = null
+
+/** Set while a build is running, so concurrent requests share one Strapi round trip instead of starting their own. */
+let inFlight: Promise<Snapshot> | null = null
+
+export const getInventorySnapshot = (): Promise<Snapshot> => {
+  if (snapshot && Date.now() - snapshot.builtAt < SNAPSHOT_TTL_MS) {
+    return Promise.resolve(snapshot)
+  }
+
+  if (inFlight) {
+    return inFlight
+  }
+
+  inFlight = buildInventory()
+    .then((entries) => {
+      snapshot = { builtAt: Date.now(), entries }
+
+      return snapshot
+    })
+    .finally(() => {
+      inFlight = null
+    })
+
+  return inFlight
+}
+
+/** Not used yet - call it from the Strapi revalidate webhook if the ttl ever turns out to be too coarse. */
+export const clearInventorySnapshot = () => {
+  snapshot = null
+}

--- a/next/src/services/content-inventory/types.ts
+++ b/next/src/services/content-inventory/types.ts
@@ -1,0 +1,92 @@
+export const inventoryTypes = [
+  'page',
+  'article',
+  'asset',
+  'regulation',
+  'inba-release',
+  'urban-study',
+] as const
+
+export type InventoryType = (typeof inventoryTypes)[number]
+
+export type InventoryCategory = { title: string; slug: string }
+
+/**
+ * Fields shared by every content type. Anything type specific lives under the `[type]` key of the entry, the same way
+ * documents are wrapped in the shared Meilisearch index.
+ */
+export type InventoryEntryBase = {
+  /** Unique key, `${type}:${documentId}:${locale}` - Strapi shares documentId across locales. */
+  id: string
+  /** Absolute, locale prefixed. Null only for content whose host page could not be resolved. */
+  url: string | null
+  locale: string
+  /** False for content types that exist only once in Strapi (asset, regulation, inba-release, urban-study). */
+  isLocalized: boolean
+  title: string
+  /** First non-empty of perex / subtext / description. */
+  summary?: string
+  /**
+   * When the content was added, i.e. first published. Editors can override the publication date on some content types,
+   * so this is the first non-empty of the type's own date (addedAt, customPublishedAt, releaseDate) and Strapi's
+   * publishedAt.
+   */
+  addedAt: string | null
+  /** When the last change was published. */
+  modifiedAt: string | null
+}
+
+export type PageInventoryData = {
+  metaDescription?: string
+  keywords?: string
+}
+
+export type ArticleInventoryData = {
+  category?: InventoryCategory
+  tags: { title: string; slug: string }[]
+}
+
+export type AssetInventoryData = {
+  category?: InventoryCategory
+}
+
+export type RegulationInventoryData = {
+  regNumber: string
+  /** Strapi enum key, e.g. `pomenovanieUlic` - unlike other types this is not a relation, so it has no title. */
+  category: string
+  validity: {
+    isValid: boolean
+    effectiveFrom: string | null
+    effectiveUntil: string | null
+    cancelledBy: { regNumber: string; url: string } | null
+  }
+}
+
+export type UrbanStudyInventoryData = {
+  year?: string
+  category?: InventoryCategory
+  state?: InventoryCategory
+}
+
+/** Each content type carries only its own data - `inba-release` has none beyond the shared fields. */
+export type InventoryEntry =
+  | (InventoryEntryBase & { type: 'page'; page?: PageInventoryData })
+  | (InventoryEntryBase & { type: 'article'; article?: ArticleInventoryData })
+  | (InventoryEntryBase & { type: 'asset'; asset?: AssetInventoryData })
+  | (InventoryEntryBase & { type: 'regulation'; regulation: RegulationInventoryData })
+  | (InventoryEntryBase & { type: 'inba-release' })
+  | (InventoryEntryBase & { type: 'urban-study'; 'urban-study'?: UrbanStudyInventoryData })
+
+/** Reduced entry returned for `?fields=url`, meant for cheap diffing (including detecting removals). */
+export type InventoryUrlEntry = Pick<InventoryEntryBase, 'id' | 'url' | 'modifiedAt'>
+
+export type InventoryResponse = {
+  version: number
+  generatedAt: string
+  /** Number of entries matching the filters, across all pages. */
+  totalItems: number
+  page: number
+  pageSize: number
+  pageCount: number
+  items: (InventoryEntry | InventoryUrlEntry)[]
+}

--- a/next/src/services/graphql/index.ts
+++ b/next/src/services/graphql/index.ts
@@ -7611,6 +7611,72 @@ export type Dev_AllArticlesQuery = {
   } | null>
 }
 
+export type ArticleInventoryEntityFragment = {
+  __typename: 'Article'
+  perex?: string | null
+  addedAt: any
+  updatedAt?: any | null
+  documentId: string
+  slug: string
+  title: string
+  locale?: string | null
+  articleCategory?: {
+    __typename?: 'ArticleCategory'
+    documentId: string
+    title: string
+    slug: string
+  } | null
+  tags: Array<{
+    __typename?: 'Tag'
+    documentId: string
+    title: string
+    slug: string
+    pageCategory?: {
+      __typename?: 'PageCategory'
+      documentId: string
+      title?: string | null
+      color?: Enum_Pagecategory_Color | null
+    } | null
+  } | null>
+}
+
+export type ArticlesInventoryQueryVariables = Exact<{
+  limit?: InputMaybe<Scalars['Int']['input']>
+  locale?: InputMaybe<Scalars['I18NLocaleCode']['input']>
+}>
+
+export type ArticlesInventoryQuery = {
+  __typename?: 'Query'
+  articles: Array<{
+    __typename: 'Article'
+    perex?: string | null
+    addedAt: any
+    updatedAt?: any | null
+    documentId: string
+    slug: string
+    title: string
+    locale?: string | null
+    articleCategory?: {
+      __typename?: 'ArticleCategory'
+      documentId: string
+      title: string
+      slug: string
+    } | null
+    tags: Array<{
+      __typename?: 'Tag'
+      documentId: string
+      title: string
+      slug: string
+      pageCategory?: {
+        __typename?: 'PageCategory'
+        documentId: string
+        title?: string | null
+        color?: Enum_Pagecategory_Color | null
+      } | null
+    } | null>
+  } | null>
+}
+
 export type AssetCategoryEntityFragment = {
   __typename?: 'AssetCategory'
   documentId: string
@@ -7702,6 +7768,47 @@ export type AssetCategoriesQuery = {
     documentId: string
     title: string
     slug: string
+  } | null>
+}
+
+export type AssetInventoryEntityFragment = {
+  __typename: 'Asset'
+  updatedAt?: any | null
+  publishedAt?: any | null
+  customPublishedAt?: any | null
+  description?: string | null
+  documentId: string
+  slug: string
+  title: string
+  assetCategory?: {
+    __typename?: 'AssetCategory'
+    documentId: string
+    title: string
+    slug: string
+  } | null
+}
+
+export type AssetsInventoryQueryVariables = Exact<{
+  limit?: InputMaybe<Scalars['Int']['input']>
+}>
+
+export type AssetsInventoryQuery = {
+  __typename?: 'Query'
+  assets: Array<{
+    __typename: 'Asset'
+    updatedAt?: any | null
+    publishedAt?: any | null
+    customPublishedAt?: any | null
+    description?: string | null
+    documentId: string
+    slug: string
+    title: string
+    assetCategory?: {
+      __typename?: 'AssetCategory'
+      documentId: string
+      title: string
+      slug: string
+    } | null
   } | null>
 }
 
@@ -10892,6 +10999,35 @@ export type LatestInbaReleaseQuery = {
   } | null>
 }
 
+export type InbaReleaseInventoryEntityFragment = {
+  __typename?: 'InbaRelease'
+  perex?: string | null
+  releaseDate: any
+  updatedAt?: any | null
+  publishedAt?: any | null
+  documentId: string
+  title: string
+  slug: string
+}
+
+export type InbaReleasesInventoryQueryVariables = Exact<{
+  limit?: InputMaybe<Scalars['Int']['input']>
+}>
+
+export type InbaReleasesInventoryQuery = {
+  __typename?: 'Query'
+  inbaReleases: Array<{
+    __typename?: 'InbaRelease'
+    perex?: string | null
+    releaseDate: any
+    updatedAt?: any | null
+    publishedAt?: any | null
+    documentId: string
+    title: string
+    slug: string
+  } | null>
+}
+
 export type PageCategoryEntityFragment = {
   __typename?: 'PageCategory'
   documentId: string
@@ -12075,11 +12211,11 @@ export type PageEntityFragment = {
           } | null>
           amendments: Array<{
             __typename?: 'Regulation'
+            isFullTextRegulation: boolean
             documentId: string
             regNumber: string
             slug: string
             effectiveFrom: any
-            isFullTextRegulation: boolean
             attachments: Array<{
               __typename?: 'UploadFile'
               documentId: string
@@ -12109,6 +12245,7 @@ export type PageEntityFragment = {
               documentId: string
               regNumber: string
               slug: string
+              effectiveFrom: any
               cancellation?: {
                 __typename?: 'Regulation'
                 documentId: string
@@ -13676,11 +13813,11 @@ export type PageByPathQuery = {
             } | null>
             amendments: Array<{
               __typename?: 'Regulation'
+              isFullTextRegulation: boolean
               documentId: string
               regNumber: string
               slug: string
               effectiveFrom: any
-              isFullTextRegulation: boolean
               attachments: Array<{
                 __typename?: 'UploadFile'
                 documentId: string
@@ -13710,6 +13847,7 @@ export type PageByPathQuery = {
                 documentId: string
                 regNumber: string
                 slug: string
+                effectiveFrom: any
                 cancellation?: {
                   __typename?: 'Regulation'
                   documentId: string
@@ -15288,11 +15426,11 @@ export type Dev_AllPagesQuery = {
             } | null>
             amendments: Array<{
               __typename?: 'Regulation'
+              isFullTextRegulation: boolean
               documentId: string
               regNumber: string
               slug: string
               effectiveFrom: any
-              isFullTextRegulation: boolean
               attachments: Array<{
                 __typename?: 'UploadFile'
                 documentId: string
@@ -15322,6 +15460,7 @@ export type Dev_AllPagesQuery = {
                 documentId: string
                 regNumber: string
                 slug: string
+                effectiveFrom: any
                 cancellation?: {
                   __typename?: 'Regulation'
                   documentId: string
@@ -15801,6 +15940,40 @@ export type UpdatePageMutation = {
   updatePage?: { __typename?: 'Page'; documentId: string } | null
 }
 
+export type PageInventoryEntityFragment = {
+  __typename?: 'Page'
+  updatedAt?: any | null
+  publishedAt?: any | null
+  subtext?: string | null
+  metaDescription?: string | null
+  keywords?: string | null
+  documentId: string
+  title: string
+  locale?: string | null
+  path?: string | null
+}
+
+export type PagesInventoryQueryVariables = Exact<{
+  limit?: InputMaybe<Scalars['Int']['input']>
+  locale?: InputMaybe<Scalars['I18NLocaleCode']['input']>
+}>
+
+export type PagesInventoryQuery = {
+  __typename?: 'Query'
+  pages: Array<{
+    __typename?: 'Page'
+    updatedAt?: any | null
+    publishedAt?: any | null
+    subtext?: string | null
+    metaDescription?: string | null
+    keywords?: string | null
+    documentId: string
+    title: string
+    locale?: string | null
+    path?: string | null
+  } | null>
+}
+
 export type RegulationsStaticPathsQueryVariables = Exact<{
   limit?: InputMaybe<Scalars['Int']['input']>
 }>
@@ -15848,11 +16021,11 @@ export type RegulationBySlugQuery = {
     } | null>
     amendments: Array<{
       __typename?: 'Regulation'
+      isFullTextRegulation: boolean
       documentId: string
       regNumber: string
       slug: string
       effectiveFrom: any
-      isFullTextRegulation: boolean
       attachments: Array<{
         __typename?: 'UploadFile'
         documentId: string
@@ -15882,6 +16055,7 @@ export type RegulationBySlugQuery = {
         documentId: string
         regNumber: string
         slug: string
+        effectiveFrom: any
         cancellation?: {
           __typename?: 'Regulation'
           documentId: string
@@ -15913,6 +16087,14 @@ export type RegulationSlugEntityFragment = {
   documentId: string
   slug: string
   titleText?: string | null
+}
+
+export type RegulationRelationEntityFragment = {
+  __typename?: 'Regulation'
+  documentId: string
+  regNumber: string
+  slug: string
+  effectiveFrom: any
 }
 
 export type RegulationEntityFragment = {
@@ -15947,11 +16129,11 @@ export type RegulationEntityFragment = {
   } | null>
   amendments: Array<{
     __typename?: 'Regulation'
+    isFullTextRegulation: boolean
     documentId: string
     regNumber: string
     slug: string
     effectiveFrom: any
-    isFullTextRegulation: boolean
     attachments: Array<{
       __typename?: 'UploadFile'
       documentId: string
@@ -15981,6 +16163,7 @@ export type RegulationEntityFragment = {
       documentId: string
       regNumber: string
       slug: string
+      effectiveFrom: any
       cancellation?: {
         __typename?: 'Regulation'
         documentId: string
@@ -16003,6 +16186,73 @@ export type RegulationEntityFragment = {
     regNumber: string
     slug: string
     effectiveFrom: any
+  } | null>
+}
+
+export type RegulationInventoryEntityFragment = {
+  __typename?: 'Regulation'
+  fullTitle: string
+  category: Enum_Regulation_Category
+  updatedAt?: any | null
+  publishedAt?: any | null
+  documentId: string
+  slug: string
+  titleText?: string | null
+  regNumber: string
+  effectiveFrom: any
+  cancellation?: {
+    __typename?: 'Regulation'
+    documentId: string
+    regNumber: string
+    slug: string
+    effectiveFrom: any
+  } | null
+  amending: Array<{
+    __typename?: 'Regulation'
+    cancellation?: {
+      __typename?: 'Regulation'
+      documentId: string
+      regNumber: string
+      slug: string
+      effectiveFrom: any
+    } | null
+  } | null>
+}
+
+export type RegulationsInventoryQueryVariables = Exact<{
+  limit?: InputMaybe<Scalars['Int']['input']>
+}>
+
+export type RegulationsInventoryQuery = {
+  __typename?: 'Query'
+  regulations: Array<{
+    __typename?: 'Regulation'
+    fullTitle: string
+    category: Enum_Regulation_Category
+    updatedAt?: any | null
+    publishedAt?: any | null
+    documentId: string
+    slug: string
+    titleText?: string | null
+    regNumber: string
+    effectiveFrom: any
+    cancellation?: {
+      __typename?: 'Regulation'
+      documentId: string
+      regNumber: string
+      slug: string
+      effectiveFrom: any
+    } | null
+    amending: Array<{
+      __typename?: 'Regulation'
+      cancellation?: {
+        __typename?: 'Regulation'
+        documentId: string
+        regNumber: string
+        slug: string
+        effectiveFrom: any
+      } | null
+    } | null>
   } | null>
 }
 
@@ -16851,11 +17101,11 @@ export type RegulationsSectionFragment = {
     } | null>
     amendments: Array<{
       __typename?: 'Regulation'
+      isFullTextRegulation: boolean
       documentId: string
       regNumber: string
       slug: string
       effectiveFrom: any
-      isFullTextRegulation: boolean
       attachments: Array<{
         __typename?: 'UploadFile'
         documentId: string
@@ -16885,6 +17135,7 @@ export type RegulationsSectionFragment = {
         documentId: string
         regNumber: string
         slug: string
+        effectiveFrom: any
         cancellation?: {
           __typename?: 'Regulation'
           documentId: string
@@ -18602,11 +18853,11 @@ type Sections_ComponentSectionsRegulations_Fragment = {
     } | null>
     amendments: Array<{
       __typename?: 'Regulation'
+      isFullTextRegulation: boolean
       documentId: string
       regNumber: string
       slug: string
       effectiveFrom: any
-      isFullTextRegulation: boolean
       attachments: Array<{
         __typename?: 'UploadFile'
         documentId: string
@@ -18636,6 +18887,7 @@ type Sections_ComponentSectionsRegulations_Fragment = {
         documentId: string
         regNumber: string
         slug: string
+        effectiveFrom: any
         cancellation?: {
           __typename?: 'Regulation'
           documentId: string
@@ -19306,11 +19558,11 @@ export type UrbanStudyEntityFragment = {
     } | null>
     amendments: Array<{
       __typename?: 'Regulation'
+      isFullTextRegulation: boolean
       documentId: string
       regNumber: string
       slug: string
       effectiveFrom: any
-      isFullTextRegulation: boolean
       attachments: Array<{
         __typename?: 'UploadFile'
         documentId: string
@@ -19340,6 +19592,7 @@ export type UrbanStudyEntityFragment = {
         documentId: string
         regNumber: string
         slug: string
+        effectiveFrom: any
         cancellation?: {
           __typename?: 'Regulation'
           documentId: string
@@ -19475,11 +19728,11 @@ export type UrbanStudyBySlugQuery = {
       } | null>
       amendments: Array<{
         __typename?: 'Regulation'
+        isFullTextRegulation: boolean
         documentId: string
         regNumber: string
         slug: string
         effectiveFrom: any
-        isFullTextRegulation: boolean
         attachments: Array<{
           __typename?: 'UploadFile'
           documentId: string
@@ -19509,6 +19762,7 @@ export type UrbanStudyBySlugQuery = {
           documentId: string
           regNumber: string
           slug: string
+          effectiveFrom: any
           cancellation?: {
             __typename?: 'Regulation'
             documentId: string
@@ -19576,6 +19830,59 @@ export type UrbanStudiesStaticPathsQueryVariables = Exact<{
 export type UrbanStudiesStaticPathsQuery = {
   __typename?: 'Query'
   urbanStudies: Array<{ __typename?: 'UrbanStudy'; documentId: string; slug: string } | null>
+}
+
+export type UrbanStudyInventoryEntityFragment = {
+  __typename: 'UrbanStudy'
+  updatedAt?: any | null
+  publishedAt?: any | null
+  customPublishedAt?: any | null
+  year?: string | null
+  documentId: string
+  slug: string
+  title: string
+  urbanStudyCategory?: {
+    __typename?: 'UrbanStudyCategory'
+    documentId: string
+    slug: string
+    title: string
+  } | null
+  urbanStudyState?: {
+    __typename?: 'UrbanStudyState'
+    documentId: string
+    slug: string
+    title: string
+  } | null
+}
+
+export type UrbanStudiesInventoryQueryVariables = Exact<{
+  limit?: InputMaybe<Scalars['Int']['input']>
+}>
+
+export type UrbanStudiesInventoryQuery = {
+  __typename?: 'Query'
+  urbanStudies: Array<{
+    __typename: 'UrbanStudy'
+    updatedAt?: any | null
+    publishedAt?: any | null
+    customPublishedAt?: any | null
+    year?: string | null
+    documentId: string
+    slug: string
+    title: string
+    urbanStudyCategory?: {
+      __typename?: 'UrbanStudyCategory'
+      documentId: string
+      slug: string
+      title: string
+    } | null
+    urbanStudyState?: {
+      __typename?: 'UrbanStudyState'
+      documentId: string
+      slug: string
+      title: string
+    } | null
+  } | null>
 }
 
 export const ArticleSlugEntityFragmentDoc = gql`
@@ -19718,6 +20025,52 @@ export const ArticleEntityFragmentDoc = gql`
   ${InbaReleaseCardEntityFragmentDoc}
   ${AdminGroupSlugEntityFragmentDoc}
 `
+export const ArticleInventoryEntityFragmentDoc = gql`
+  fragment ArticleInventoryEntity on Article {
+    ...ArticleSlugEntity
+    perex
+    addedAt
+    updatedAt
+    articleCategory {
+      ...ArticleCategoryEntity
+    }
+    tags {
+      ...TagEntity
+    }
+  }
+  ${ArticleSlugEntityFragmentDoc}
+  ${ArticleCategoryEntityFragmentDoc}
+  ${TagEntityFragmentDoc}
+`
+export const AssetSlugEntityFragmentDoc = gql`
+  fragment AssetSlugEntity on Asset {
+    __typename
+    documentId
+    slug
+    title
+  }
+`
+export const AssetCategoryEntityFragmentDoc = gql`
+  fragment AssetCategoryEntity on AssetCategory {
+    documentId
+    title
+    slug
+  }
+`
+export const AssetInventoryEntityFragmentDoc = gql`
+  fragment AssetInventoryEntity on Asset {
+    ...AssetSlugEntity
+    updatedAt
+    publishedAt
+    customPublishedAt
+    description
+    assetCategory {
+      ...AssetCategoryEntity
+    }
+  }
+  ${AssetSlugEntityFragmentDoc}
+  ${AssetCategoryEntityFragmentDoc}
+`
 export const UploadFileFragmentDoc = gql`
   fragment UploadFile on UploadFile {
     documentId
@@ -19736,14 +20089,6 @@ export const RegulationSlugEntityFragmentDoc = gql`
     documentId
     slug
     titleText
-  }
-`
-export const AssetSlugEntityFragmentDoc = gql`
-  fragment AssetSlugEntity on Asset {
-    __typename
-    documentId
-    slug
-    title
   }
 `
 export const CommonLinkFragmentDoc = gql`
@@ -20112,6 +20457,16 @@ export const InbaReleaseHomepageInbaCardEntityFragmentDoc = gql`
     }
   }
   ${UploadImageEntityFragmentDoc}
+`
+export const InbaReleaseInventoryEntityFragmentDoc = gql`
+  fragment InbaReleaseInventoryEntity on InbaRelease {
+    ...InbaReleaseSlugEntity
+    perex
+    releaseDate
+    updatedAt
+    publishedAt
+  }
+  ${InbaReleaseSlugEntityFragmentDoc}
 `
 export const PageSubnavigationEntityFragmentDoc = gql`
   fragment PageSubnavigationEntity on Page {
@@ -20579,6 +20934,14 @@ export const ContactsSectionFragmentDoc = gql`
   ${ContactPersonCardBlockFragmentDoc}
   ${ContactDirectionsCardBlockFragmentDoc}
 `
+export const RegulationRelationEntityFragmentDoc = gql`
+  fragment RegulationRelationEntity on Regulation {
+    documentId
+    regNumber
+    slug
+    effectiveFrom
+  }
+`
 export const RegulationEntityFragmentDoc = gql`
   fragment RegulationEntity on Regulation {
     ...RegulationSlugEntity
@@ -20594,53 +20957,34 @@ export const RegulationEntityFragmentDoc = gql`
       ...UploadFileEntity
     }
     amendments {
-      documentId
-      regNumber
-      slug
-      effectiveFrom
+      ...RegulationRelationEntity
       isFullTextRegulation
       attachments {
         ...UploadFileEntity
       }
     }
     amending {
-      documentId
-      regNumber
-      slug
-      effectiveFrom
+      ...RegulationRelationEntity
       cancellation {
-        documentId
-        regNumber
-        slug
-        effectiveFrom
+        ...RegulationRelationEntity
       }
       amending {
-        documentId
-        regNumber
-        slug
+        ...RegulationRelationEntity
         cancellation {
-          documentId
-          regNumber
-          slug
-          effectiveFrom
+          ...RegulationRelationEntity
         }
       }
     }
     cancellation {
-      documentId
-      regNumber
-      slug
-      effectiveFrom
+      ...RegulationRelationEntity
     }
     cancelling {
-      documentId
-      regNumber
-      slug
-      effectiveFrom
+      ...RegulationRelationEntity
     }
   }
   ${RegulationSlugEntityFragmentDoc}
   ${UploadFileEntityFragmentDoc}
+  ${RegulationRelationEntityFragmentDoc}
 `
 export const RegulationsSectionFragmentDoc = gql`
   fragment RegulationsSection on ComponentSectionsRegulations {
@@ -20709,13 +21053,6 @@ export const PartnersSectionFragmentDoc = gql`
     titleLevelPartnersSection: titleLevel
   }
   ${PartnerBlockFragmentDoc}
-`
-export const AssetCategoryEntityFragmentDoc = gql`
-  fragment AssetCategoryEntity on AssetCategory {
-    documentId
-    title
-    slug
-  }
 `
 export const AssetEntityFragmentDoc = gql`
   fragment AssetEntity on Asset {
@@ -21213,6 +21550,37 @@ export const PageEntityFragmentDoc = gql`
   ${TagEntityFragmentDoc}
   ${PageParentPagesFragmentDoc}
 `
+export const PageInventoryEntityFragmentDoc = gql`
+  fragment PageInventoryEntity on Page {
+    ...PageSlugEntity
+    updatedAt
+    publishedAt
+    subtext
+    metaDescription
+    keywords
+  }
+  ${PageSlugEntityFragmentDoc}
+`
+export const RegulationInventoryEntityFragmentDoc = gql`
+  fragment RegulationInventoryEntity on Regulation {
+    ...RegulationSlugEntity
+    ...RegulationRelationEntity
+    fullTitle
+    category
+    updatedAt
+    publishedAt
+    cancellation {
+      ...RegulationRelationEntity
+    }
+    amending {
+      cancellation {
+        ...RegulationRelationEntity
+      }
+    }
+  }
+  ${RegulationSlugEntityFragmentDoc}
+  ${RegulationRelationEntityFragmentDoc}
+`
 export const UrbanStudyPartItemFragmentDoc = gql`
   fragment UrbanStudyPartItem on ComponentBlocksUrbanStudyPartItem {
     id
@@ -21261,6 +21629,24 @@ export const UrbanStudyEntityFragmentDoc = gql`
   ${UrbanStudyPartFragmentDoc}
   ${RegulationEntityFragmentDoc}
   ${CommonLinkFragmentDoc}
+`
+export const UrbanStudyInventoryEntityFragmentDoc = gql`
+  fragment UrbanStudyInventoryEntity on UrbanStudy {
+    ...UrbanStudySlugEntity
+    updatedAt
+    publishedAt
+    customPublishedAt
+    year
+    urbanStudyCategory {
+      ...UrbanStudyCategoryEntity
+    }
+    urbanStudyState {
+      ...UrbanStudyStateEntity
+    }
+  }
+  ${UrbanStudySlugEntityFragmentDoc}
+  ${UrbanStudyCategoryEntityFragmentDoc}
+  ${UrbanStudyStateEntityFragmentDoc}
 `
 export const AdminGroupsDocument = gql`
   query AdminGroups($limit: Int = -1, $sort: [String] = ["title"]) {
@@ -21365,6 +21751,14 @@ export const Dev_AllArticlesDocument = gql`
   }
   ${ArticleEntityFragmentDoc}
 `
+export const ArticlesInventoryDocument = gql`
+  query ArticlesInventory($limit: Int = -1, $locale: I18NLocaleCode = "*") {
+    articles(locale: $locale, sort: "updatedAt:desc", pagination: { limit: $limit }) {
+      ...ArticleInventoryEntity
+    }
+  }
+  ${ArticleInventoryEntityFragmentDoc}
+`
 export const AssetsStaticPathsDocument = gql`
   query AssetsStaticPaths($limit: Int = -1) {
     assets(sort: "updatedAt:desc", pagination: { limit: $limit }) {
@@ -21388,6 +21782,14 @@ export const AssetCategoriesDocument = gql`
     }
   }
   ${AssetCategoryEntityFragmentDoc}
+`
+export const AssetsInventoryDocument = gql`
+  query AssetsInventory($limit: Int = -1) {
+    assets(sort: "updatedAt:desc", pagination: { limit: $limit }) {
+      ...AssetInventoryEntity
+    }
+  }
+  ${AssetInventoryEntityFragmentDoc}
 `
 export const FaqCategoriesDocument = gql`
   query FaqCategories($locale: I18NLocaleCode, $sort: [String] = ["title"]) {
@@ -21585,6 +21987,14 @@ export const LatestInbaReleaseDocument = gql`
   }
   ${InbaReleaseEntityFragmentDoc}
 `
+export const InbaReleasesInventoryDocument = gql`
+  query InbaReleasesInventory($limit: Int = -1) {
+    inbaReleases(sort: "updatedAt:desc", pagination: { limit: $limit }) {
+      ...InbaReleaseInventoryEntity
+    }
+  }
+  ${InbaReleaseInventoryEntityFragmentDoc}
+`
 export const PageCategoriesDocument = gql`
   query PageCategories($locale: I18NLocaleCode) {
     pageCategories(pagination: { limit: -1 }, locale: $locale) {
@@ -21669,6 +22079,14 @@ export const UpdatePageDocument = gql`
     }
   }
 `
+export const PagesInventoryDocument = gql`
+  query PagesInventory($limit: Int = -1, $locale: I18NLocaleCode = "*") {
+    pages(locale: $locale, sort: "updatedAt:desc", pagination: { limit: $limit }) {
+      ...PageInventoryEntity
+    }
+  }
+  ${PageInventoryEntityFragmentDoc}
+`
 export const RegulationsStaticPathsDocument = gql`
   query RegulationsStaticPaths($limit: Int = -1) {
     regulations(sort: "updatedAt:desc", pagination: { limit: $limit }) {
@@ -21684,6 +22102,14 @@ export const RegulationBySlugDocument = gql`
     }
   }
   ${RegulationEntityFragmentDoc}
+`
+export const RegulationsInventoryDocument = gql`
+  query RegulationsInventory($limit: Int = -1) {
+    regulations(sort: "updatedAt:desc", pagination: { limit: $limit }) {
+      ...RegulationInventoryEntity
+    }
+  }
+  ${RegulationInventoryEntityFragmentDoc}
 `
 export const TagsDocument = gql`
   query Tags($locale: I18NLocaleCode, $sort: [String] = ["title"]) {
@@ -21708,6 +22134,14 @@ export const UrbanStudiesStaticPathsDocument = gql`
       slug
     }
   }
+`
+export const UrbanStudiesInventoryDocument = gql`
+  query UrbanStudiesInventory($limit: Int = -1) {
+    urbanStudies(sort: "updatedAt:desc", pagination: { limit: $limit }) {
+      ...UrbanStudyInventoryEntity
+    }
+  }
+  ${UrbanStudyInventoryEntityFragmentDoc}
 `
 
 export type SdkFunctionWrapper = <T>(
@@ -21843,6 +22277,21 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
         variables,
       )
     },
+    ArticlesInventory(
+      variables?: ArticlesInventoryQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<ArticlesInventoryQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<ArticlesInventoryQuery>(ArticlesInventoryDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'ArticlesInventory',
+        'query',
+        variables,
+      )
+    },
     AssetsStaticPaths(
       variables?: AssetsStaticPathsQueryVariables,
       requestHeaders?: GraphQLClientRequestHeaders,
@@ -21884,6 +22333,21 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
             ...wrappedRequestHeaders,
           }),
         'AssetCategories',
+        'query',
+        variables,
+      )
+    },
+    AssetsInventory(
+      variables?: AssetsInventoryQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<AssetsInventoryQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<AssetsInventoryQuery>(AssetsInventoryDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'AssetsInventory',
         'query',
         variables,
       )
@@ -22039,6 +22503,21 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
         variables,
       )
     },
+    InbaReleasesInventory(
+      variables?: InbaReleasesInventoryQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<InbaReleasesInventoryQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<InbaReleasesInventoryQuery>(InbaReleasesInventoryDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'InbaReleasesInventory',
+        'query',
+        variables,
+      )
+    },
     PageCategories(
       variables?: PageCategoriesQueryVariables,
       requestHeaders?: GraphQLClientRequestHeaders,
@@ -22145,6 +22624,21 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
         variables,
       )
     },
+    PagesInventory(
+      variables?: PagesInventoryQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<PagesInventoryQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<PagesInventoryQuery>(PagesInventoryDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'PagesInventory',
+        'query',
+        variables,
+      )
+    },
     RegulationsStaticPaths(
       variables?: RegulationsStaticPathsQueryVariables,
       requestHeaders?: GraphQLClientRequestHeaders,
@@ -22171,6 +22665,21 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
             ...wrappedRequestHeaders,
           }),
         'RegulationBySlug',
+        'query',
+        variables,
+      )
+    },
+    RegulationsInventory(
+      variables?: RegulationsInventoryQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<RegulationsInventoryQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<RegulationsInventoryQuery>(RegulationsInventoryDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'RegulationsInventory',
         'query',
         variables,
       )
@@ -22216,6 +22725,21 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
             ...wrappedRequestHeaders,
           }),
         'UrbanStudiesStaticPaths',
+        'query',
+        variables,
+      )
+    },
+    UrbanStudiesInventory(
+      variables?: UrbanStudiesInventoryQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<UrbanStudiesInventoryQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<UrbanStudiesInventoryQuery>(UrbanStudiesInventoryDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'UrbanStudiesInventory',
         'query',
         variables,
       )

--- a/next/src/services/graphql/queries/Articles.graphql
+++ b/next/src/services/graphql/queries/Articles.graphql
@@ -130,3 +130,23 @@ query Dev_AllArticles(
     ...ArticleEntity
   }
 }
+
+# Used by the /api/content-inventory endpoint.
+fragment ArticleInventoryEntity on Article {
+  ...ArticleSlugEntity
+  perex
+  addedAt
+  updatedAt
+  articleCategory {
+    ...ArticleCategoryEntity
+  }
+  tags {
+    ...TagEntity
+  }
+}
+
+query ArticlesInventory($limit: Int = -1, $locale: I18NLocaleCode = "*") {
+  articles(locale: $locale, sort: "updatedAt:desc", pagination: { limit: $limit }) {
+    ...ArticleInventoryEntity
+  }
+}

--- a/next/src/services/graphql/queries/Assets.graphql
+++ b/next/src/services/graphql/queries/Assets.graphql
@@ -42,3 +42,21 @@ query AssetCategories {
     ...AssetCategoryEntity
   }
 }
+
+# Used by the /api/content-inventory endpoint.
+fragment AssetInventoryEntity on Asset {
+  ...AssetSlugEntity
+  updatedAt
+  publishedAt
+  customPublishedAt
+  description
+  assetCategory {
+    ...AssetCategoryEntity
+  }
+}
+
+query AssetsInventory($limit: Int = -1) {
+  assets(sort: "updatedAt:desc", pagination: { limit: $limit }) {
+    ...AssetInventoryEntity
+  }
+}

--- a/next/src/services/graphql/queries/InbaReleases.graphql
+++ b/next/src/services/graphql/queries/InbaReleases.graphql
@@ -73,3 +73,18 @@ query LatestInbaRelease {
     ...InbaReleaseEntity
   }
 }
+
+# Used by the /api/content-inventory endpoint.
+fragment InbaReleaseInventoryEntity on InbaRelease {
+  ...InbaReleaseSlugEntity
+  perex
+  releaseDate
+  updatedAt
+  publishedAt
+}
+
+query InbaReleasesInventory($limit: Int = -1) {
+  inbaReleases(sort: "updatedAt:desc", pagination: { limit: $limit }) {
+    ...InbaReleaseInventoryEntity
+  }
+}

--- a/next/src/services/graphql/queries/Pages.graphql
+++ b/next/src/services/graphql/queries/Pages.graphql
@@ -145,3 +145,19 @@ mutation updatePage($documentId: ID!, $locale: I18NLocaleCode, $pageInput: PageI
     documentId
   }
 }
+
+# Used by the /api/content-inventory endpoint.
+fragment PageInventoryEntity on Page {
+  ...PageSlugEntity
+  updatedAt
+  publishedAt
+  subtext
+  metaDescription
+  keywords
+}
+
+query PagesInventory($limit: Int = -1, $locale: I18NLocaleCode = "*") {
+  pages(locale: $locale, sort: "updatedAt:desc", pagination: { limit: $limit }) {
+    ...PageInventoryEntity
+  }
+}

--- a/next/src/services/graphql/queries/Regulations.graphql
+++ b/next/src/services/graphql/queries/Regulations.graphql
@@ -17,6 +17,14 @@ fragment RegulationSlugEntity on Regulation {
   titleText
 }
 
+# The shape a regulation is referenced by from another regulation (amendments, cancellations).
+fragment RegulationRelationEntity on Regulation {
+  documentId
+  regNumber
+  slug
+  effectiveFrom
+}
+
 fragment RegulationEntity on Regulation {
   ...RegulationSlugEntity
   regNumber
@@ -31,48 +39,53 @@ fragment RegulationEntity on Regulation {
     ...UploadFileEntity
   }
   amendments {
-    documentId
-    regNumber
-    slug
-    effectiveFrom
+    ...RegulationRelationEntity
     isFullTextRegulation
     attachments {
       ...UploadFileEntity
     }
   }
   amending {
-    documentId
-    regNumber
-    slug
-    effectiveFrom
+    ...RegulationRelationEntity
     cancellation {
-      documentId
-      regNumber
-      slug
-      effectiveFrom
+      ...RegulationRelationEntity
     }
     amending {
-      documentId
-      regNumber
-      slug
+      ...RegulationRelationEntity
       cancellation {
-        documentId
-        regNumber
-        slug
-        effectiveFrom
+        ...RegulationRelationEntity
       }
     }
   }
   cancellation {
-    documentId
-    regNumber
-    slug
-    effectiveFrom
+    ...RegulationRelationEntity
   }
   cancelling {
-    documentId
-    regNumber
-    slug
-    effectiveFrom
+    ...RegulationRelationEntity
+  }
+}
+
+# Used by the /api/content-inventory endpoint. `cancellation` is the regulation cancelling this one, `amending` are
+# the regulations this one amends - a cancelled amendee cancels this one too, see getRegulationMetadata.ts.
+fragment RegulationInventoryEntity on Regulation {
+  ...RegulationSlugEntity
+  ...RegulationRelationEntity
+  fullTitle
+  category
+  updatedAt
+  publishedAt
+  cancellation {
+    ...RegulationRelationEntity
+  }
+  amending {
+    cancellation {
+      ...RegulationRelationEntity
+    }
+  }
+}
+
+query RegulationsInventory($limit: Int = -1) {
+  regulations(sort: "updatedAt:desc", pagination: { limit: $limit }) {
+    ...RegulationInventoryEntity
   }
 }

--- a/next/src/services/graphql/queries/UrbanStudies.graphql
+++ b/next/src/services/graphql/queries/UrbanStudies.graphql
@@ -68,3 +68,24 @@ query UrbanStudiesStaticPaths($limit: Int = -1) {
     slug
   }
 }
+
+# Used by the /api/content-inventory endpoint.
+fragment UrbanStudyInventoryEntity on UrbanStudy {
+  ...UrbanStudySlugEntity
+  updatedAt
+  publishedAt
+  customPublishedAt
+  year
+  urbanStudyCategory {
+    ...UrbanStudyCategoryEntity
+  }
+  urbanStudyState {
+    ...UrbanStudyStateEntity
+  }
+}
+
+query UrbanStudiesInventory($limit: Int = -1) {
+  urbanStudies(sort: "updatedAt:desc", pagination: { limit: $limit }) {
+    ...UrbanStudyInventoryEntity
+  }
+}

--- a/next/tsconfig.json
+++ b/next/tsconfig.json
@@ -2,7 +2,11 @@
   "compilerOptions": {
     "target": "es6",
     "jsx": "react-jsx",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
@@ -23,9 +27,21 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     }
   },
-  "include": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "next-env.d.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.js",
+    "**/*.jsx",
+    "next-env.d.ts",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## What

New public `GET /api/content-inventory` endpoint that lists all published content on bratislava.sk, so the AI chatbot can discover and re-ingest it.

- Covers 6 content types: `page`, `article`, `asset`, `regulation`, `inba-release`, `urban-study`.
- Shared fields per entry (`id`, `url`, `locale`, `title`, `summary`, `addedAt`, `modifiedAt`), with type-specific data nested under the `[type]` key — same wrapping as the shared Meilisearch index.
- `addedAt` unifies the per-type publication dates (`addedAt` / `customPublishedAt` / `releaseDate`), falling back to Strapi's `publishedAt`.
- `modifiedAt` unifies the per-type dates of last changes
- Query params: `modifiedSince` (ISO date, for incremental ingest), `type` (comma-separated), `locale`, `page`/`pageSize`, and `fields=url` for a reduced entry meant for cheap diffing (including detecting removals).
- Invalid params return `400` instead of silently falling back — a mistyped `modifiedSince` would otherwise mean a full re-ingest, and a mistyped `type` a partial one.
- `version` field in the response, bumped whenever the entry shape changes in a breaking way.

## Caching

The whole snapshot is cached in module state for 10 minutes (the app runs as a long-lived node server, `output: 'standalone'`). Only the snapshot is cached, never per-query responses — a public endpoint must not let anyone grow the cache by varying query params. Concurrent requests during a build share one Strapi round trip.

`clearInventorySnapshot()` is exported but unused — hook it into the Strapi revalidate webhook if the TTL turns out to be too coarse.

## Also

- New `*Inventory` GraphQL queries per content type; `next/src/services/graphql/index.ts` is codegen output.
- `next/tsconfig.json` — reformatting plus `.next/types` includes, written by `next dev`.

## Testing

- `/api/content-inventory` — full inventory
- `/api/content-inventory?fields=url&type=article,page`
- `/api/content-inventory?modifiedSince=2026-01-01T00:00:00Z`
- `/api/content-inventory?type=nonsense` → 400
