### PR TITLE
2495 add data ai crawl exclude attribute

### DIFF
--- a/next/src/components/common/Breadcrumbs/Breadcrumbs.tsx
+++ b/next/src/components/common/Breadcrumbs/Breadcrumbs.tsx
@@ -16,7 +16,8 @@ const Breadcrumbs = (props: BreadcrumbsProps) => {
       <nav className="hidden lg:block">
         <DesktopBreadcrumbs {...props} />
       </nav>
-      <nav className="lg:hidden">
+      {/* Even tho it's hidden on desktop, it's still rendered in html, so we exclude it fro crawler */}
+      <nav className="lg:hidden" data-ai-crawl-exclude>
         <MobileBreadcrumbs {...props} />
       </nav>
     </>

--- a/next/src/components/common/CookieConsentGate/CookieConsentGate.tsx
+++ b/next/src/components/common/CookieConsentGate/CookieConsentGate.tsx
@@ -63,6 +63,7 @@ const CookieConsentGate = (props: Props) => {
 
   return (
     <div
+      data-ai-crawl-exclude
       className={cn(
         'flex flex-col items-center justify-center gap-4 rounded-lg bg-background-passive-secondary p-4 text-center lg:p-8',
         className,

--- a/next/src/components/common/FaqsAll/FaqsAll.tsx
+++ b/next/src/components/common/FaqsAll/FaqsAll.tsx
@@ -91,7 +91,7 @@ const FaqsAll = ({ accordionTitleLevel = 'h2' }: { accordionTitleLevel?: Accordi
   }
 
   return (
-    <div className="flex flex-col gap-4">
+    <div data-ai-crawl-exclude className="flex flex-col gap-4">
       <SearchBar
         ref={searchRef}
         placeholder={t('SearchPage.enterKeyword')}

--- a/next/src/components/common/Footer/Footer.tsx
+++ b/next/src/components/common/Footer/Footer.tsx
@@ -4,10 +4,10 @@ import MobileFooter from '@/src/components/common/Footer/MobileFooter'
 const Footer = () => {
   return (
     <>
-      <div className="hidden lg:block">
+      <div data-ai-crawl-exclude className="hidden lg:block">
         <DesktopFooter />
       </div>
-      <div className="lg:hidden">
+      <div data-ai-crawl-exclude className="lg:hidden">
         <MobileFooter />
       </div>
     </>

--- a/next/src/components/common/GTranslate/GTranslateSwitcher.tsx
+++ b/next/src/components/common/GTranslate/GTranslateSwitcher.tsx
@@ -37,7 +37,7 @@ const GTranslateSwitcher = () => {
   return (
     <>
       {/* eslint-disable-next-line better-tailwindcss/no-unknown-classes -- GTranslate mounts its widget into this selector */}
-      <div className="gtranslate_wrapper" />
+      <div className="gtranslate_wrapper" data-ai-crawl-exclude />
       <Script id="gtranslate-settings" strategy="afterInteractive">
         {`window.gtranslateSettings = ${JSON.stringify(gtranslateSettings)}`}
       </Script>

--- a/next/src/components/common/HomepageSearch/HomePageSearch.tsx
+++ b/next/src/components/common/HomepageSearch/HomePageSearch.tsx
@@ -55,7 +55,7 @@ const HomePageSearch = ({ isOpen, setOpen }: HomePageSearchProps) => {
   }, [router, input, t])
 
   return (
-    <div ref={ref} className="relative">
+    <div ref={ref} data-ai-crawl-exclude className="relative">
       <div
         className={cn(
           isOpen ? 'md:w-[634px]' : 'md:w-[444px]',

--- a/next/src/components/common/LatestNews/LatestNews.tsx
+++ b/next/src/components/common/LatestNews/LatestNews.tsx
@@ -28,7 +28,7 @@ const LatestNews = ({ leftArticle, rightArticle, otherArticles, newsPageLink }: 
     [leftArticle, rightArticle, ...otherArticles].filter(isDefined).slice(0, 6) ?? []
 
   return (
-    <div className="flex flex-col gap-y-14">
+    <div data-ai-crawl-exclude className="flex flex-col gap-y-14">
       <ResponsiveCarousel
         className="lg:hidden"
         hasVerticalPadding={false}

--- a/next/src/components/common/ModalDialog/Modal.tsx
+++ b/next/src/components/common/ModalDialog/Modal.tsx
@@ -31,6 +31,7 @@ const Modal = forwardRef<HTMLDivElement, Props>(
        */
       <ModalOverlay
         ref={ref}
+        data-ai-crawl-exclude
         className={cn(
           'fixed top-0 left-0 z-50 flex h-(--visual-viewport-height) w-screen items-center justify-center bg-background-passive-inverted-base/48',
           overlayClassname,

--- a/next/src/components/common/Pagination/Pagination.tsx
+++ b/next/src/components/common/Pagination/Pagination.tsx
@@ -35,7 +35,7 @@ const Pagination = ({ currentPage, totalCount, onPageChange = () => {} }: Pagina
   })
 
   return (
-    <nav>
+    <nav data-ai-crawl-exclude>
       <ul
         className="flex flex-wrap items-center justify-center gap-1 lg:gap-2"
         data-cy="pagination"

--- a/next/src/components/common/Pagination/PaginationWithInput.tsx
+++ b/next/src/components/common/Pagination/PaginationWithInput.tsx
@@ -31,7 +31,7 @@ const PaginationWithInput = ({
   })
 
   return (
-    <nav>
+    <nav data-ai-crawl-exclude>
       <div className={cn('flex items-center justify-start gap-4')}>
         <Button
           variant="plain"

--- a/next/src/components/common/ScrollToTopButton/ScrollToTopButton.tsx
+++ b/next/src/components/common/ScrollToTopButton/ScrollToTopButton.tsx
@@ -28,6 +28,7 @@ const ScrollToTopButton = () => {
 
   return (
     <Button
+      data-ai-crawl-exclude
       variant="icon-wrapped"
       aria-label={t('ScrollToTopButton.ariaLabel')}
       id="scrollToTopButton"

--- a/next/src/components/common/ShareBlock/ShareBlock.tsx
+++ b/next/src/components/common/ShareBlock/ShareBlock.tsx
@@ -15,7 +15,10 @@ export type ShareBlockProps = {
 
 const ShareBlock = ({ text, buttonText }: ShareBlockProps) => {
   return (
-    <div className="flex flex-col items-center gap-3 rounded-lg bg-background-passive-secondary p-4 lg:flex-row lg:gap-2.5 lg:px-8 lg:py-6">
+    <div
+      data-ai-crawl-exclude
+      className="flex flex-col items-center gap-3 rounded-lg bg-background-passive-secondary p-4 lg:flex-row lg:gap-2.5 lg:px-8 lg:py-6"
+    >
       <div className="grow">
         <Typography variant="h5">{text}</Typography>
       </div>

--- a/next/src/components/common/Submenu/StarzSubmenu.tsx
+++ b/next/src/components/common/Submenu/StarzSubmenu.tsx
@@ -24,7 +24,7 @@ const StarzSubmenu = ({ adminGroup, className }: Props) => {
 
   // Beware of paddings, margins and gaps - they are used to enlarge clickable/touchable area of links, and they are carefully set to fit Figma design together
   return (
-    <SectionContainer className={cn('bg-starz-primary-700', className)}>
+    <SectionContainer data-ai-crawl-exclude className={cn('bg-starz-primary-700', className)}>
       <div className="flex gap-6">
         <StarzLogo
           variant="white"

--- a/next/src/components/common/TableOfContents/TableOfContents.tsx
+++ b/next/src/components/common/TableOfContents/TableOfContents.tsx
@@ -38,6 +38,7 @@ const TableOfContents = ({ scrollOffset = DEFAULT_SCROLL_OFFSET, className }: Pr
 
   return (
     <div
+      data-ai-crawl-exclude
       className={cn(
         'flex flex-col overflow-hidden rounded-lg border border-border-passive-primary bg-background-passive-base px-6',
         className,

--- a/next/src/components/common/Waves/Waves.tsx
+++ b/next/src/components/common/Waves/Waves.tsx
@@ -21,6 +21,7 @@ const Waves = ({
   return (
     <div
       aria-hidden
+      data-ai-crawl-exclude
       style={{ backgroundColor, color: waveColor }}
       className={cn('overflow-hidden', className)}
     >

--- a/next/src/components/layouts/PageLayout.tsx
+++ b/next/src/components/layouts/PageLayout.tsx
@@ -12,7 +12,7 @@ const PageLayout = ({ className, children }: PropsWithChildren<PageLayoutProps>)
   return (
     // Z-indices are set to create stacking contexts for easier z-index management.
     <div className={className}>
-      <header className="relative">
+      <header data-ai-crawl-exclude className="relative">
         <NavBar />
       </header>
 

--- a/next/src/components/page-contents/InbaReleasePageContent.tsx
+++ b/next/src/components/page-contents/InbaReleasePageContent.tsx
@@ -128,7 +128,7 @@ const InbaReleasePageContent = ({ inbaRelease }: Props) => {
         </div>
       </SectionContainer>
 
-      <SectionContainer className="py-10 md:py-18">
+      <SectionContainer data-ai-crawl-exclude className="py-10 md:py-18">
         <div className="flex flex-col gap-5 lg:gap-6">
           <Typography variant="h3" as="h2" id="clanky-v-tomto-cisle">
             {t('InbaRelease.articlesInThisRelease')}

--- a/next/src/components/sections/ArticlesSection/ArticlesAll/ArticlesAll.tsx
+++ b/next/src/components/sections/ArticlesSection/ArticlesAll/ArticlesAll.tsx
@@ -68,7 +68,7 @@ const ArticlesAll = ({ section }: Props) => {
   }, [filters.page, filters.pageSize])
 
   return (
-    <div className="flex flex-col gap-8">
+    <div data-ai-crawl-exclude className="flex flex-col gap-8">
       <div className="flex flex-col gap-6">
         <SectionHeader title={title} text={text} />
         <SearchBar

--- a/next/src/components/sections/AssetsSection/AssetsAll.tsx
+++ b/next/src/components/sections/AssetsSection/AssetsAll.tsx
@@ -66,7 +66,7 @@ const AssetsAllSection = ({ section }: Props) => {
   })
 
   return (
-    <div className="flex flex-col gap-6">
+    <div data-ai-crawl-exclude className="flex flex-col gap-6">
       <div className="flex flex-col gap-6">
         <SectionHeader title={title} text={text} titleLevel={titleLevel} />
         <SearchBar

--- a/next/src/components/sections/InbaReleasesSection/InbaReleasesGridAll.tsx
+++ b/next/src/components/sections/InbaReleasesSection/InbaReleasesGridAll.tsx
@@ -23,7 +23,7 @@ type Props = { section: InbaReleasesSectionFragment }
  * Figma: https://www.figma.com/design/17wbd0MDQcMW9NbXl6UPs8/DS--Component-library?node-id=17826-20475&t=oiip1Wu4BbgLXqBp-4
  */
 
-const InbaReleasesGrid = ({ section }: Props) => {
+const InbaReleasesGridAll = ({ section }: Props) => {
   const { t } = useTranslation()
 
   const { title, text } = section
@@ -48,7 +48,7 @@ const InbaReleasesGrid = ({ section }: Props) => {
   }
 
   return (
-    <div className="flex flex-col gap-8">
+    <div data-ai-crawl-exclude className="flex flex-col gap-8">
       <SectionHeader title={title} text={text} />
 
       <SearchBar
@@ -97,4 +97,4 @@ const InbaReleasesGrid = ({ section }: Props) => {
   )
 }
 
-export default InbaReleasesGrid
+export default InbaReleasesGridAll

--- a/next/src/components/sections/InbaReleasesSection/InbaReleasesSection.tsx
+++ b/next/src/components/sections/InbaReleasesSection/InbaReleasesSection.tsx
@@ -1,6 +1,6 @@
 import SectionContainer from '@/src/components/layouts/SectionContainer'
 import InbaReleasesCarousel from '@/src/components/sections/InbaReleasesSection/InbaReleasesCarousel'
-import InbaReleasesGrid from '@/src/components/sections/InbaReleasesSection/InbaReleasesGrid'
+import InbaReleasesGridAll from '@/src/components/sections/InbaReleasesSection/InbaReleasesGridAll'
 import {
   Enum_Componentsectionsinbareleases_Variant,
   InbaReleasesSectionFragment,
@@ -24,7 +24,7 @@ const InbaReleasesSection = ({ section }: Props) => {
   // TODO make variant required and implement correct check
   return (
     <SectionContainer>
-      <InbaReleasesGrid section={section} />
+      <InbaReleasesGridAll section={section} />
     </SectionContainer>
   )
 }

--- a/next/src/components/sections/NewsletterSection/Newsletter.tsx
+++ b/next/src/components/sections/NewsletterSection/Newsletter.tsx
@@ -78,7 +78,7 @@ const Newsletter = ({
   const privacyPolicyPage = general?.privacyPolicyPage
 
   return (
-    <div className="lg:max-w-122 lg:min-w-122 lg:rounded-lg lg:border lg:p-8">
+    <div data-ai-crawl-exclude className="lg:max-w-122 lg:min-w-122 lg:rounded-lg lg:border lg:p-8">
       <form onSubmit={onSubmit}>
         <div className="flex flex-col gap-6 lg:gap-8">
           <div className="flex flex-col gap-4 lg:grid lg:grid-cols-2 lg:gap-6">

--- a/next/src/components/sections/OfficialBoardSection/OfficialBoardSection.tsx
+++ b/next/src/components/sections/OfficialBoardSection/OfficialBoardSection.tsx
@@ -44,7 +44,7 @@ const OfficialBoardSection = () => {
   const fetchingQueriesCount = useIsFetching({ queryKey: ['Search'] })
 
   return (
-    <SectionContainer>
+    <SectionContainer data-ai-crawl-exclude>
       <div className="flex w-full flex-col gap-8">
         <SearchBar
           ref={searchRef}

--- a/next/src/components/sections/PartnersSection.tsx
+++ b/next/src/components/sections/PartnersSection.tsx
@@ -24,7 +24,7 @@ const PartnersSection = ({ section }: Props) => {
   const count = filteredPartners.length
 
   return (
-    <SectionContainer>
+    <SectionContainer data-ai-crawl-exclude>
       <div className="flex flex-col gap-6 lg:gap-8">
         <SectionHeader title={title} titleLevel={titleLevel} text={text} />
 

--- a/next/src/components/sections/RelatedArticlesSection.tsx
+++ b/next/src/components/sections/RelatedArticlesSection.tsx
@@ -37,7 +37,7 @@ const RelatedArticlesSection = ({ page, className }: Props) => {
   }
 
   return (
-    <SectionContainer className={className}>
+    <SectionContainer data-ai-crawl-exclude className={className}>
       <div className="flex flex-col">
         <SectionHeader
           title={t('RelatedArticlesSection.relatedArticles')}

--- a/next/src/components/sections/SearchSection/GlobalSearchSectionContent.tsx
+++ b/next/src/components/sections/SearchSection/GlobalSearchSectionContent.tsx
@@ -208,7 +208,7 @@ const GlobalSearchSectionContent = ({ variant, searchOption }: Props) => {
   const fetchingQueriesCount = useIsFetching({ queryKey: ['Search'] })
 
   return (
-    <div className="flex w-full flex-col gap-y-8">
+    <div data-ai-crawl-exclude className="flex w-full flex-col gap-y-8">
       {/* Filters */}
       <div className="flex flex-col gap-3 lg:gap-4">
         <SearchBar

--- a/next/src/components/sections/UrbanStudiesSection/UrbanStudiesAll.tsx
+++ b/next/src/components/sections/UrbanStudiesSection/UrbanStudiesAll.tsx
@@ -62,7 +62,7 @@ const UrbanStudiesAll = ({ section }: Props) => {
   })
 
   return (
-    <div className="flex flex-col gap-6">
+    <div data-ai-crawl-exclude className="flex flex-col gap-6">
       <div className="flex flex-col gap-6">
         <SectionHeader title={title} text={text} titleLevel={titleLevel} />
 


### PR DESCRIPTION
## What

Adds `data-ai-crawl-exclude` to markup the AI chat crawler should skip. The attribute name is agreed with the AI chatbot team, and marks the element **and its subtree** as excluded.

Nothing is removed or restyled — the attribute is inert for users. Placement is on component roots wherever possible, so one attribute covers every usage.

## Why

Three kinds of markup hurt retrieval rather than help it:

1. **UI chrome** — pagination numbers, share buttons, "back", consent walls. Text that is interface, not information.
2. **Boilerplate repeated on every page** — nav, footer, submenu. Present in every chunk, so it matches every query weakly and dilutes the index.
3. **Client-fetched listings** — search results, article/document lists, related articles. Rendered by react-query after hydration, so a crawler without JS sees only the empty state ("Zadajte hľadaný výraz", "Žiadne výsledky"), and a crawler with JS sees a stale page 1 that duplicates detail pages already crawled on their own URLs.

## Components that got the attribute

### Site chrome (outside `<main>`)

| Component | Scope |
|---|---|
| `layouts/PageLayout` | the whole `<header>` — NavBar desktop + mobile, `AlertBanner`, `SkipToContentButton` |
| `common/Footer/Footer` | both breakpoint variants (2 attributes — desktop and mobile both render, CSS-hidden) |
| `common/ModalDialog/Modal` | on `ModalOverlay`, so every modal at once — RAC portals these to `document.body`, outside `<main>` |
| `common/GTranslate/GTranslateSwitcher` | the `.gtranslate_wrapper` the widget mounts into |

### Navigation and page controls

| Component | Note |
|---|---|
| `common/Breadcrumbs/Breadcrumbs` | **mobile `<nav>` only** — desktop breadcrumbs stay crawlable, they carry the page's place in the hierarchy. Both variants render, so this also removes the duplication |
| `common/TableOfContents` | |
| `common/Pagination` | |
| `common/Pagination/PaginationWithInput` | |
| `common/Submenu/StarzSubmenu` | |
| `common/ScrollToTopButton` | |
| `common/ShareBlock` | |
| `common/CookieConsentGate` | the consent wall only — the embed itself is untouched once consent is given |
| `common/Waves` | decorative |

### Search and filter UI

| Component | Note |
|---|---|
| `common/HomepageSearch/HomePageSearch` | field + live results dropdown |
| `sections/SearchSection/GlobalSearchSectionContent` | the whole search page: filters, chips, counts, results |

### Client-fetched listings — whole section excluded

| Component |
|---|
| `sections/ArticlesSection/ArticlesAll` |
| `sections/AssetsSection/AssetsAll` |
| `sections/UrbanStudiesSection/UrbanStudiesAll` |
| `sections/InbaReleasesSection/InbaReleasesGridAll` |
| `sections/OfficialBoardSection` |
| `page-contents/InbaReleasePageContent` — the "articles in this release" section |
| `sections/RelatedArticlesSection` |
| `common/LatestNews` — covers both usages (articles landing page, homepage tab) |
| `common/FaqsAll` — the searchable, paginated FAQ listing (`FaqsSection` with `showAll`). Editor-picked FAQs via `FaqsGroup` stay crawlable |

### Promo

| Component | Note |
|---|---|
| `sections/PartnersSection` | logo wall |
| `sections/NewsletterSection/Newsletter` | the signup form only — the section's heading, text and social links stay crawlable |

`sections/InbaReleasesSection` also appears in the diff for the `InbaReleasesGrid` → `InbaReleasesGridAll` rename, with no attribute of its own.

## Deliberately left crawlable

- **Desktop breadcrumbs** — encode page taxonomy
- **`SubnavigationSection`** — lists child pages, real site structure
- **`BannerSection`**, **`AlertSection`** — editor-placed, relevant content
- **`FaqsGroup`** — editor-picked FAQs, server-rendered; the crawlable FAQ path
- Page headers and perexes, `Markdown` bodies, contacts, opening hours, file lists, regulations, official board documents, urban studies — and all detail pages, which are where the content actually lives

## Notes for the crawler side

- A `<main>`-only crawl is already safe: every public page puts its content inside `PageLayout`'s single `<main>`, with only context providers and `SeoHead` as siblings. The attributes on header/footer/modals are belt-and-braces for a whole-page crawl.
- Footer contacts and opening hours are excluded with the rest of the footer — that data has its own page, which is crawled.
- Listing pages might be better handled by a crawler-side URL denylist than by attributes; the attributes make them safe either way.