### PR TITLE
Add FAQs to content inventory endpoint

### DIFF
--- a/next/src/components/common/FaqsGroup/FaqsGroup.tsx
+++ b/next/src/components/common/FaqsGroup/FaqsGroup.tsx
@@ -9,13 +9,13 @@ import DisclosureHeader from '@/src/components/common/Disclosure/DisclosureHeade
 import DisclosurePanel from '@/src/components/common/Disclosure/DisclosurePanel'
 import HorizontalDivider from '@/src/components/common/Divider/HorizontalDivider'
 import Markdown from '@/src/components/formatting/Markdown/Markdown'
-import { FaqCategoryEntityFragment, FaqEntityFragment } from '@/src/services/graphql'
+import { FaqCategoryWithFaqsEntityFragment, FaqEntityFragment } from '@/src/services/graphql'
 import { isDefined } from '@/src/utils/isDefined'
 
 export type FaqsGroupProps = {
   faqs?: FaqEntityFragment[]
   accordionTitleLevel?: AccordionTitleLevel
-  faqCategories?: FaqCategoryEntityFragment[]
+  faqCategories?: FaqCategoryWithFaqsEntityFragment[]
 }
 
 const FaqsGroup = ({ faqs, accordionTitleLevel = 'h2', faqCategories }: FaqsGroupProps) => {

--- a/next/src/pages/api/content-inventory.md
+++ b/next/src/pages/api/content-inventory.md
@@ -2,6 +2,10 @@
 
 Versions of the `/api/content-inventory` response, as returned in its `version` field.
 
+## 5
+
+- Add the `faq` type, listing the frequently asked questions, with the question as the entry's `title`, the answer as `faq.body` in markdown and `faq.category` naming the category it is filed under, listed whole in `taxonomies.faqCategories` - they are rendered inside the pages that list them, so their `url` is always null
+
 ## 4
 
 - Add the `job-offer` type, listing the city's open positions from Nalgoo, with `job-offer.location`, `job-offer.salary`, `job-offer.salaryInfo` and `job-offer.employmentForms` - their `url` points to external page, and the offers returned without one are left out

--- a/next/src/services/content-inventory/buildInventory.ts
+++ b/next/src/services/content-inventory/buildInventory.ts
@@ -25,6 +25,7 @@ import { isDefined } from '@/src/utils/isDefined'
 
 import { FETCH_CHUNK_SIZE } from './config'
 import {
+  FaqInventoryData,
   Inventory,
   InventoryContact,
   InventoryContactType,
@@ -139,8 +140,9 @@ const getBase = <TType extends InventoryType>(
         /** Only for content hosted elsewhere, i.e. the city account - everything else lives on this website. */
         siteUrl?: string
       }
-    // Content that is not addressed by a path under a site root, i.e. the job offers Nalgoo hosts.
-    | { url: string }
+    // Content that is not addressed by a path under a site root - the job offers Nalgoo hosts, and the FAQs, which
+    // are rendered inside other pages and so have no url at all.
+    | { url: string | null }
   ),
 ): InventoryEntryBase & { type: TType } => ({
   id: getEntryId(type, entry.documentId),
@@ -611,6 +613,30 @@ const buildJobOffers = async (): Promise<InventoryEntry[]> => {
     .filter(isDefined)
 }
 
+/**
+ * FAQs have no page of their own - they are rendered inside the pages listing them, so an entry carries no url and the
+ * question and the answer alone.
+ */
+const buildFaqs = async (): Promise<InventoryEntry[]> => {
+  const faqs = await fetchAll((variables) =>
+    client.FaqsInventory(variables).then((result) => result.faqs),
+  )
+
+  return faqs.map((faq) => ({
+    ...getBase('faq', {
+      ...faq,
+      url: null,
+      owner: getOwner(faq.adminGroups),
+      addedAt: faq.publishedAt,
+      modifiedAt: faq.updatedAt,
+    }),
+    faq: getTypeData<FaqInventoryData>({
+      body: getFirstNonEmpty(faq.body),
+      category: getCategory(faq.faqCategory),
+    }),
+  }))
+}
+
 /** A taxonomy is only its identity here - what it is filed with is on the entries, which name it by its slug. */
 const getTaxonomy = (values: ({ title: string; slug: string } | null)[]): InventoryTaxonomy[] =>
   values.filter(isDefined).map((value) => ({ title: value.title, slug: value.slug }))
@@ -644,6 +670,7 @@ const buildTaxonomies = async (): Promise<InventoryTaxonomies> => {
     regulationCategories: getTaxonomy(taxonomies.regulationCategories),
     urbanStudyCategories: getTaxonomy(taxonomies.urbanStudyCategories),
     urbanStudyStates: getTaxonomy(taxonomies.urbanStudyStates),
+    faqCategories: getTaxonomy(taxonomies.faqCategories),
   }
 }
 
@@ -664,6 +691,7 @@ export const buildInventory = async (): Promise<Inventory> => {
     officialBoard,
     municipalServices,
     jobOffers,
+    faqs,
     taxonomies,
   ] = await Promise.all([
     buildPages(),
@@ -675,6 +703,7 @@ export const buildInventory = async (): Promise<Inventory> => {
     buildOfficialBoard(),
     buildMunicipalServices(),
     buildJobOffers(),
+    buildFaqs(),
     buildTaxonomies(),
   ])
 
@@ -688,6 +717,7 @@ export const buildInventory = async (): Promise<Inventory> => {
     ...officialBoard,
     ...municipalServices,
     ...jobOffers,
+    ...faqs,
   ].sort((a, b) => (b.modifiedAt ?? '').localeCompare(a.modifiedAt ?? ''))
 
   return { entries, taxonomies }

--- a/next/src/services/content-inventory/config.ts
+++ b/next/src/services/content-inventory/config.ts
@@ -1,5 +1,5 @@
 /** The shape of the entries, bumped whenever a change can break consumers. Changelog in content-inventory.md. */
-export const INVENTORY_VERSION = 4
+export const INVENTORY_VERSION = 5
 
 /** The whole inventory is built at once and served from memory until it expires. */
 export const SNAPSHOT_TTL_MS = 60 * 60 * 1000 // 1 hour

--- a/next/src/services/content-inventory/types.ts
+++ b/next/src/services/content-inventory/types.ts
@@ -1,4 +1,4 @@
-/** Every content type that has its own url on the website, i.e. everything the inventory can list. */
+/** Every content type the inventory can list, i.e. everything the website publishes. */
 export const inventoryTypes = [
   'page',
   'article',
@@ -9,6 +9,7 @@ export const inventoryTypes = [
   'official-board',
   'municipal-service',
   'job-offer',
+  'faq',
 ] as const
 
 export type InventoryType = (typeof inventoryTypes)[number]
@@ -40,7 +41,7 @@ export type InventoryFile = {
 export type InventoryEntryBase = {
   /** Unique key, `${type}:${documentId}`. */
   id: string
-  /** Absolute. Null only for content whose host page could not be resolved. */
+  /** Absolute. Null for content that has no page of its own, i.e. the FAQs, and for an unresolved host page. */
   url: string | null
   /** As shown to a visitor. */
   title: string
@@ -230,6 +231,17 @@ export type JobOfferInventoryData = {
   employmentForms?: string[]
 }
 
+/**
+ * FAQs are rendered inside the pages that list them, so an entry carries the question as its `title` and the answer
+ * here, in the markdown the editor wrote.
+ */
+export type FaqInventoryData = {
+  /** The answer, as markdown. */
+  body?: string
+  /** The slug of the single category the question is filed under. */
+  category?: string
+}
+
 /** What one build of the inventory produces - the entries plus the taxonomies listed next to them. */
 export type Inventory = {
   entries: InventoryEntry[]
@@ -250,6 +262,7 @@ export type InventoryEntry =
       'municipal-service'?: MunicipalServiceInventoryData
     })
   | (InventoryEntryBase & { type: 'job-offer'; 'job-offer'?: JobOfferInventoryData })
+  | (InventoryEntryBase & { type: 'faq'; faq?: FaqInventoryData })
 
 /**
  * One value of a taxonomy, listed alongside the entries so a consumer sees the whole taxonomy and not only the values
@@ -279,6 +292,8 @@ export type InventoryTaxonomies = {
   officialBoardCategories: InventoryTaxonomy[]
   /** The city account's categories, i.e. what `municipal-service.categories` name. */
   municipalServiceCategories: InventoryTaxonomy[]
+  /** What `faq.category` names. */
+  faqCategories: InventoryTaxonomy[]
 }
 
 /** Reduced entry returned for `?fields=url`, meant for cheap diffing (including detecting removals). */

--- a/next/src/services/graphql/index.ts
+++ b/next/src/services/graphql/index.ts
@@ -8239,12 +8239,24 @@ export type FaqCategoryEntityFragment = {
   documentId: string
   title: string
   slug: string
+}
+
+export type FaqCategoryWithFaqsEntityFragment = {
+  __typename?: 'FaqCategory'
+  documentId: string
+  title: string
+  slug: string
   faqs: Array<{
     __typename?: 'Faq'
     documentId: string
     title: string
     body?: string | null
-    faqCategory?: { __typename?: 'FaqCategory'; title: string } | null
+    faqCategory?: {
+      __typename?: 'FaqCategory'
+      documentId: string
+      title: string
+      slug: string
+    } | null
   } | null>
 }
 
@@ -8253,7 +8265,12 @@ export type FaqEntityFragment = {
   documentId: string
   title: string
   body?: string | null
-  faqCategory?: { __typename?: 'FaqCategory'; title: string } | null
+  faqCategory?: {
+    __typename?: 'FaqCategory'
+    documentId: string
+    title: string
+    slug: string
+  } | null
 }
 
 export type FaqCategoriesQueryVariables = Exact<{
@@ -8275,8 +8292,64 @@ export type FaqCategoriesQuery = {
       documentId: string
       title: string
       body?: string | null
-      faqCategory?: { __typename?: 'FaqCategory'; title: string } | null
+      faqCategory?: {
+        __typename?: 'FaqCategory'
+        documentId: string
+        title: string
+        slug: string
+      } | null
     } | null>
+  } | null>
+}
+
+export type FaqInventoryEntityFragment = {
+  __typename?: 'Faq'
+  updatedAt?: any | null
+  publishedAt?: any | null
+  documentId: string
+  title: string
+  body?: string | null
+  adminGroups: Array<{
+    __typename?: 'AdminGroup'
+    documentId: string
+    slug: string
+    title: string
+  } | null>
+  faqCategory?: {
+    __typename?: 'FaqCategory'
+    documentId: string
+    title: string
+    slug: string
+  } | null
+}
+
+export type FaqsInventoryQueryVariables = Exact<{
+  start?: InputMaybe<Scalars['Int']['input']>
+  limit?: InputMaybe<Scalars['Int']['input']>
+  locale?: InputMaybe<Scalars['I18NLocaleCode']['input']>
+}>
+
+export type FaqsInventoryQuery = {
+  __typename?: 'Query'
+  faqs: Array<{
+    __typename?: 'Faq'
+    updatedAt?: any | null
+    publishedAt?: any | null
+    documentId: string
+    title: string
+    body?: string | null
+    adminGroups: Array<{
+      __typename?: 'AdminGroup'
+      documentId: string
+      slug: string
+      title: string
+    } | null>
+    faqCategory?: {
+      __typename?: 'FaqCategory'
+      documentId: string
+      title: string
+      slug: string
+    } | null
   } | null>
 }
 
@@ -12507,7 +12580,12 @@ export type PageEntityFragment = {
           documentId: string
           title: string
           body?: string | null
-          faqCategory?: { __typename?: 'FaqCategory'; title: string } | null
+          faqCategory?: {
+            __typename?: 'FaqCategory'
+            documentId: string
+            title: string
+            slug: string
+          } | null
         } | null>
         faqCategories: Array<{
           __typename?: 'FaqCategory'
@@ -12519,7 +12597,12 @@ export type PageEntityFragment = {
             documentId: string
             title: string
             body?: string | null
-            faqCategory?: { __typename?: 'FaqCategory'; title: string } | null
+            faqCategory?: {
+              __typename?: 'FaqCategory'
+              documentId: string
+              title: string
+              slug: string
+            } | null
           } | null>
         } | null>
       }
@@ -14336,7 +14419,12 @@ export type PageByPathQuery = {
             documentId: string
             title: string
             body?: string | null
-            faqCategory?: { __typename?: 'FaqCategory'; title: string } | null
+            faqCategory?: {
+              __typename?: 'FaqCategory'
+              documentId: string
+              title: string
+              slug: string
+            } | null
           } | null>
           faqCategories: Array<{
             __typename?: 'FaqCategory'
@@ -14348,7 +14436,12 @@ export type PageByPathQuery = {
               documentId: string
               title: string
               body?: string | null
-              faqCategory?: { __typename?: 'FaqCategory'; title: string } | null
+              faqCategory?: {
+                __typename?: 'FaqCategory'
+                documentId: string
+                title: string
+                slug: string
+              } | null
             } | null>
           } | null>
         }
