### PR TITLE
AVI-to-nginx-migration: upload limits and proxy header buffers

### DIFF
--- a/next/kubernetes/base/ingress.yml
+++ b/next/kubernetes/base/ingress.yml
@@ -6,6 +6,8 @@ metadata:
   labels:
     service: app
   annotations:
+    nginx.org/proxy-buffer-size: 16k
+    nginx.org/proxy-buffers: 8 16k
     cert-manager.io/cluster-issuer: cloudflare-dns01
     cert-manager.io/issue-temporary-certificate: 'true'
 spec:

--- a/next/kubernetes/base/redirects/camping.ingress.yml
+++ b/next/kubernetes/base/redirects/camping.ingress.yml
@@ -6,6 +6,8 @@ metadata:
   labels:
     service: redirect
   annotations:
+    nginx.org/proxy-buffer-size: 16k
+    nginx.org/proxy-buffers: 8 16k
     cert-manager.io/cluster-issuer: cloudflare-dns01
     cert-manager.io/issue-temporary-certificate: 'true'
     ingress.kubernetes.io/redirect-to: https://${BRATISKA_HOSTNAME}/vzdelavanie-a-volny-cas/sport/kemping

--- a/next/kubernetes/base/redirects/horskypark.ingress.yml
+++ b/next/kubernetes/base/redirects/horskypark.ingress.yml
@@ -6,6 +6,8 @@ metadata:
   labels:
     service: redirect
   annotations:
+    nginx.org/proxy-buffer-size: 16k
+    nginx.org/proxy-buffers: 8 16k
     cert-manager.io/cluster-issuer: cloudflare-dns01
     cert-manager.io/issue-temporary-certificate: 'true'
     ingress.kubernetes.io/redirect-to: https://${BRATISKA_HOSTNAME}/zivotne-prostredie-a-vystavba/zelen/udrzba-a-tvorba-zelene/parky-a-zahrady/horsky-park

--- a/next/kubernetes/base/redirects/izba.ingress.yml
+++ b/next/kubernetes/base/redirects/izba.ingress.yml
@@ -6,6 +6,8 @@ metadata:
   labels:
     service: redirect
   annotations:
+    nginx.org/proxy-buffer-size: 16k
+    nginx.org/proxy-buffers: 8 16k
     cert-manager.io/cluster-issuer: cloudflare-dns01
     cert-manager.io/issue-temporary-certificate: 'true'
     ingress.kubernetes.io/redirect-to: https://${BRATISKA_HOSTNAME}/socialne-sluzby-a-byvanie/socialne-sluzby-a-zariadenia/klub-izba

--- a/next/kubernetes/base/redirects/kariera.ingress.yml
+++ b/next/kubernetes/base/redirects/kariera.ingress.yml
@@ -6,6 +6,8 @@ metadata:
   labels:
     service: redirect
   annotations:
+    nginx.org/proxy-buffer-size: 16k
+    nginx.org/proxy-buffers: 8 16k
     cert-manager.io/cluster-issuer: cloudflare-dns01
     cert-manager.io/issue-temporary-certificate: 'true'
     ingress.kubernetes.io/redirect-to: https://${BRATISKA_HOSTNAME}/mesto-bratislava/sprava-mesta/magistrat/pracovne-prilezitosti

--- a/next/kubernetes/base/redirects/klima.ingress.yml
+++ b/next/kubernetes/base/redirects/klima.ingress.yml
@@ -6,6 +6,8 @@ metadata:
   labels:
     service: redirect
   annotations:
+    nginx.org/proxy-buffer-size: 16k
+    nginx.org/proxy-buffers: 8 16k
     cert-manager.io/cluster-issuer: cloudflare-dns01
     cert-manager.io/issue-temporary-certificate: 'true'
     ingress.kubernetes.io/redirect-to: https://${BRATISKA_HOSTNAME}/zivotne-prostredie-a-vystavba/klima/klimaticky-plan

--- a/next/kubernetes/base/redirects/klimatickavyzva.ingress.yml
+++ b/next/kubernetes/base/redirects/klimatickavyzva.ingress.yml
@@ -6,6 +6,8 @@ metadata:
   labels:
     service: redirect
   annotations:
+    nginx.org/proxy-buffer-size: 16k
+    nginx.org/proxy-buffers: 8 16k
     cert-manager.io/cluster-issuer: cloudflare-dns01
     cert-manager.io/issue-temporary-certificate: 'true'
     ingress.kubernetes.io/redirect-to: https://${BRATISKA_HOSTNAME}/zivotne-prostredie-a-vystavba/klima/klimaticka-vyzva

