### PR TITLE
2477 Hide legacy category enum and fix fullTitle usage

### DIFF
--- a/next/src/pages/vzn/[slug].tsx
+++ b/next/src/pages/vzn/[slug].tsx
@@ -83,8 +83,8 @@ const RegulationPage = ({ general, regulation }: RegulationPageProps) => {
     <GeneralContextProvider general={general}>
       <AdminGroupsContextProvider adminGroups={[]}>
         <SeoHead
-          title={`VZN ${regulation.regNumber}`}
-          description={`Všeobecné záväzné nariadenie ${regulation.fullTitle}`}
+          title={`VZN ${regulation.regNumber} ${regulation.titleText}`}
+          description={regulation.fullTitle}
         />
 
         <PageLayout>

--- a/next/src/services/content-inventory/buildInventory.ts
+++ b/next/src/services/content-inventory/buildInventory.ts
@@ -123,8 +123,8 @@ const buildRegulations = async (): Promise<InventoryEntry[]> => {
       ...getBase('regulation', {
         ...regulation,
         path: `/vzn/${regulation.slug}`,
-        title: getFirstNonEmpty(regulation.titleText, regulation.fullTitle) ?? regulation.regNumber,
-        summary: getFirstNonEmpty(regulation.fullTitle),
+        title: `VZN ${regulation.regNumber} ${regulation.titleText}`,
+        summary: regulation.fullTitle,
         addedAt: regulation.publishedAt,
         modifiedAt: regulation.updatedAt,
       }),

--- a/next/src/services/graphql/index.ts
+++ b/next/src/services/graphql/index.ts
@@ -6017,7 +6017,7 @@ export type Regulation = {
   cancellation?: Maybe<Regulation>
   cancelling: Array<Maybe<Regulation>>
   cancelling_connection?: Maybe<RegulationRelationResponseCollection>
-  category: Enum_Regulation_Category
+  category?: Maybe<Enum_Regulation_Category>
   createdAt?: Maybe<Scalars['DateTime']['output']>
   documentId: Scalars['ID']['output']
   effectiveFrom: Scalars['Date']['output']
@@ -12315,7 +12315,6 @@ export type PageEntityFragment = {
           regNumber: string
           fullTitle: string
           effectiveFrom: any
-          category: Enum_Regulation_Category
           isFullTextRegulation: boolean
           documentId: string
           slug: string
@@ -13924,7 +13923,6 @@ export type PageByPathQuery = {
             regNumber: string
             fullTitle: string
             effectiveFrom: any
-            category: Enum_Regulation_Category
             isFullTextRegulation: boolean
             documentId: string
             slug: string
@@ -15544,7 +15542,6 @@ export type Dev_AllPagesQuery = {
             regNumber: string
             fullTitle: string
             effectiveFrom: any
-            category: Enum_Regulation_Category
             isFullTextRegulation: boolean
             documentId: string
             slug: string
@@ -16154,7 +16151,6 @@ export type RegulationBySlugQuery = {
     regNumber: string
     fullTitle: string
     effectiveFrom: any
-    category: Enum_Regulation_Category
     isFullTextRegulation: boolean
     documentId: string
     slug: string
@@ -16269,7 +16265,6 @@ export type RegulationEntityFragment = {
   regNumber: string
   fullTitle: string
   effectiveFrom: any
-  category: Enum_Regulation_Category
   isFullTextRegulation: boolean
   documentId: string
   slug: string
@@ -16366,7 +16361,7 @@ export type RegulationEntityFragment = {
 export type RegulationInventoryEntityFragment = {
   __typename?: 'Regulation'
   fullTitle: string
-  category: Enum_Regulation_Category
+  category?: Enum_Regulation_Category | null
   updatedAt?: any | null
   publishedAt?: any | null
   documentId: string
@@ -16409,7 +16404,7 @@ export type RegulationsInventoryQuery = {
   regulations: Array<{
     __typename?: 'Regulation'
     fullTitle: string
-    category: Enum_Regulation_Category
+    category?: Enum_Regulation_Category | null
     updatedAt?: any | null
     publishedAt?: any | null
     documentId: string
@@ -17262,7 +17257,6 @@ export type RegulationsSectionFragment = {
     regNumber: string
     fullTitle: string
     effectiveFrom: any
-    category: Enum_Regulation_Category
     isFullTextRegulation: boolean
     documentId: string
     slug: string
@@ -19021,7 +19015,6 @@ type Sections_ComponentSectionsRegulations_Fragment = {
     regNumber: string
     fullTitle: string
     effectiveFrom: any
-    category: Enum_Regulation_Category
     isFullTextRegulation: boolean
     documentId: string
     slug: string
@@ -19733,7 +19726,6 @@ export type UrbanStudyEntityFragment = {
     regNumber: string
     fullTitle: string
     effectiveFrom: any
-    category: Enum_Regulation_Category
     isFullTextRegulation: boolean
     documentId: string
     slug: string
@@ -19910,7 +19902,6 @@ export type UrbanStudyBySlugQuery = {
       regNumber: string
       fullTitle: string
       effectiveFrom: any
-      category: Enum_Regulation_Category
       isFullTextRegulation: boolean
       documentId: string
       slug: string
@@ -21172,7 +21163,6 @@ export const RegulationEntityFragmentDoc = gql`
     regNumber
     fullTitle
     effectiveFrom
-    category
     regulationCategory {
       ...RegulationCategoryEntity
     }

--- a/next/src/services/graphql/queries/Regulations.graphql
+++ b/next/src/services/graphql/queries/Regulations.graphql
@@ -37,7 +37,6 @@ fragment RegulationEntity on Regulation {
   regNumber
   fullTitle
   effectiveFrom
-  category
   regulationCategory {
     ...RegulationCategoryEntity
   }

--- a/next/src/services/meili/fetchers/homepageSearchFetcher.ts
+++ b/next/src/services/meili/fetchers/homepageSearchFetcher.ts
@@ -76,11 +76,11 @@ export const homepageSearchFetcher = (filters: HomepageSearchFilters, locale: st
         }
 
         if (type === 'regulation') {
-          const { regNumber, titleText, fullTitle } = dataInner
+          const { regNumber, titleText } = dataInner
 
           return {
             type,
-            title: `VZN ${regNumber} ${titleText ?? fullTitle}`,
+            title: `VZN ${regNumber} ${titleText}`,
             link: getLinkProps({ regulation: dataInner }).href,
             data: dataInner,
           } as HomepageSearchResult

--- a/strapi/config/sync/core-store.plugin_content_manager_configuration_content_types##api##regulation.regulation.json
+++ b/strapi/config/sync/core-store.plugin_content_manager_configuration_content_types##api##regulation.regulation.json
@@ -38,7 +38,7 @@
       "slug": {
         "edit": {
           "label": "Slug",
-          "description": "Rovnaké ako Číslo VZN ale so spojovníkom (napr. 2-2012) na základe čoho sa vygeneruje adresa pre stránku VZN (napr. bratislava.sk/vzn/2-2012)",
+          "description": "Rovnaké ako Číslo VZN ale so spojovníkom (napr. 2-2012), používa sa v url.",
           "placeholder": "",
           "visible": true,
           "editable": true
@@ -51,8 +51,8 @@
       },
       "titleText": {
         "edit": {
-          "label": "Názov",
-          "description": "Tento názov bude zobrazený vedľa čísla VZN",
+          "label": "o čom… / ktorým sa…",
+          "description": "Tento text sa zobrazuje vedľa čísla VZN, a používa sa pri skrátených názvoch, ktoré sa skladajú zo skratky VZN, Čísla VZN a tohto textu.",
           "placeholder": "",
           "visible": true,
           "editable": true
@@ -66,7 +66,7 @@
       "fullTitle": {
         "edit": {
           "label": "Plný názov",
-          "description": "Kompletný oficiálny názov VZN. Zatiaľ ho nikde nezobrazujeme.",
+          "description": "Kompletný oficiálny názov VZN. Používa sa vo vyhľadávaní, SEO, a v dátach pre AI chatbota.",
           "placeholder": "",
           "visible": true,
           "editable": true
@@ -319,30 +319,10 @@
         [
           {
             "name": "titleText",
-            "size": 6
+            "size": 12
           },
           {
             "name": "fullTitle",
-            "size": 6
-          }
-        ],
-        [
-          {
-            "name": "effectiveFrom",
-            "size": 4
-          },
-          {
-            "name": "isFullTextRegulation",
-            "size": 4
-          },
-          {
-            "name": "category",
-            "size": 4
-          }
-        ],
-        [
-          {
-            "name": "mainDocument",
             "size": 6
           },
           {
@@ -352,8 +332,22 @@
         ],
         [
           {
+            "name": "effectiveFrom",
+            "size": 6
+          },
+          {
+            "name": "isFullTextRegulation",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "mainDocument",
+            "size": 6
+          },
+          {
             "name": "attachments",
-            "size": 12
+            "size": 6
           }
         ],
         [

--- a/strapi/schema.graphql
+++ b/strapi/schema.graphql
@@ -4359,7 +4359,7 @@ type Regulation {
   cancellation: Regulation
   cancelling(filters: RegulationFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): [Regulation]!
   cancelling_connection(filters: RegulationFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): RegulationRelationResponseCollection
-  category: ENUM_REGULATION_CATEGORY!
+  category: ENUM_REGULATION_CATEGORY
   createdAt: DateTime
   documentId: ID!
   effectiveFrom: Date!

--- a/strapi/src/api/regulation/content-types/regulation/schema.json
+++ b/strapi/src/api/regulation/content-types/regulation/schema.json
@@ -36,7 +36,7 @@
     },
     "category": {
       "type": "enumeration",
-      "required": true,
+      "required": false,
       "enum": [
         "daneAPoplatky",
         "pomenovanieUlic",

--- a/strapi/types/generated/contentTypes.d.ts
+++ b/strapi/types/generated/contentTypes.d.ts
@@ -1332,8 +1332,7 @@ export interface ApiRegulationRegulation extends Struct.CollectionTypeSchema {
         'ostatne',
         'archiv',
       ]
-    > &
-      Schema.Attribute.Required
+    >
     createdAt: Schema.Attribute.DateTime
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> & Schema.Attribute.Private
     effectiveFrom: Schema.Attribute.Date & Schema.Attribute.Required


### PR DESCRIPTION
- hide legacy `category` enum in strapi, keep in only in db
- make it optional, so new regulations does not need to fill it
- update labels and helptext + layout in strapi admin for regulations
- fix usage of `fullTitle` - it's required and it should always start with "VZN number" or "Vseobecne zavazne nariadenie number", so it should be used like that now correctly.

<img width="800" height="486" alt="image" src="https://github.com/user-attachments/assets/7b985344-c863-49cb-894e-678a7559a858" />