@@ -16190,7 +16283,12 @@ export type Dev_AllPagesQuery = {
             documentId: string
             title: string
             body?: string | null
-            faqCategory?: { __typename?: 'FaqCategory'; title: string } | null
+            faqCategory?: {
+              __typename?: 'FaqCategory'
+              documentId: string
+              title: string
+              slug: string
+            } | null
           } | null>
           faqCategories: Array<{
             __typename?: 'FaqCategory'
@@ -16202,7 +16300,12 @@ export type Dev_AllPagesQuery = {
               documentId: string
               title: string
               body?: string | null
-              faqCategory?: { __typename?: 'FaqCategory'; title: string } | null
+              faqCategory?: {
+                __typename?: 'FaqCategory'
+                documentId: string
+                title: string
+                slug: string
+              } | null
             } | null>
           } | null>
         }
@@ -18949,7 +19052,12 @@ export type FaqsSectionFragment = {
     documentId: string
     title: string
     body?: string | null
-    faqCategory?: { __typename?: 'FaqCategory'; title: string } | null
+    faqCategory?: {
+      __typename?: 'FaqCategory'
+      documentId: string
+      title: string
+      slug: string
+    } | null
   } | null>
   faqCategories: Array<{
     __typename?: 'FaqCategory'
@@ -18961,7 +19069,12 @@ export type FaqsSectionFragment = {
       documentId: string
       title: string
       body?: string | null
-      faqCategory?: { __typename?: 'FaqCategory'; title: string } | null
+      faqCategory?: {
+        __typename?: 'FaqCategory'
+        documentId: string
+        title: string
+        slug: string
+      } | null
     } | null>
   } | null>
 }