--- a/next/kubernetes/base/redirects/old_aliases.ingress.yml
+++ b/next/kubernetes/base/redirects/old_aliases.ingress.yml
@@ -6,6 +6,8 @@ metadata:
   labels:
     service: redirect
   annotations:
+    nginx.org/proxy-buffer-size: 16k
+    nginx.org/proxy-buffers: 8 16k
     cert-manager.io/cluster-issuer: cloudflare-dns01
     cert-manager.io/issue-temporary-certificate: 'true'
     ingress.kubernetes.io/redirect-to: 'https://www.${BRATISKA_HOSTNAME}/'

--- a/next/kubernetes/base/redirects/platbadane.ingress.yml
+++ b/next/kubernetes/base/redirects/platbadane.ingress.yml
@@ -6,6 +6,8 @@ metadata:
   labels:
     service: redirect
   annotations:
+    nginx.org/proxy-buffer-size: 16k
+    nginx.org/proxy-buffers: 8 16k
     cert-manager.io/cluster-issuer: cloudflare-dns01
     cert-manager.io/issue-temporary-certificate: 'true'
     ingress.kubernetes.io/redirect-to: 'https://www.${BRATISKA_HOSTNAME}/mesto-bratislava/dane-a-poplatky/dan-z-nehnutelnosti/digitalna-platba'

--- a/next/kubernetes/base/redirects/ukrajina.ingress.yml
+++ b/next/kubernetes/base/redirects/ukrajina.ingress.yml
@@ -6,6 +6,8 @@ metadata:
   labels:
     service: redirect
   annotations:
+    nginx.org/proxy-buffer-size: 16k
+    nginx.org/proxy-buffers: 8 16k
     cert-manager.io/cluster-issuer: cloudflare-dns01
     cert-manager.io/issue-temporary-certificate: 'true'
     ingress.kubernetes.io/redirect-to: 'https://www.${BRATISKA_HOSTNAME}/bratislava-pre-ukrajinu'

--- a/next/kubernetes/envs/Prod/redirects/behdevin.ingress.yml
+++ b/next/kubernetes/envs/Prod/redirects/behdevin.ingress.yml
@@ -6,6 +6,8 @@ metadata:
   labels:
     service: redirect
   annotations:
+    nginx.org/proxy-buffer-size: 16k
+    nginx.org/proxy-buffers: 8 16k
     cert-manager.io/cluster-issuer: cloudflare-dns01
     cert-manager.io/issue-temporary-certificate: 'true'
     ingress.kubernetes.io/redirect-to: https://${BRATISKA_HOSTNAME}/vzdelavanie-a-volny-cas/sport/podujatia/devin-bratislava

--- a/next/kubernetes/envs/Prod/redirects/primacialnypalac.ingress.yml
+++ b/next/kubernetes/envs/Prod/redirects/primacialnypalac.ingress.yml
@@ -6,6 +6,8 @@ metadata:
   labels:
     service: redirect
   annotations:
+    nginx.org/proxy-buffer-size: 16k
+    nginx.org/proxy-buffers: 8 16k
     cert-manager.io/cluster-issuer: cloudflare-dns01
     cert-manager.io/issue-temporary-certificate: 'true'
     ingress.kubernetes.io/redirect-to: https://${BRATISKA_HOSTNAME}/mesto-bratislava/transparentne-mesto/majetok-mesta/primacialny-palac

--- a/strapi/kubernetes/base/ingress.yml
+++ b/strapi/kubernetes/base/ingress.yml
@@ -6,6 +6,8 @@ metadata:
   labels:
     service: app
   annotations:
+    nginx.org/proxy-buffer-size: 16k
+    nginx.org/proxy-buffers: 8 16k
     cert-manager.io/cluster-issuer: cloudflare-dns01
     cert-manager.io/issue-temporary-certificate: 'true'
     nginx.org/client-max-body-size: '0'


### PR DESCRIPTION
Note: should be merged once production default ingress is switched to nginx.

Part of the AVI → nginx cutover. Adds to the ingress:

```yaml
nginx.org/proxy-buffer-size: 16k
nginx.org/proxy-buffers: 8 16k
```

Responses on `*.bratislava.sk` carry large cookies, and nginx's 4k default response-header buffer rejects them with a 502 and `upstream sent too big header` in the controller log. That is exactly what happened to `city-account-next` on staging after its cutover (infra #350), and AVI had no such limit, so it only surfaces once traffic moves.

Both keys are required together — `nginx -t` rejects `proxy_buffer_size 16k` on its own, because the default `proxy_buffers 8 4k` then violates `proxy_busy_buffers_size`.

Verified with `kustomize build` on the Dev/Staging/Prod overlays: the only change in the rendered output is the two added annotations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