@@ -20528,7 +20641,12 @@ type Sections_ComponentSectionsFaqs_Fragment = {
     documentId: string
     title: string
     body?: string | null
-    faqCategory?: { __typename?: 'FaqCategory'; title: string } | null
+    faqCategory?: {
+      __typename?: 'FaqCategory'
+      documentId: string
+      title: string
+      slug: string
+    } | null
   } | null>
   faqCategories: Array<{
     __typename?: 'FaqCategory'
@@ -20540,7 +20658,12 @@ type Sections_ComponentSectionsFaqs_Fragment = {
       documentId: string
       title: string
       body?: string | null
-      faqCategory?: { __typename?: 'FaqCategory'; title: string } | null
+      faqCategory?: {
+        __typename?: 'FaqCategory'
+        documentId: string
+        title: string
+        slug: string
+      } | null
     } | null>
   } | null>
 }
@@ -22210,6 +22333,7 @@ export type TaxonomiesInventoryQuery = {
     slug: string
   } | null>
   urbanStudyStates: Array<{ __typename?: 'UrbanStudyState'; title: string; slug: string } | null>
+  faqCategories: Array<{ __typename?: 'FaqCategory'; title: string; slug: string } | null>
 }
 
 export const ArticleSlugEntityFragmentDoc = gql`
@@ -22417,6 +22541,36 @@ export const AssetInventoryEntityFragmentDoc = gql`
   ${AdminGroupSlugEntityFragmentDoc}
   ${AssetCategoryEntityFragmentDoc}
   ${UploadFileEntityFragmentDoc}
+`
+export const FaqCategoryEntityFragmentDoc = gql`
+  fragment FaqCategoryEntity on FaqCategory {
+    documentId
+    title
+    slug
+  }
+`
+export const FaqEntityFragmentDoc = gql`
+  fragment FaqEntity on Faq {
+    documentId
+    title
+    body
+    faqCategory {
+      ...FaqCategoryEntity
+    }
+  }
+  ${FaqCategoryEntityFragmentDoc}
+`
+export const FaqInventoryEntityFragmentDoc = gql`
+  fragment FaqInventoryEntity on Faq {
+    ...FaqEntity
+    updatedAt
+    publishedAt
+    adminGroups {
+      ...AdminGroupSlugEntity
+    }
+  }
+  ${FaqEntityFragmentDoc}
+  ${AdminGroupSlugEntityFragmentDoc}
 `
 export const UploadFileFragmentDoc = gql`
   fragment UploadFile on UploadFile {
@@ -23372,25 +23526,14 @@ export const RegulationsSectionFragmentDoc = gql`
   }
   ${RegulationEntityFragmentDoc}
 `
-export const FaqEntityFragmentDoc = gql`
-  fragment FaqEntity on Faq {
-    documentId
-    title
-    body
-    faqCategory {
-      title
-    }
-  }
-`
-export const FaqCategoryEntityFragmentDoc = gql`
-  fragment FaqCategoryEntity on FaqCategory {
-    documentId
-    title
-    slug
+export const FaqCategoryWithFaqsEntityFragmentDoc = gql`
+  fragment FaqCategoryWithFaqsEntity on FaqCategory {
+    ...FaqCategoryEntity
     faqs {
       ...FaqEntity
     }
   }
+  ${FaqCategoryEntityFragmentDoc}
   ${FaqEntityFragmentDoc}
 `
 export const FaqsSectionFragmentDoc = gql`
@@ -23401,13 +23544,13 @@ export const FaqsSectionFragmentDoc = gql`
       ...FaqEntity
     }
     faqCategories {
-      ...FaqCategoryEntity
+      ...FaqCategoryWithFaqsEntity
     }
     showAll
     titleLevelFaqsSection: titleLevel
   }
   ${FaqEntityFragmentDoc}
-  ${FaqCategoryEntityFragmentDoc}
+  ${FaqCategoryWithFaqsEntityFragmentDoc}
 `
 export const PartnerBlockFragmentDoc = gql`
   fragment PartnerBlock on ComponentBlocksPartner {
@@ -24308,10 +24451,18 @@ export const AssetsInventoryDocument = gql`
 export const FaqCategoriesDocument = gql`
   query FaqCategories($locale: I18NLocaleCode, $sort: [String] = ["title"]) {
     faqCategories(pagination: { limit: -1 }, locale: $locale, sort: $sort) {
-      ...FaqCategoryEntity
+      ...FaqCategoryWithFaqsEntity
     }
   }
-  ${FaqCategoryEntityFragmentDoc}
+  ${FaqCategoryWithFaqsEntityFragmentDoc}
+`
+export const FaqsInventoryDocument = gql`
+  query FaqsInventory($start: Int = 0, $limit: Int = 100, $locale: I18NLocaleCode = "sk") {
+    faqs(locale: $locale, sort: "id:asc", pagination: { start: $start, limit: $limit }) {
+      ...FaqInventoryEntity
+    }
+  }
+  ${FaqInventoryEntityFragmentDoc}
 `
 export const AllFilesDocument = gql`
   query allFiles($locale: I18NLocaleCode) {
@@ -24711,6 +24862,10 @@ export const TaxonomiesInventoryDocument = gql`
       title
       slug
     }
+    faqCategories(locale: $locale, sort: "title", pagination: { limit: $limit }) {
+      title
+      slug
+    }
   }
 `
 
@@ -24949,6 +25104,21 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
             ...wrappedRequestHeaders,
           }),
         'FaqCategories',
+        'query',
+        variables,
+      )
+    },
+    FaqsInventory(
+      variables?: FaqsInventoryQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<FaqsInventoryQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<FaqsInventoryQuery>(FaqsInventoryDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'FaqsInventory',
         'query',
         variables,
       )

--- a/next/src/services/graphql/queries/Faqs.graphql
+++ b/next/src/services/graphql/queries/Faqs.graphql
@@ -2,21 +2,42 @@ fragment FaqCategoryEntity on FaqCategory {
   documentId
   title
   slug
+}
+
+fragment FaqCategoryWithFaqsEntity on FaqCategory {
+  ...FaqCategoryEntity
   faqs {
     ...FaqEntity
   }
 }
+
 fragment FaqEntity on Faq {
   documentId
   title
   body
   faqCategory {
-    title
+    ...FaqCategoryEntity
   }
 }
 
 query FaqCategories($locale: I18NLocaleCode, $sort: [String] = ["title"]) {
   faqCategories(pagination: { limit: -1 }, locale: $locale, sort: $sort) {
-    ...FaqCategoryEntity
+    ...FaqCategoryWithFaqsEntity
+  }
+}
+
+# Used by the /api/content-inventory endpoint.
+fragment FaqInventoryEntity on Faq {
+  ...FaqEntity
+  updatedAt
+  publishedAt
+  adminGroups {
+    ...AdminGroupSlugEntity
+  }
+}
+
+query FaqsInventory($start: Int = 0, $limit: Int = 100, $locale: I18NLocaleCode = "sk") {
+  faqs(locale: $locale, sort: "id:asc", pagination: { start: $start, limit: $limit }) {
+    ...FaqInventoryEntity
   }
 }

--- a/next/src/services/graphql/queries/Sections.graphql
+++ b/next/src/services/graphql/queries/Sections.graphql
@@ -361,7 +361,7 @@ fragment FaqsSection on ComponentSectionsFaqs {
     ...FaqEntity
   }
   faqCategories {
-    ...FaqCategoryEntity
+    ...FaqCategoryWithFaqsEntity
   }
   showAll
   titleLevelFaqsSection: titleLevel

--- a/next/src/services/graphql/queries/_taxonomies.graphql
+++ b/next/src/services/graphql/queries/_taxonomies.graphql
@@ -26,4 +26,8 @@ query TaxonomiesInventory($limit: Int = -1, $locale: I18NLocaleCode = "sk") {
     title
     slug
   }
+  faqCategories(locale: $locale, sort: "title", pagination: { limit: $limit }) {
+    title
+    slug
+  }
 }


### PR DESCRIPTION
## Changes

- Add the `faq` type to `/api/content-inventory` (version bumped to 5)
  - `title` — the question
  - `faq.body` — the answer, as markdown
  - `faq.category` — slug of the FAQ category
  - `owner` — from the admin groups, the same way pages/articles/assets resolve it
  - `url` — always null, FAQs are rendered inside the pages that list them, so they have no page of their own
- Add `taxonomies.faqCategories`, listed whole like the other taxonomies
- Split the nested faqs out of `FaqCategoryEntity` into a new `FaqCategoryWithFaqsEntity`, so the inventory fragment does not carry them; `FaqsSection` and the `FaqCategories` query use the new fragment (`FaqsGroup` prop type updated)

`npx tsc --noEmit` and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)